### PR TITLE
Postgres user stats, copy template plots

### DIFF
--- a/src/main/java/org/openforis/ceo/Server.java
+++ b/src/main/java/org/openforis/ceo/Server.java
@@ -119,6 +119,7 @@ public class Server implements SparkApplication {
 
         // Routing Table: Users API
         get("/get-all-users",                         users::getAllUsers);
+        get("/get-user-stats/:userid",                users::getUserStats);
         post("/update-user-institution-role",         users::updateInstitutionRole);
         post("/request-institution-membership",       users::requestInstitutionMembership);
 

--- a/src/main/java/org/openforis/ceo/db_api/Users.java
+++ b/src/main/java/org/openforis/ceo/db_api/Users.java
@@ -13,6 +13,7 @@ public interface Users {
     Request getPasswordResetKey(Request req, Response res);
     Request resetPassword(Request req, Response res);
     String getAllUsers(Request req, Response res);
+    String getUserStats(Request req, Response res);
     Map<Integer, String> getInstitutionRoles(int userId);
     String updateInstitutionRole(Request req, Response res);
     String requestInstitutionMembership(Request req, Response res);

--- a/src/main/java/org/openforis/ceo/local/JsonUsers.java
+++ b/src/main/java/org/openforis/ceo/local/JsonUsers.java
@@ -293,6 +293,10 @@ public class JsonUsers implements Users {
         }
     }
 
+    public String getUserStats(Request req, Response res) {
+        return "";
+    }
+    
     public Map<Integer, String> getInstitutionRoles(int userId) {
         var institutions = readJsonFile("institution-list.json").getAsJsonArray();
         var userIdJson = new JsonPrimitive(userId);

--- a/src/main/java/org/openforis/ceo/postgres/PostgresProjects.java
+++ b/src/main/java/org/openforis/ceo/postgres/PostgresProjects.java
@@ -634,7 +634,7 @@ public class PostgresProjects implements Projects {
         }
     }
 
-    private static void deleteCsvFile(String csvFile) {
+    private static void deleteFile(String csvFile) {
         var csvFilePath = Paths.get(expandResourcePath("/csv"), csvFile);
         try {
             if (csvFilePath.toFile().exists()) {
@@ -648,9 +648,11 @@ public class PostgresProjects implements Projects {
         }
     }
 
-    private static void deleteCsvFiles(int projectId) {
-        deleteCsvFile("project-" + projectId + "-plots.csv");
-        deleteCsvFile("project-" + projectId + "-samples.csv");
+    private static void deleteFiles(int projectId) {
+        deleteFile("project-" + projectId + "-plots.csv");
+        deleteFile("project-" + projectId + "-samples.csv");        
+        deleteFile("project-" + projectId + "-plots.zip");
+        deleteFile("project-" + projectId + "-samples.zip");
     }
 
     private static String loadPlots(Connection conn, String plotDistribution, Integer projectId, String plotsFile) {
@@ -933,7 +935,7 @@ public class PostgresProjects implements Projects {
                             // Create the requested plot set and write it to plot-data-<newProjectId>.json
                             createProjectPlots(newProject);
 
-                            deleteCsvFiles(Integer.parseInt(newProjectId));
+                            deleteFiles(Integer.parseInt(newProjectId));
                             deleteShapeFileDirectories(Integer.parseInt(newProjectId));
                         }
                     }

--- a/src/main/java/org/openforis/ceo/postgres/PostgresProjects.java
+++ b/src/main/java/org/openforis/ceo/postgres/PostgresProjects.java
@@ -8,7 +8,22 @@ import static org.openforis.ceo.utils.JsonUtils.toStream;
 import static org.openforis.ceo.utils.PartUtils.partToString;
 import static org.openforis.ceo.utils.PartUtils.partsToJsonObject;
 import static org.openforis.ceo.utils.PartUtils.writeFilePart;
-import static org.openforis.ceo.utils.ProjectUtils.*;
+import static org.openforis.ceo.utils.ProjectUtils.padBounds;
+import static org.openforis.ceo.utils.ProjectUtils.reprojectBounds;
+import static org.openforis.ceo.utils.ProjectUtils.createGriddedPointsInBounds;
+import static org.openforis.ceo.utils.ProjectUtils.createGriddedSampleSet;
+import static org.openforis.ceo.utils.ProjectUtils.createRandomPointsInBounds;
+import static org.openforis.ceo.utils.ProjectUtils.createRandomSampleSet;
+import static org.openforis.ceo.utils.ProjectUtils.outputAggregateCsv;
+import static org.openforis.ceo.utils.ProjectUtils.outputRawCsv;
+import static org.openforis.ceo.utils.ProjectUtils.getOrEmptyString;
+import static org.openforis.ceo.utils.ProjectUtils.getOrZero;
+import static org.openforis.ceo.utils.ProjectUtils.getValueDistribution;
+import static org.openforis.ceo.utils.ProjectUtils.makeGeoJsonPoint;
+import static org.openforis.ceo.utils.ProjectUtils.makeGeoJsonPolygon;
+import static org.openforis.ceo.utils.ProjectUtils.getSampleValueTranslations;
+import static org.openforis.ceo.utils.ProjectUtils.deleteShapeFileDirectories;
+import static org.openforis.ceo.utils.ProjectUtils.runBashScriptForProject;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
@@ -252,9 +267,9 @@ public class PostgresProjects implements Projects {
                     stats.addProperty("members",rs.getInt("members"));
                     stats.addProperty("contributors",rs.getInt("contributors"));
                     stats.addProperty("createdDate",rs.getString("created_date"));
-                    stats.addProperty("publishDate",rs.getString("published_date"));
-                    stats.addProperty("closeDate",rs.getString("closed_date"));
-                    stats.addProperty("archiveDate",rs.getString("archived_date"));
+                    stats.addProperty("publishedDate",rs.getString("published_date"));
+                    stats.addProperty("closedDate",rs.getString("closed_date"));
+                    stats.addProperty("archivedDate",rs.getString("archived_date"));
                 }
             }
             return  stats.toString();

--- a/src/main/java/org/openforis/ceo/postgres/PostgresProjects.java
+++ b/src/main/java/org/openforis/ceo/postgres/PostgresProjects.java
@@ -461,17 +461,6 @@ public class PostgresProjects implements Projects {
 
                                 }
 
-                                // FIXME GeoJson does not store in CVS columns will with comma as the main delimitator
-                                // geometry come seperate so it can be converted to GeoJson
-                                // if (valueOrBlank(rsDump.getString("plot_geom")) != "") {
-                                //     plotSummary.addProperty("plot_geom", quoteValueOrEmpty(rsDump.getString("plot_geom")));
-                                //     if (!plotHeaders.contains("plot_geom")) plotHeaders.add("plot_geom");
-                                // }
-                                // if (valueOrBlank(rsDump.getString("sample_geom")) != "") {
-                                //     plotSummary.addProperty("sample_geom", quoteValueOrEmpty(rsDump.getString("sample_geom")));
-                                //     if (!sampleHeaders.contains("sample_geom")) sampleHeaders.add("sample_geom");
-                                // }
-
                                 if (valueOrBlank(rsDump.getString("ext_plot_data")) != ""){
                                     var ext_plot_data = parseJson(rsDump.getString("ext_plot_data")).getAsJsonObject();                              
                                     plotHeaders.forEach(head ->

--- a/src/main/java/org/openforis/ceo/postgres/PostgresUsers.java
+++ b/src/main/java/org/openforis/ceo/postgres/PostgresUsers.java
@@ -300,6 +300,28 @@ public class PostgresUsers implements Users {
         return "";
     }
 
+    public String getUserStats(Request req, Response res) {
+        var userId =     req.params(":userid");
+        try (var conn = connect();
+             var pstmt = conn.prepareStatement("SELECT * FROM get_user_stats(?)");) {
+                 
+            pstmt.setString(1, userId);
+            try(var rs = pstmt.executeQuery()){
+                var userJson = new JsonObject();
+                if (rs.next()) {
+                    userJson.addProperty("totalProjects", rs.getInt("total_projects"));
+                    userJson.addProperty("totalPlots", rs.getInt("total_plots"));
+                    userJson.addProperty("averageTime", rs.getInt("average_time"));
+                    userJson.add("plotsByProject", parseJson(rs.getString("plots_by_project")).getAsJsonObject());
+                    userJson.add("timeByProject", parseJson(rs.getString("time_by_project")).getAsJsonObject());
+                }
+                return userJson.toString();
+            }
+        } catch (SQLException e) {
+            System.out.println(e.getMessage());
+        }
+        return "";
+    }
     // FIXME this appears to be unused.  Not tested
     public Map<Integer, String> getInstitutionRoles(int userId) {
         var inst = new HashMap<Integer,String>();

--- a/src/main/java/org/openforis/ceo/users/OfUsers.java
+++ b/src/main/java/org/openforis/ceo/users/OfUsers.java
@@ -267,6 +267,8 @@ public class OfUsers implements Users {
         return req;
     }
 
+    public String getUserStats(Request req, Response res) { return "";}
+
     public String getAllUsers(Request req, Response res) {
         var institutionId = req.queryParams("institutionId");
         try {

--- a/src/main/java/org/openforis/ceo/utils/ProjectUtils.java
+++ b/src/main/java/org/openforis/ceo/utils/ProjectUtils.java
@@ -373,7 +373,7 @@ public class ProjectUtils {
     }
 
     public static JsonElement getOrZero(JsonObject obj, String field) {
-        return obj.get(field).isJsonNull() ? new JsonPrimitive(0) : obj.get(field);
+        return obj.get(field).isJsonNull() || obj.get(field) == null ? new JsonPrimitive(0) : obj.get(field);
     }
 
     public static JsonElement getOrEmptyString(JsonObject obj, String field) {

--- a/src/main/java/org/openforis/ceo/utils/ProjectUtils.java
+++ b/src/main/java/org/openforis/ceo/utils/ProjectUtils.java
@@ -124,7 +124,7 @@ public class ProjectUtils {
         var sampleValueKeys = getSampleKeys(sampleValueGroups);
         // fileds are straight forward json values
         var fields = Stream.concat(
-                        Arrays.stream(new String[]{"plot_id", "center_lon", "center_lat", "size_m", "shape", "flagged", "analyses", "sample_points", "user_id", "collection_time"}), 
+                        Arrays.stream(new String[]{"plot_id", "center_lon", "center_lat", "size_m", "shape", "flagged", "analyses", "sample_points", "user_id", "analysis_duration", "collection_time"}), 
                         Arrays.stream(externalHeaders))
                         .toArray(String[]::new);
         // labels require interpretation of the next json object
@@ -164,7 +164,7 @@ public class ProjectUtils {
 
         // fileds are straight forward json values
         var fields = Stream.concat(
-                        Arrays.stream(new String[]{"plot_id", "sample_id", "lon", "lat", "flagged", "analyses", "user_id", "collection_time"}), 
+                        Arrays.stream(new String[]{"plot_id", "sample_id", "lon", "lat", "flagged", "analyses", "user_id", "analysis_duration", "collection_time"}), 
                         Arrays.stream(externalHeaders))
                         .toArray(String[]::new);
         // labels require interpretation of the next json object

--- a/src/main/java/org/openforis/ceo/utils/ProjectUtils.java
+++ b/src/main/java/org/openforis/ceo/utils/ProjectUtils.java
@@ -122,7 +122,7 @@ public class ProjectUtils {
 
     public static HttpServletResponse outputAggregateCsv(Response res, JsonArray sampleValueGroups, JsonArray plotSummaries, String projectName, String[] externalHeaders){
         var sampleValueKeys = getSampleKeys(sampleValueGroups);
-        // fileds are straight forward json values
+        // fields are straight forward json values
         var fields = Stream.concat(
                         Arrays.stream(new String[]{"plot_id", "center_lon", "center_lat", "size_m", "shape", "flagged", "analyses", "sample_points", "user_id", "analysis_duration", "collection_time"}), 
                         Arrays.stream(externalHeaders))

--- a/src/main/java/org/openforis/ceo/utils/ProjectUtils.java
+++ b/src/main/java/org/openforis/ceo/utils/ProjectUtils.java
@@ -137,7 +137,7 @@ public class ProjectUtils {
                     var labelStream = Arrays.stream(labels);
                     var distribution = plotSummary.get("distribution").getAsJsonObject();
                     return Stream.concat(
-                            fieldStream.map(field -> plotSummary.get(field).isJsonNull()
+                            fieldStream.map(field -> plotSummary.has(field) && plotSummary.get(field).isJsonNull()
                                     ? ""
                                     : plotSummary.get(field).getAsString()),
                             labelStream.map(label -> distribution.has(label)
@@ -184,7 +184,7 @@ public class ProjectUtils {
                             labelStream.map(label -> {
                                 var value = sampleSummary.get("value");
                                 if (value.isJsonNull()) {
-                                    return "0";
+                                    return "";
                                 // original format is single integer index
                                 } else if (value.isJsonPrimitive()) {
                                     var sampleValueTranslations = getSampleValueTranslations(sampleValueGroups);
@@ -198,7 +198,7 @@ public class ProjectUtils {
                                     // newest format nests the answer in another json object
                                     return value.getAsJsonObject().get(label).getAsJsonObject().get("answer").getAsString();
                                 } else {
-                                    return "0";
+                                    return "";
                                 }
                             })).collect(Collectors.joining(","));         
                 }).collect(Collectors.joining("\n"));

--- a/src/main/java/org/openforis/ceo/utils/ProjectUtils.java
+++ b/src/main/java/org/openforis/ceo/utils/ProjectUtils.java
@@ -43,11 +43,11 @@ public class ProjectUtils {
         var firstGroup = sampleValueGroups.get(0).getAsJsonObject();
         if (firstGroup.has("name")) {
             return new String[]{"name", "values", "name"};
-        }
-        if (firstGroup.has("question")) {
+        } else if (firstGroup.has("question")) {
             return new String[]{"question", "answers", "answer"};
+        } else {
+            return new String[]{};
         }
-        return new String[]{};
     }
 
     private static String[] getValueDistributionLabels(JsonArray sampleValueGroups, String[] keys) {
@@ -358,18 +358,6 @@ public class ProjectUtils {
                         .filter(y -> plotShape.equals("square") || squareDistance(x, y, centerX, centerY) < radiusSquared)
                         .map(y -> reprojectPoint(new Double[]{x, y}, 3857, 4326)))
                 .toArray(Double[][]::new);
-    }
-
-    public static Double[] calculateBounds(Double[][] points, double buffer) {
-        var lons = Arrays.stream(points).map(point -> point[0]).toArray(Double[]::new);
-        var lats = Arrays.stream(points).map(point -> point[1]).toArray(Double[]::new);
-        var lonMin = Arrays.stream(lons).min(Comparator.naturalOrder()).get();
-        var latMin = Arrays.stream(lats).min(Comparator.naturalOrder()).get();
-        var lonMax = Arrays.stream(lons).max(Comparator.naturalOrder()).get();
-        var latMax = Arrays.stream(lats).max(Comparator.naturalOrder()).get();
-        var bounds = reprojectBounds(lonMin, latMin, lonMax, latMax, 4326, 3857);
-        var paddedBounds = padBounds(bounds[0], bounds[1], bounds[2], bounds[3], -buffer);
-        return reprojectBounds(paddedBounds[0], paddedBounds[1], paddedBounds[2], paddedBounds[3], 3857, 4326);
     }
 
     public static JsonElement getOrZero(JsonObject obj, String field) {

--- a/src/main/resources/sql/load_ceo_functions.sql
+++ b/src/main/resources/sql/load_ceo_functions.sql
@@ -196,9 +196,14 @@ CREATE OR REPLACE FUNCTION get_user_stats(_user_email text)
 	user_totals as (
 		SELECT
 			count(DISTINCT proj_id)::int as proj_count,
-			count(DISTINCT plot_id)::int as plot_count,
+			count(DISTINCT plot_id)::int as plot_count
+		FROM users_plots
+	),
+	average_totals as (
+		SELECT
 			round(avg(seconds)::numeric, 1) as sec_avg
 		FROM users_plots
+		WHERE seconds IS NOT null
 	),
 	proj_groups as (
 		SELECT proj_id,
@@ -217,7 +222,7 @@ CREATE OR REPLACE FUNCTION get_user_stats(_user_email text)
 				END) , ',')) as avg_json
 		FROM proj_groups
 	)
-	SELECT * FROM user_totals, proj_agg
+	SELECT * FROM user_totals, average_totals, proj_agg
 $$ LANGUAGE SQL;
 
 -- Adds a new role to the database.

--- a/src/main/resources/sql/load_ceo_tables.sql
+++ b/src/main/resources/sql/load_ceo_tables.sql
@@ -27,13 +27,11 @@ CREATE TABLE projects (
   boundary                  geometry(Polygon,4326),
   base_map_source           text,
   plot_distribution         text,
-  -- FIXME this chould be counted instead of stored
   num_plots                 integer,
   plot_spacing              float,
   plot_shape                text,
   plot_size                 float,
   sample_distribution       text,
-  -- FIXME this could be counted instead of stored
   samples_per_plot          integer,
   sample_resolution         float,
   sample_survey             jsonb,
@@ -87,21 +85,22 @@ CREATE TABLE institution_users (
 );
 
 CREATE TABLE user_plots(
-	id              serial primary key,
-	user_id         integer not null references users (id) on delete cascade on update cascade,
-    plot_id         integer not null references plots (id) on delete cascade on update cascade,
-    flagged         boolean default false,
-	confidence      integer CHECK (confidence >= 0 AND confidence <= 100),
-	collection_time timestamp
+	id                  serial primary key,
+	user_id             integer not null references users (id) on delete cascade on update cascade,
+    plot_id             integer not null references plots (id) on delete cascade on update cascade,
+    flagged             boolean default false,
+	confidence          integer CHECK (confidence >= 0 AND confidence <= 100),
+    collection_start    timestamp,
+	collection_time     timestamp
 );
 
 CREATE TABLE sample_values(
-	id             serial primary key,
-	user_plot_id   integer not null references user_plots (id) on delete cascade on update cascade,
-    sample_id      integer not null references samples (id) on delete cascade on update cascade,     
-	imagery_id     integer references imagery (id) on delete cascade on update cascade,
-	imagery_date   date,
-	value          jsonb
+	id                  serial primary key,
+	user_plot_id        integer not null references user_plots (id) on delete cascade on update cascade,
+    sample_id           integer not null references samples (id) on delete cascade on update cascade,     
+	imagery_id          integer references imagery (id) on delete cascade on update cascade,
+    imagery_attributes  jsonb,
+	value               jsonb
 );
 
 CREATE TABLE project_widgets(


### PR DESCRIPTION
Add functionality to copy plots from template projects

Update API for adding user samples to include collection start time and imagery used. 

Add route for getting user statistics.  User stats include total projects analyzed, total number of plots, average time spent per plot (for all plots with a collection time), {projectId: numplots}, and {projectId: average_seconds}
````````
{
  "totalProjects": 2,
  "totalPlots": 16,
  "averageTime": 7.8,
  "plotsByProject": {
    "324": "2",
    "427": "14"
  },
  "timeByProject": {
    "324": "0",
    "427": "7.8"
  }
}
````````

Extend extend the aggregate to csv output to include analysis duration and imagery used.

Added error handling for malformed csv and shp files