### PR TITLE
allow for additional data, additional data checking

### DIFF
--- a/src/main/java/org/openforis/ceo/local/JsonImagery.java
+++ b/src/main/java/org/openforis/ceo/local/JsonImagery.java
@@ -28,6 +28,15 @@ public class JsonImagery implements Imagery {
         }
     }
 
+    public static String getImageryTitle(String id) {
+        var imageryList = readJsonFile("imagery-list.json").getAsJsonArray();
+
+        var matchingImagery = filterJsonArray(imageryList,
+                                imagery -> imagery.get("id").getAsString().equals(id));
+        return matchingImagery.get(0).getAsJsonObject().get("title").getAsString();
+        
+    }
+
     public synchronized String addInstitutionImagery(Request req, Response res) {
         try {
             var jsonInputs            = parseJson(req.body()).getAsJsonObject();

--- a/src/main/java/org/openforis/ceo/local/JsonProjects.java
+++ b/src/main/java/org/openforis/ceo/local/JsonProjects.java
@@ -577,8 +577,8 @@ public class JsonProjects implements Projects {
                         plotSummary.addProperty("analyses", getOrZero(project, "analyses").getAsInt());
                         plotSummary.addProperty("sample_points", samples.size());
                         plotSummary.add("user_id", plot.get("user"));
-                        plotSummary.addProperty("collection_time", simple.format(new Date(collectionTime)));
-                        plotSummary.addProperty("analysis_duration", finalAnalysisDuration);
+                        plotSummary.addProperty("collection_time", collectionTime > 0 ? simple.format(new Date(collectionTime)) : "");
+                        plotSummary.addProperty("analysis_duration", finalAnalysisDuration > 0 : finalAnalysisDuration : 0);
                         plotSummary.addProperty("confidence", confidence);
                         plotSummary.add("distribution",
                                 getValueDistribution(samples, getSampleValueTranslations(sampleValueGroups)));
@@ -668,7 +668,7 @@ public class JsonProjects implements Projects {
                             sampleSummary.add("user_id", userId);
                             sampleSummary.add("value", sample.get("value"));
                             
-                            sampleSummary.addProperty("collection_time", simple.format(new Date(collectionTime)));
+                            sampleSummary.addProperty("collection_time", collectionTime > 0 ? simple.format(new Date(collectionTime)) : "");
                             sampleSummary.addProperty("analysis_duration", finalAnalysisDuration);
                             sampleSummary.addProperty("confidence", confidence);
                             

--- a/src/main/java/org/openforis/ceo/local/JsonProjects.java
+++ b/src/main/java/org/openforis/ceo/local/JsonProjects.java
@@ -527,7 +527,15 @@ public class JsonProjects implements Projects {
             return new ArrayList<String>();
         }
     }
-
+    
+    // Some older data contains a useless string fromat for collection time. 
+    private Long collectTimeIgnoreString (JsonObject plot){
+        try {
+            return getOrZero(plot, "collectionTime").getAsLong();
+        } catch (Exception e) {
+            return 0L;
+        }
+    }
 
     public HttpServletResponse dumpProjectAggregateData(Request req, Response res) {
         final var projectId = req.params(":id");
@@ -550,7 +558,7 @@ public class JsonProjects implements Projects {
                         final var samples = plot.get("samples").getAsJsonArray();
                         final var center = parseJson(plot.get("center").getAsString()).getAsJsonObject();
                         final var coords = center.get("coordinates").getAsJsonArray();
-                        final var collectionTime = getOrZero(plot, "collectionTime").getAsLong();
+                        final var collectionTime = collectTimeIgnoreString(plot);
                         final var collectionStart = getOrZero(plot, "collectionStart").getAsLong();
                         final var confidence = getOrZero(plot, "confidence").getAsInt();
                         var analysisDuration = 0.0;
@@ -578,7 +586,7 @@ public class JsonProjects implements Projects {
                         plotSummary.addProperty("sample_points", samples.size());
                         plotSummary.add("user_id", plot.get("user"));
                         plotSummary.addProperty("collection_time", collectionTime > 0 ? simple.format(new Date(collectionTime)) : "");
-                        plotSummary.addProperty("analysis_duration", finalAnalysisDuration > 0 : finalAnalysisDuration : 0);
+                        plotSummary.addProperty("analysis_duration", finalAnalysisDuration > 0 ? finalAnalysisDuration : 0);
                         plotSummary.addProperty("confidence", confidence);
                         plotSummary.add("distribution",
                                 getValueDistribution(samples, getSampleValueTranslations(sampleValueGroups)));
@@ -636,7 +644,7 @@ public class JsonProjects implements Projects {
                         final var flagged = plot.get("flagged").getAsBoolean();
                         final var analyses = plot.get("analyses").getAsInt();
                         final var userId = plot.get("user");
-                        final var collectionTime = getOrZero(plot, "collectionTime").getAsLong();
+                        final var collectionTime = collectTimeIgnoreString(plot);
                         final var collectionStart = getOrZero(plot, "collectionStart").getAsLong();
                         final var confidence = getOrZero(plot, "confidence").getAsInt();
                         var analysisDuration = 0.0;

--- a/src/main/java/org/openforis/ceo/local/JsonProjects.java
+++ b/src/main/java/org/openforis/ceo/local/JsonProjects.java
@@ -338,7 +338,8 @@ public class JsonProjects implements Projects {
 
     /*  The following functions load data to merge with JSON plot/sample information.
         Even though the new data uses a integer hasmap to ensure correct order for other functions
-        we can leave the merge as a String HasMap because we are not doing any sorting on merge.
+        we can leave the merge as a String HasMap for backwords compatability
+        because we are not doing any sorting on merge.
     */
 
     // Old csv files do not include plotId or sampleId
@@ -346,10 +347,10 @@ public class JsonProjects implements Projects {
         try (var lines = Files.lines(Paths.get(expandResourcePath("/csv/" + filename)))) {
             var plotPoints = new HashMap<String, HashMap<String, String>>();
             var linesArr = lines.toArray(String[]::new);
-            var fieldNames =  Arrays.stream(linesArr[0].split(",")).toArray(String[]::new);
+            final var fieldNames =  Arrays.stream(linesArr[0].split(",")).toArray(String[]::new);
             for (int r = 1; r != linesArr.length ; r++) {
                 var plotField = new HashMap<String, String>();
-                var fieldData = Arrays.stream(linesArr[r].split(",")).toArray(String[]::new);
+                final var fieldData = Arrays.stream(linesArr[r].split(",")).toArray(String[]::new);
                 for (int i = 0; i != fieldNames.length ; i++) {
                     plotField.put(fieldNames[i], fieldData[i]);
                 }
@@ -366,11 +367,11 @@ public class JsonProjects implements Projects {
     private static HashMap<String, HashMap<String, String>> loadCsvPlotAllColumnsNew(String filename) {
         try (var lines = Files.lines(Paths.get(expandResourcePath("/csv/" + filename)))) {
             var plotPoints = new HashMap<String, HashMap<String, String>>();
-            var linesArr = lines.toArray(String[]::new);
-            var fieldNames =  Arrays.stream(linesArr[0].split(",")).toArray(String[]::new);
+            final var linesArr = lines.toArray(String[]::new);
+            final var fieldNames =  Arrays.stream(linesArr[0].split(",")).toArray(String[]::new);
             for (int r = 1; r != linesArr.length ; r++) {
                 var plotField = new HashMap<String, String>();
-                var fieldData = Arrays.stream(linesArr[r].split(",")).toArray(String[]::new);
+                final var fieldData = Arrays.stream(linesArr[r].split(",")).toArray(String[]::new);
                 for (int i = 0; i != fieldNames.length ; i++) {
                     plotField.put(fieldNames[i], fieldData[i]);
                 }
@@ -387,11 +388,11 @@ public class JsonProjects implements Projects {
     private static HashMap<String, HashMap<String, String>> loadCsvPlotAllSamplesNew(String filename) {
         try (var lines = Files.lines(Paths.get(expandResourcePath("/csv/" + filename)))) {
             var plotPoints = new HashMap<String, HashMap<String, String>>();
-            var linesArr = lines.toArray(String[]::new);
-            var fieldNames =  Arrays.stream(linesArr[0].split(",")).toArray(String[]::new);
+            final var linesArr = lines.toArray(String[]::new);
+            final var fieldNames =  Arrays.stream(linesArr[0].split(",")).toArray(String[]::new);
             for (int r = 1; r != linesArr.length ; r++) {
                 var plotField = new HashMap<String, String>();
-                var fieldData = Arrays.stream(linesArr[r].split(",")).toArray(String[]::new);
+                final var fieldData = Arrays.stream(linesArr[r].split(",")).toArray(String[]::new);
                 for (int i = 0; i != fieldNames.length ; i++) {
                     plotField.put(fieldNames[i], fieldData[i]);
                 }
@@ -407,12 +408,12 @@ public class JsonProjects implements Projects {
     private static List<String> getGeoJsonHeaders(int projectId, String plotOrSample) {
         var jsonKeys = new ArrayList<String>();
         try {
-            var geoJson = readJsonFile("../shp/project-" + projectId + "-" + plotOrSample
+            final var geoJson = readJsonFile("../shp/project-" + projectId + "-" + plotOrSample
                                        + "/project-" + projectId + "-" + plotOrSample + ".json").getAsJsonObject();
             if (geoJson.get("type").getAsString().equals("FeatureCollection")) {
-                var properties = toStream(geoJson.get("features").getAsJsonArray())
+                final var properties = toStream(geoJson.get("features").getAsJsonArray())
                     .filter(feature -> {
-                            var geometry = feature.get("geometry").getAsJsonObject();
+                            final var geometry = feature.get("geometry").getAsJsonObject();
                             return geometry.get("type").getAsString().equals("Polygon");
                         })
                     .findFirst().get();
@@ -427,17 +428,17 @@ public class JsonProjects implements Projects {
     private static HashMap<String, HashMap<String, String>>  getGeoJsonPlotData(int projectId) {
         var plotGeoms = new HashMap<String, HashMap<String, String>>();
         try {
-            var geoJson = readJsonFile("../shp/project-" + projectId + "-plots"
+            final var geoJson = readJsonFile("../shp/project-" + projectId + "-plots"
                                        + "/project-" + projectId + "-plots.json").getAsJsonObject();
             if (geoJson.get("type").getAsString().equals("FeatureCollection")) {
                 toStream(geoJson.get("features").getAsJsonArray())
                     .filter(feature -> {
-                            var geometry = feature.get("geometry").getAsJsonObject();
+                            final var geometry = feature.get("geometry").getAsJsonObject();
                             return geometry.get("type").getAsString().equals("Polygon");
                         })
                     .forEach(feature -> {
-                            var properties = feature.get("properties").getAsJsonObject();
-                            var plotId = properties.get("PLOTID").getAsString();
+                            final var properties = feature.get("properties").getAsJsonObject();
+                            final var plotId = properties.get("PLOTID").getAsString();
                             var propertyMap = new HashMap<String, String>();
                             properties.keySet().forEach(key -> {
                                 propertyMap.put(key, getOrEmptyString(properties, key).getAsString());
@@ -451,21 +452,20 @@ public class JsonProjects implements Projects {
         return plotGeoms;
     }
 
-
     private static HashMap<String, HashMap<String, String>>  getGeoJsonSampleData(int projectId) {
         var plotGeoms = new HashMap<String, HashMap<String, String>>();
         try {
-            var geoJson = readJsonFile("../shp/project-" + projectId + "-samples"
+            final var geoJson = readJsonFile("../shp/project-" + projectId + "-samples"
                                        + "/project-" + projectId + "-samples.json").getAsJsonObject();
             if (geoJson.get("type").getAsString().equals("FeatureCollection")) {
                 toStream(geoJson.get("features").getAsJsonArray())
                     .filter(feature -> {
-                            var geometry = feature.get("geometry").getAsJsonObject();
+                            final var geometry = feature.get("geometry").getAsJsonObject();
                             return geometry.get("type").getAsString().equals("Polygon");
                         })
                     .forEach(feature -> {
-                            var properties = feature.get("properties").getAsJsonObject();
-                            var sampleId = properties.get("SAMPLEID").getAsString();
+                            final var properties = feature.get("properties").getAsJsonObject();
+                            final var sampleId = properties.get("SAMPLEID").getAsString();
                             var propertyMap = new HashMap<String, String>();
                             properties.keySet().forEach(key -> {
                                 propertyMap.put(key, getOrEmptyString(properties, key).getAsString());
@@ -479,48 +479,80 @@ public class JsonProjects implements Projects {
         return plotGeoms;
     }
 
+    private static HashMap<String, HashMap<String, String>>  getDataHashMap(JsonObject project, String plotOrSample) {
+        if (plotOrSample.equals("plots")) {
+            if (project.has("csv") && project.get("plotDistribution").getAsString().equals("csv")){
+                return loadCsvPlotAllColumnsOld(project.get("csv").getAsString());
+            } else if (project.has("plots-csv") && project.get("plotDistribution").getAsString().equals("csv")) {
+                return loadCsvPlotAllColumnsNew(project.get("plots-csv").getAsString());
+            } else if (project.has("plots-shp") && project.get("plotDistribution").getAsString().equals("shp")) {
+                return getGeoJsonPlotData(project.get("id").getAsInt());
+            } else {
+                return new HashMap<String, HashMap<String, String>>();
+            }
+        } else if (plotOrSample.equals("samples")) {
+            if (project.has("samples-csv") && project.get("sampleDistribution").getAsString().equals("csv")) {
+                return loadCsvPlotAllSamplesNew(project.get("samples-csv").getAsString());
+            } else if (project.has("samples-csv") && project.get("sampleDistribution").getAsString().equals("shp")) {
+                return getGeoJsonSampleData(project.get("id").getAsInt());
+            } else {
+                return new HashMap<String, HashMap<String, String>>();
+            }
+        } else {
+            return new HashMap<String, HashMap<String, String>>();
+        }
+
+    }
+
+    private static List<String> getHeadersList(JsonObject project, String plotOrSample) {
+        if (plotOrSample.equals("plots")) {
+            if (project.has("csv") && project.get("plotDistribution").getAsString().equals("csv")){
+                return getCsvHeaders(project.get("csv").getAsString());
+            } else if (project.has("plots-csv") && project.get("plotDistribution").getAsString().equals("csv")) {
+                return getCsvHeaders(project.get("plots-csv").getAsString());
+            } else if (project.has("plots-shp") && project.get("plotDistribution").getAsString().equals("shp")) {
+                return getGeoJsonHeaders(project.get("id").getAsInt(), "plots");
+            } else {
+                return new ArrayList<String>();
+            }
+        } else if (plotOrSample.equals("samples")) {
+            if (project.has("samples-csv") && project.get("sampleDistribution").getAsString().equals("csv")) {
+                return getCsvHeaders(project.get("samples-csv").getAsString());
+            } else if (project.has("samples-csv") && project.get("sampleDistribution").getAsString().equals("shp")) {
+                return getGeoJsonHeaders(project.get("id").getAsInt(), "samples");
+            } else {
+                return new ArrayList<String>();
+            }
+        } else {
+            return new ArrayList<String>();
+        }
+    }
+
+
     public HttpServletResponse dumpProjectAggregateData(Request req, Response res) {
-        var projectId = req.params(":id");
-        var projects = readJsonFile("project-list.json").getAsJsonArray();
-        var matchingProject = findInJsonArray(projects, project -> project.get("id").getAsString().equals(projectId));
+        final var projectId = req.params(":id");
+        final var projects = readJsonFile("project-list.json").getAsJsonArray();
+        final var matchingProject = findInJsonArray(projects, project -> project.get("id").getAsString().equals(projectId));
         DateFormat simple = new SimpleDateFormat("dd MMM yyyy HH:mm:ss");
 
         if (matchingProject.isPresent()) {
-            var project = matchingProject.get();
-            var sampleValueGroups = project.get("sampleValues").getAsJsonArray();
-            var projectName = project.get("name").getAsString().replace(" ", "-").replace(",", "").toLowerCase();
+            final var project = matchingProject.get();
+            final var sampleValueGroups = project.get("sampleValues").getAsJsonArray();
+            final var projectName = project.get("name").getAsString().replace(" ", "-").replace(",", "").toLowerCase();
             var optionalHeaders = new ArrayList<String>();
 
-            List<String> plotHeaders =  new ArrayList<String>();
-            var plotData = new  HashMap<String, HashMap<String, String>>();
-            if (project.has("csv") && project.get("plotDistribution").getAsString().equals("csv")){
-                plotData = loadCsvPlotAllColumnsOld(project.get("csv").getAsString());
-                plotHeaders = getCsvHeaders(project.get("csv").getAsString());
-            } else if (project.has("plots-csv") && project.get("plotDistribution").getAsString().equals("csv")) {
-                plotData = loadCsvPlotAllColumnsNew(project.get("plots-csv").getAsString());
-                plotHeaders = getCsvHeaders(project.get("plots-csv").getAsString());
-            } else if (project.has("plots-shp") && project.get("plotDistribution").getAsString().equals("shp")) {
-                plotData = getGeoJsonPlotData(project.get("id").getAsInt());
-                plotHeaders = getGeoJsonHeaders(project.get("id").getAsInt(), "plots");
-            }
-            final var finalPlotHeaders = plotHeaders;
-            final var finalPlotData = plotData;
+            final var plotHeaders = getHeadersList(project, "plots");
+            final var plotData = getDataHashMap(project, "plots");
 
-            var plots = readJsonFile("plot-data-" + projectId + ".json").getAsJsonArray();
+            final var plots = readJsonFile("plot-data-" + projectId + ".json").getAsJsonArray();
             var plotSummaries = mapJsonArray(plots,
                     plot -> {
-                        var samples = plot.get("samples").getAsJsonArray();
-                        var center = parseJson(plot.get("center").getAsString()).getAsJsonObject();
-                        var coords = center.get("coordinates").getAsJsonArray();
-
-                        // unfortunately there is an (small) intermediate step where collection time was stored as unusalble string
-                        var collectionTime = 0L;
-                        try {collectionTime = getOrZero(plot, "collectionTime").getAsLong();}
-                        catch (Exception e) {collectionTime = 0L;}
-                        final var finalCollectionTime = collectionTime;
-
-                        var collectionStart = getOrZero(plot, "collectionStart").getAsLong();
-                        var confidence = getOrZero(plot, "confidence").getAsInt();
+                        final var samples = plot.get("samples").getAsJsonArray();
+                        final var center = parseJson(plot.get("center").getAsString()).getAsJsonObject();
+                        final var coords = center.get("coordinates").getAsJsonArray();
+                        final var collectionTime = getOrZero(plot, "collectionTime").getAsLong();
+                        final var collectionStart = getOrZero(plot, "collectionStart").getAsLong();
+                        final var confidence = getOrZero(plot, "confidence").getAsInt();
                         var analysisDuration = 0.0;
                         // Wait until these fields is found to add the column header
                         if (collectionTime > 0L){
@@ -545,18 +577,18 @@ public class JsonProjects implements Projects {
                         plotSummary.addProperty("analyses", getOrZero(project, "analyses").getAsInt());
                         plotSummary.addProperty("sample_points", samples.size());
                         plotSummary.add("user_id", plot.get("user"));
-                        plotSummary.addProperty("collection_time", simple.format(new Date(finalCollectionTime)));
+                        plotSummary.addProperty("collection_time", simple.format(new Date(collectionTime)));
                         plotSummary.addProperty("analysis_duration", finalAnalysisDuration);
                         plotSummary.addProperty("confidence", confidence);
                         plotSummary.add("distribution",
                                 getValueDistribution(samples, getSampleValueTranslations(sampleValueGroups)));
 
-                        if (finalPlotHeaders.size() > 0 && finalPlotData.containsKey(plot.has("plotId") 
+                        if (plotHeaders.size() > 0 && plotData.containsKey(plot.has("plotId") 
                                 ? plot.get("plotId").getAsString() 
                                 : plot.get("id").getAsString()))
                         {
-                            finalPlotHeaders.forEach(head ->
-                                plotSummary.addProperty("pl_" + head, finalPlotData.get(plot.has("plotId") 
+                            plotHeaders.forEach(head ->
+                                plotSummary.addProperty("pl_" + head, plotData.get(plot.has("plotId") 
                                     ? plot.get("plotId").getAsString() 
                                     : plot.get("id").getAsString())
                                 .get(head) )
@@ -565,7 +597,7 @@ public class JsonProjects implements Projects {
                         return plotSummary;
                     });
 
-            var combinedHeaders = Stream.concat(
+            final var combinedHeaders = Stream.concat(
                     optionalHeaders.stream(),
                     plotHeaders.stream()
                         .map(head -> !head.toString().contains("pl_") ? "pl_" + head : head)
@@ -580,60 +612,33 @@ public class JsonProjects implements Projects {
     }
 
     public HttpServletResponse dumpProjectRawData(Request req, Response res) {
-        var projectId = req.params(":id");
-        var projects = readJsonFile("project-list.json").getAsJsonArray();
-        var matchingProject = findInJsonArray(projects, project -> project.get("id").getAsString().equals(projectId));
+        final var projectId = req.params(":id");
+        final var projects = readJsonFile("project-list.json").getAsJsonArray();
+        final var matchingProject = findInJsonArray(projects, project -> project.get("id").getAsString().equals(projectId));
         DateFormat simple = new SimpleDateFormat("dd MMM yyyy HH:mm:ss");
 
         if (matchingProject.isPresent()) {
-            var project = matchingProject.get();
-            var sampleValueGroups = project.get("sampleValues").getAsJsonArray();
+            final var project = matchingProject.get();
+            final var sampleValueGroups = project.get("sampleValues").getAsJsonArray();
             
             var optionalHeaders = new ArrayList<String>();
 
-            List<String> plotHeaders =  new ArrayList<String>();
-            var plotData = new  HashMap<String, HashMap<String, String>>();
-            if (project.has("csv") && project.get("plotDistribution").getAsString().equals("csv")){
-                plotData = loadCsvPlotAllColumnsOld(project.get("csv").getAsString());
-                plotHeaders = getCsvHeaders(project.get("csv").getAsString());
-            } else if (project.has("plots-csv") && project.get("plotDistribution").getAsString().equals("csv")) {
-                plotData = loadCsvPlotAllColumnsNew(project.get("plots-csv").getAsString());
-                plotHeaders = getCsvHeaders(project.get("plots-csv").getAsString());
-            } else if (project.has("plots-shp") && project.get("plotDistribution").getAsString().equals("shp")) {
-                plotData = getGeoJsonPlotData(project.get("id").getAsInt());
-                plotHeaders = getGeoJsonHeaders(project.get("id").getAsInt(), "plots");
-            }
-            final var finalPlotHeaders = plotHeaders;
-            final var finalPlotData = plotData;
-            
-            List<String> sampleHeaders = new ArrayList<String>();
-            var sampleData = new  HashMap<String, HashMap<String, String>>();
-            if (project.has("samples-csv") && project.get("sampleDistribution").getAsString().equals("csv")) {
-                sampleData = loadCsvPlotAllSamplesNew(project.get("samples-csv").getAsString());
-                sampleHeaders = getCsvHeaders(project.get("samples-csv").getAsString());
-            } else if (project.has("samples-csv") && project.get("sampleDistribution").getAsString().equals("shp")) {
-                sampleData = getGeoJsonSampleData(project.get("id").getAsInt());
-                sampleHeaders = getGeoJsonHeaders(project.get("id").getAsInt(), "samples");
-            }
-            final var finalSampleHeaders = sampleHeaders;
-            final var finalSampleData = sampleData;
+            final var plotHeaders = getHeadersList(project, "plots");
+            final var plotData = getDataHashMap(project, "plots");
+
+            final var sampleHeaders = getHeadersList(project, "samples");
+            final var sampleData = getDataHashMap(project, "samples");
 
             var plots = readJsonFile("plot-data-" + projectId + ".json").getAsJsonArray();
             var sampleSummaries = flatMapJsonArray(plots,
                     plot -> {
-                        var plotId = plot.get("id").getAsInt();
-                        var flagged = plot.get("flagged").getAsBoolean();
-                        var analyses = plot.get("analyses").getAsInt();
-                        var userId = plot.get("user");
-
-                        // unfortunately there is a (small) intermediate step where collection time was stored as unusalble string
-                        var collectionTime = 0L;
-                        try {collectionTime = getOrZero(plot, "collectionTime").getAsLong();}
-                        catch (Exception e) {collectionTime = 0L;}
-                        final var finalCollectionTime = collectionTime;
-
-                        var collectionStart = getOrZero(plot, "collectionStart").getAsLong();
-                        var confidence = getOrZero(plot, "confidence").getAsInt();
+                        final var plotId = plot.get("id").getAsInt();
+                        final var flagged = plot.get("flagged").getAsBoolean();
+                        final var analyses = plot.get("analyses").getAsInt();
+                        final var userId = plot.get("user");
+                        final var collectionTime = getOrZero(plot, "collectionTime").getAsLong();
+                        final var collectionStart = getOrZero(plot, "collectionStart").getAsLong();
+                        final var confidence = getOrZero(plot, "confidence").getAsInt();
                         var analysisDuration = 0.0;
                         // Wait until these fields is found to add the column header
                         if (collectionTime > 0L){
@@ -648,11 +653,11 @@ public class JsonProjects implements Projects {
                             if (!optionalHeaders.contains("confidence")) optionalHeaders.add("confidence");
                         }
 
-                        var samples = plot.get("samples").getAsJsonArray();
+                        final var samples = plot.get("samples").getAsJsonArray();
                         return toStream(samples).map(sample -> {
-                            var center = parseJson(sample.get("point").getAsString())
+                            final var center = parseJson(sample.get("point").getAsString())
                                     .getAsJsonObject();
-                            var coords = center.get("coordinates").getAsJsonArray();
+                            final var coords = center.get("coordinates").getAsJsonArray();
                             var sampleSummary = new JsonObject();
                             sampleSummary.addProperty("plot_id", plotId);
                             sampleSummary.addProperty("sample_id", sample.get("id").getAsInt());
@@ -663,19 +668,19 @@ public class JsonProjects implements Projects {
                             sampleSummary.add("user_id", userId);
                             sampleSummary.add("value", sample.get("value"));
                             
-                            sampleSummary.addProperty("collection_time", simple.format(new Date(finalCollectionTime)));
+                            sampleSummary.addProperty("collection_time", simple.format(new Date(collectionTime)));
                             sampleSummary.addProperty("analysis_duration", finalAnalysisDuration);
                             sampleSummary.addProperty("confidence", confidence);
                             
                             // Add imagery data to output if it exists
                             if (sample.has("userImage")) {
-                                var imageData = sample.get("userImage").getAsJsonObject();
+                                final var imageData = sample.get("userImage").getAsJsonObject();
 
                                 sampleSummary.addProperty("imagery_title", getImageryTitle(imageData.get("id").getAsString()));
                                 if (!optionalHeaders.contains("imagery_title")) optionalHeaders.add("imagery_title");
                                 
                                 if (imageData.has("attributes")) {
-                                    var attributes = imageData.get("attributes").getAsJsonObject();
+                                    final var attributes = imageData.get("attributes").getAsJsonObject();
                                     attributes.keySet().forEach(key -> {
                                         sampleSummary.addProperty(key, attributes.get(key).getAsString());
                                         if (!optionalHeaders.contains(key)) optionalHeaders.add(key);
@@ -683,13 +688,13 @@ public class JsonProjects implements Projects {
                                 }
                             }
 
-                            if (finalPlotHeaders.size() > 0 && finalPlotData.containsKey(
+                            if (plotHeaders.size() > 0 && plotData.containsKey(
                                     plot.has("plotId") 
                                     ? plot.get("plotId").getAsString() 
                                     : plot.get("id").getAsString())
                                 ){
-                                finalPlotHeaders.forEach(head ->
-                                    sampleSummary.addProperty("pl_" + head, finalPlotData.get(
+                                plotHeaders.forEach(head ->
+                                    sampleSummary.addProperty("pl_" + head, plotData.get(
                                         plot.has("plotId") 
                                         ? plot.get("plotId").getAsString() 
                                         : plot.get("id").getAsString())
@@ -697,17 +702,15 @@ public class JsonProjects implements Projects {
                                 );
                             }
 
-                            if (finalSampleHeaders.size() > 0 && finalSampleData.containsKey(
+                            if (sampleHeaders.size() > 0 && sampleData.containsKey(
                                     sample.has("sampleId") 
                                     ? sample.get("sampleId").getAsString() 
                                     : "")
                                 ){
-                                finalSampleHeaders.forEach(head ->
-                                    sampleSummary.addProperty("smpl_" + head, finalSampleData.get(
-                                        sample.has("sampleId") 
-                                        ? sample.get("sampleId").getAsString() 
-                                        : sample.get("id").getAsString())
-                                    .get(head) )
+                                sampleHeaders.forEach(head ->
+                                    sampleSummary.addProperty("smpl_" + head, sampleData.get(
+                                                        sample.get("sampleId").getAsString() )
+                                    .get(head))
                                 );
                             }
 
@@ -715,9 +718,9 @@ public class JsonProjects implements Projects {
                         });
                     });
 
-            var projectName = project.get("name").getAsString().replace(" ", "-").replace(",", "").toLowerCase();
+            final var projectName = project.get("name").getAsString().replace(" ", "-").replace(",", "").toLowerCase();
 
-            var combinedHeaders = 
+            final var combinedHeaders = 
                         Stream.concat(
                             optionalHeaders.stream(),
                             Stream.concat(
@@ -852,9 +855,9 @@ public class JsonProjects implements Projects {
             lines
                 .skip(1)
                 .forEach(line -> {
-                        var fields = Arrays.stream(line.split(",")).map(String::trim).toArray(String[]::new);
-                        var plotId = Integer.parseInt(fields[2]);
-                        var plotCenter = new Double[]{Double.parseDouble(fields[0]),
+                        final var fields = Arrays.stream(line.split(",")).map(String::trim).toArray(String[]::new);
+                        final var plotId = Integer.parseInt(fields[2]);
+                        final var plotCenter = new Double[]{Double.parseDouble(fields[0]),
                                                       Double.parseDouble(fields[1])};
                         plotPoints.put(plotId, plotCenter);
                     });
@@ -871,10 +874,10 @@ public class JsonProjects implements Projects {
             lines
                 .skip(1)
                 .forEach(line -> {
-                        var fields = Arrays.stream(line.split(",")).map(String::trim).toArray(String[]::new);
-                        var plotId = Integer.parseInt(fields[2]);
-                        var sampleId = Integer.parseInt(fields[3]);
-                        var sampleCenter = new Double[]{Double.parseDouble(fields[0]),
+                        final var fields = Arrays.stream(line.split(",")).map(String::trim).toArray(String[]::new);
+                        final var plotId = Integer.parseInt(fields[2]);
+                        final var sampleId = Integer.parseInt(fields[3]);
+                        final var sampleCenter = new Double[]{Double.parseDouble(fields[0]),
                                                         Double.parseDouble(fields[1])};
                         if (samplesByPlot.containsKey(plotId)) {
                             var samplePoints = samplesByPlot.get(plotId);
@@ -894,19 +897,19 @@ public class JsonProjects implements Projects {
     // The uploaded GeoJson must contain Polygon geometries with PLOTID properties
     private static HashMap<Integer, JsonObject> getGeoJsonPlotGeometries(int projectId) {
         try {
-            var geoJson = readJsonFile("../shp/project-" + projectId + "-plots"
+            final var geoJson = readJsonFile("../shp/project-" + projectId + "-plots"
                                        + "/project-" + projectId + "-plots.json").getAsJsonObject();
             if (geoJson.get("type").getAsString().equals("FeatureCollection")) {
-                var plotGeoms = new HashMap<Integer, JsonObject>();
+                final var plotGeoms = new HashMap<Integer, JsonObject>();
                 toStream(geoJson.get("features").getAsJsonArray())
                     .filter(feature -> {
-                            var geometry = feature.get("geometry").getAsJsonObject();
+                            final var geometry = feature.get("geometry").getAsJsonObject();
                             return geometry.get("type").getAsString().equals("Polygon");
                         })
                     .forEach(feature -> {
-                            var geometry = feature.get("geometry").getAsJsonObject();
-                            var properties = feature.get("properties").getAsJsonObject();
-                            var plotId = properties.get("PLOTID").getAsInt();
+                            final var geometry = feature.get("geometry").getAsJsonObject();
+                            final var properties = feature.get("properties").getAsJsonObject();
+                            final var plotId = properties.get("PLOTID").getAsInt();
                             plotGeoms.put(plotId, geometry);
                         });
                 return plotGeoms;
@@ -922,22 +925,22 @@ public class JsonProjects implements Projects {
     // The uploaded GeoJson must contain Polygon geometries with PLOTID and SAMPLEID properties
     private static HashMap<Integer, HashMap<Integer, JsonObject>> getGeoJsonSampleGeometries(int projectId) {
         try {
-            var geoJson = readJsonFile("../shp/project-" + projectId + "-samples"
+            final var geoJson = readJsonFile("../shp/project-" + projectId + "-samples"
                                        + "/project-" + projectId + "-samples.json").getAsJsonObject();
             if (geoJson.get("type").getAsString().equals("FeatureCollection")) {
                 var sampleGeomsByPlot = new HashMap<Integer, HashMap<Integer, JsonObject>>();
                 toStream(geoJson.get("features").getAsJsonArray())
                     .filter(feature -> {
-                            var geometry = feature.get("geometry").getAsJsonObject();
+                            final var geometry = feature.get("geometry").getAsJsonObject();
                             return geometry.get("type").getAsString().equals("Polygon");
                         })
                     .forEach(feature -> {
-                            var geometry = feature.get("geometry").getAsJsonObject();
-                            var properties = feature.get("properties").getAsJsonObject();
-                            var plotId = properties.get("PLOTID").getAsInt();
-                            var sampleId = properties.get("SAMPLEID").getAsInt();
+                            final var geometry = feature.get("geometry").getAsJsonObject();
+                            final var properties = feature.get("properties").getAsJsonObject();
+                            final var plotId = properties.get("PLOTID").getAsInt();
+                            final var sampleId = properties.get("SAMPLEID").getAsInt();
                             if (sampleGeomsByPlot.containsKey(plotId)) {
-                                var sampleGeoms = sampleGeomsByPlot.get(plotId);
+                                final var sampleGeoms = sampleGeomsByPlot.get(plotId);
                                 sampleGeoms.put(sampleId, geometry);
                             } else {
                                 var sampleGeoms = new HashMap<Integer, JsonObject>();

--- a/src/main/java/org/openforis/ceo/postgres/PostgresProjects.java
+++ b/src/main/java/org/openforis/ceo/postgres/PostgresProjects.java
@@ -426,8 +426,8 @@ public class PostgresProjects implements Projects {
             try(var rs = pstmt.executeQuery()){
                 if (rs.next()) {
                     var plotSummaries = new JsonArray();
-                    var sampleValueGroups = parseJson(rs.getString("sample_survey")).getAsJsonArray();
-                    var projectName = rs.getString("name").replace(" ", "-").replace(",", "").toLowerCase();
+                    final var sampleValueGroups = parseJson(rs.getString("sample_survey")).getAsJsonArray();
+                    final var projectName = rs.getString("name").replace(" ", "-").replace(",", "").toLowerCase();
                     var plotHeaders = getPlotHeaders(conn, projectId);
 
                     try(var pstmtDump = conn.prepareStatement("SELECT * FROM dump_project_plot_data(?)")){
@@ -479,7 +479,7 @@ public class PostgresProjects implements Projects {
         return res.raw();
     }
     
-     public HttpServletResponse dumpProjectRawData(Request req, Response res) {
+    public HttpServletResponse dumpProjectRawData(Request req, Response res) {
         var projectId =Integer.parseInt( req.params(":id"));
 
         try (var conn = connect();
@@ -489,11 +489,11 @@ public class PostgresProjects implements Projects {
             try(var rs = pstmt.executeQuery()){
                 if (rs.next()) {
                     var sampleSummaries = new JsonArray();
-                    var sampleValueGroups = parseJson(rs.getString("sample_survey")).getAsJsonArray();
-                    var projectName = rs.getString("name").replace(" ", "-").replace(",", "").toLowerCase();
-                    var plotHeaders = getPlotHeaders(conn, projectId);
-                    var sampleHeaders = getSampleHeaders(conn, projectId);
-                    var imageryHeaders = new ArrayList<String>();
+                    final var sampleValueGroups = parseJson(rs.getString("sample_survey")).getAsJsonArray();
+                    final var projectName = rs.getString("name").replace(" ", "-").replace(",", "").toLowerCase();
+                    final var plotHeaders = getPlotHeaders(conn, projectId);
+                    final var sampleHeaders = getSampleHeaders(conn, projectId);
+                    var optionalHeaders = new ArrayList<String>();
 
                     try(var pstmtDump = conn.prepareStatement("SELECT * FROM dump_project_sample_data(?)")){
                         pstmtDump.setInt(1, projectId);
@@ -515,22 +515,22 @@ public class PostgresProjects implements Projects {
                                 }
                                 if (!valueOrBlank(rsDump.getString("collection_time")).equals("")) {
                                     plotSummary.addProperty("collection_time", valueOrBlank(rsDump.getString("collection_time")));
-                                    if (!imageryHeaders.contains("collection_time")) imageryHeaders.add("collection_time");
+                                    if (!optionalHeaders.contains("collection_time")) optionalHeaders.add("collection_time");
                                 }
                                 if (!valueOrBlank(rsDump.getString("analysis_duration")).equals("")) {
                                     plotSummary.addProperty("analysis_duration", valueOrBlank(rsDump.getString("analysis_duration")));
-                                    if (!imageryHeaders.contains("analysis_duration")) imageryHeaders.add("analysis_duration");
+                                    if (!optionalHeaders.contains("analysis_duration")) optionalHeaders.add("analysis_duration");
                                 }
 
                                 if (valueOrBlank(rsDump.getString("imagery_title")) != "") {
                                     plotSummary.addProperty("imagery_title", rsDump.getString("imagery_title"));
-                                    if (!imageryHeaders.contains("imagery_title")) imageryHeaders.add("imagery_title");
+                                    if (!optionalHeaders.contains("imagery_title")) optionalHeaders.add("imagery_title");
                                     
                                     if (valueOrBlank(rsDump.getString("imagery_attributes")).length() > 2) {
                                         var attributes = parseJson(rsDump.getString("imagery_attributes")).getAsJsonObject();
                                         attributes.keySet().forEach(key -> {
                                             plotSummary.addProperty(key, attributes.get(key).getAsString());
-                                            if (!imageryHeaders.contains(key)) imageryHeaders.add(key);
+                                            if (!optionalHeaders.contains(key)) optionalHeaders.add(key);
                                         });
                                     }
                                 }
@@ -553,7 +553,7 @@ public class PostgresProjects implements Projects {
                         }
                         var combinedHeaders = 
                         Stream.concat(
-                            imageryHeaders.stream(),
+                            optionalHeaders.stream(),
                             Stream.concat(
                                     plotHeaders.stream()
                                     .map(head -> !head.toString().contains("pl_") ? "pl_" + head : head),
@@ -695,7 +695,7 @@ public class PostgresProjects implements Projects {
     private static String loadCsvHeaders(String filename, List<String> mustInclude) {
         try (var lines = Files.lines(Paths.get(expandResourcePath("/csv/" + filename)))) {
             
-            var colList = Arrays.stream(
+            final var colList = Arrays.stream(
                 lines.findFirst().orElse("").split(","))
                     .map(col -> {
                         return col.toUpperCase();
@@ -709,7 +709,7 @@ public class PostgresProjects implements Projects {
                 }   
             });
 
-            var fields = colList.stream()
+            final var fields = colList.stream()
                     .map(col -> {
                         if (List.of("LON", "LAT", "LATITUDE", "LONGITUDE", "LONG", "CENTER_X", "CENTER_Y").contains(col.toUpperCase())) {
                             return col.toUpperCase() + " float";
@@ -729,7 +729,7 @@ public class PostgresProjects implements Projects {
     private static String[] loadCsvHeadersToRename(String filename) {
         try (var lines = Files.lines(Paths.get(expandResourcePath("/csv/" + filename)))) {
             
-            var colList = lines.findFirst().orElse("").split(",");
+            final var colList = lines.findFirst().orElse("").split(",");
             return new String[] {colList[0],colList[1]};
 
         } catch (Exception e) {
@@ -757,55 +757,61 @@ public class PostgresProjects implements Projects {
         deleteFile("project-" + projectId + "-plots.zip");
         deleteFile("project-" + projectId + "-samples.zip");
     }
-
-    private static String loadPlots(Connection conn, String plotDistribution, Integer projectId, String plotsFile) {
+    
+    private static String loadExternalData(Connection conn, String distribution, Integer projectId, String extFile, String plotsOrSamples, List<String> mustInclude) {
         try {
-            var plots_table = "";
-            if (plotDistribution.equals("csv")) {
-                plots_table = "project_" +  projectId + "_plots_csv";
+            if (distribution.equals("csv")) {
+                final var table_name = "project_" +  projectId + "_" + plotsOrSamples + "_csv";
                 // add empty table to the database
                 try(var pstmt = conn.prepareStatement("SELECT * FROM create_new_table(?,?)")){
-                    pstmt.setString(1, plots_table);
-                    pstmt.setString(2, loadCsvHeaders(plotsFile, List.of("plotId")));
+                    pstmt.setString(1, table_name);
+                    pstmt.setString(2, loadCsvHeaders(extFile, mustInclude));
                     pstmt.execute();
                 } 
                 // import csv file
-                runBashScriptForProject(projectId, "plots", "csv2postgres.sh", "/csv");
-                var renameFrom = loadCsvHeadersToRename(plotsFile);
+                runBashScriptForProject(projectId, plotsOrSamples, "csv2postgres.sh", "/csv");
+                var renameFrom = loadCsvHeadersToRename(extFile);
                 // rename columns
                 try(var pstmt = conn.prepareStatement("SELECT * FROM rename_col(?,?,?)")){
-                    pstmt.setString(1,plots_table);
+                    pstmt.setString(1,table_name);
                     pstmt.setString(2,renameFrom[0]);
                     pstmt.setString(3,"lon");
                     pstmt.execute();
-                } catch (SQLException s) {
-                    System.out.println(s.getMessage());
-                    throw new RuntimeException("Error with column names 1");
                 }
                 try(var pstmt = conn.prepareStatement("SELECT * FROM rename_col(?,?,?)")){
-                    pstmt.setString(1,plots_table);
+                    pstmt.setString(1,table_name);
                     pstmt.setString(2,renameFrom[1]);
                     pstmt.setString(3,"lat");
                     pstmt.execute();
-                } catch (SQLException s) {
-                    System.out.println(s.getMessage());
-                    throw new RuntimeException("Error with column names 2");
-                }
-
+                } 
                 // add index for reference
                 try(var pstmt = conn.prepareStatement("SELECT * FROM add_index_col(?)")){
-                    pstmt.setString(1,plots_table);
+                    pstmt.setString(1,table_name);
                     pstmt.execute();
                 } 
-            } else if (plotDistribution.equals("shp")) {
-                runBashScriptForProject(projectId, "plots", "shp2postgres.sh", "/shp");
-                plots_table = "project_" +  projectId + "_plots_shp";
-                // run query to make sure all requred fields exist
+
+                return table_name;
+
+            } else if (distribution.equals("shp")) {
+                runBashScriptForProject(projectId, plotsOrSamples, "shp2postgres.sh", "/shp");
+                return "project_" +  projectId + "_" + plotsOrSamples + "_shp";
+            } else {
+                return "";
             }
+        } catch (SQLException s) {
+            System.out.println(s.getMessage());
+            throw new RuntimeException("Error importing file into SQL");
+        }
+    }
+
+    private static String checkLoadPlots(Connection conn, String plotDistribution, Integer projectId, String plotsFile) {
+        try {
+          
             if (List.of("csv", "shp").contains(plotDistribution)){
                 // check if data is also correct after being loaded
+                final var plots_table = loadExternalData(conn, plotDistribution, projectId, plotsFile, "plot", List.of("plotId"));
                 try(var pstmt = conn.prepareStatement("SELECT * FROM select_partial_table_by_name(?)")){
-                    pstmt.setString(1,plots_table);
+                    pstmt.setString(1, plots_table);
                     pstmt.execute();
                 } catch (SQLException s) {
                     System.out.println(s.getMessage());
@@ -824,46 +830,9 @@ public class PostgresProjects implements Projects {
         } 
     }
 
-    private static String loadSamples(Connection conn, String sampleDistribution, Integer projectId, String samplesFile) {
+    private static String checkLoadSamples(Connection conn, String sampleDistribution, Integer projectId, String samplesFile) {
         try {
-            var samples_table = "";
-            if (sampleDistribution.equals("csv")) {
-                samples_table = "project_" +  projectId + "_samples_csv";
-                // create new table
-                try(var pstmt = conn.prepareStatement("SELECT * FROM create_new_table(?,?)")){
-                    pstmt.setString(1,samples_table);
-                    pstmt.setString(2, loadCsvHeaders(samplesFile, List.of("plotId", "sampleId")));
-                    pstmt.execute();
-                }
-                // fill table
-                runBashScriptForProject(projectId, "samples", "csv2postgres.sh", "/csv");
-                // add index for reference
-                // rename columns
-                var renameFrom = loadCsvHeadersToRename(samplesFile);
-                try(var pstmt = conn.prepareStatement("SELECT * FROM rename_col(?,?,?)")){
-                    pstmt.setString(1,samples_table);
-                    pstmt.setString(2,renameFrom[0]);
-                    pstmt.setString(3,"lon");
-                    pstmt.execute();
-                } catch (SQLException s) {
-                    throw new RuntimeException("Error with column names");
-                }
-                try(var pstmt = conn.prepareStatement("SELECT * FROM rename_col(?,?,?)")){
-                    pstmt.setString(1,samples_table);
-                    pstmt.setString(2,renameFrom[1]);
-                    pstmt.setString(3,"lat");
-                    pstmt.execute();
-                } catch (SQLException s) {
-                    throw new RuntimeException("Error with column names");
-                }
-                try(var pstmt = conn.prepareStatement("SELECT * FROM add_index_col(?)")){
-                    pstmt.setString(1,"project_" +  projectId + "_samples_csv");
-                    pstmt.execute();
-                }
-            } else if (sampleDistribution.equals("shp")) {
-                runBashScriptForProject(projectId, "samples", "shp2postgres.sh", "/shp");
-                samples_table = "project_" +  projectId + "_samples_shp";
-            }
+            final var samples_table = loadExternalData(conn, sampleDistribution, projectId, samplesFile, "plot", List.of("plotId", "sampleId"));
             if (List.of("csv", "shp").contains(sampleDistribution)){
                 // check if data is also correct after being loaded
                 try(var pstmt = conn.prepareStatement("SELECT * FROM select_partial_table_by_name(?)")){
@@ -907,8 +876,8 @@ public class PostgresProjects implements Projects {
             try (var pstmt = 
                 conn.prepareStatement("SELECT * FROM update_project_tables(?,?::text,?::text)")) {
                 pstmt.setInt(1, projectId);     
-                pstmt.setString(2, loadPlots(conn, plotDistribution, projectId, plotsFile));
-                pstmt.setString(3, loadSamples(conn, sampleDistribution, projectId, samplesFile));
+                pstmt.setString(2, checkLoadPlots(conn, plotDistribution, projectId, plotsFile));
+                pstmt.setString(3, checkLoadSamples(conn, sampleDistribution, projectId, samplesFile));
                 pstmt.execute();
             } catch (SQLException e) {
                 System.out.println("catch update");
@@ -952,29 +921,28 @@ public class PostgresProjects implements Projects {
                 } 
             } else {
                 // Convert the lat/lon boundary coordinates to Web Mercator (units: meters) and apply an interior buffer of plotSize / 2
-                var bounds = reprojectBounds(lonMin, latMin, lonMax, latMax, 4326, 3857);
-                var paddedBounds = padBounds(bounds[0], bounds[1], bounds[2], bounds[3], plotSize / 2.0);
-                var left = paddedBounds[0];
-                var bottom = paddedBounds[1];
-                var right = paddedBounds[2];
-                var top = paddedBounds[3];
+                final var bounds = reprojectBounds(lonMin, latMin, lonMax, latMax, 4326, 3857);
+                final var paddedBounds = padBounds(bounds[0], bounds[1], bounds[2], bounds[3], plotSize / 2.0);
+                final var left = paddedBounds[0];
+                final var bottom = paddedBounds[1];
+                final var right = paddedBounds[2];
+                final var top = paddedBounds[3];
 
                 // Generate the plot objects and their associated sample points
-                var newPlotCenters =
-                plotDistribution.equals("random") 
-                ? createRandomPointsInBounds(left, bottom, right, top, numPlots)
-                : createGriddedPointsInBounds(left, bottom, right, top, plotSpacing);
+                final var newPlotCenters =
+                    plotDistribution.equals("random") 
+                    ? createRandomPointsInBounds(left, bottom, right, top, numPlots)
+                    : createGriddedPointsInBounds(left, bottom, right, top, plotSpacing);
 
                 Arrays.stream(newPlotCenters)
-                .forEach(plotEntry -> {
-                    var plotCenter = plotEntry;
-                        var SqlPlots = "SELECT * FROM create_project_plot(?,ST_SetSRID(ST_GeomFromGeoJSON(?), 4326))";
+                .forEach(plotCenter -> {
+                        final var SqlPlots = "SELECT * FROM create_project_plot(?,ST_SetSRID(ST_GeomFromGeoJSON(?), 4326))";
                         try(var pstmtPlots = conn.prepareStatement(SqlPlots)) {
                         pstmtPlots.setInt(1, projectId);    
                         pstmtPlots.setString(2, makeGeoJsonPoint(plotCenter[0], plotCenter[1]).toString());       
                         try(var rsPlots = pstmtPlots.executeQuery()){
                             if (rsPlots.next()) {
-                                var newPlotId = rsPlots.getInt("create_project_plot");
+                                final var newPlotId = rsPlots.getInt("create_project_plot");
                                 createProjectSamples(conn, newPlotId, sampleDistribution, 
                                     plotCenter, plotShape, plotSize, samplesPerPlot, sampleResolution, false);
                             }
@@ -1039,10 +1007,10 @@ public class PostgresProjects implements Projects {
             newProject.addProperty("description", partToString(req.raw().getPart("description")));
             newProject.addProperty("availability", "unpublished");
 
-            var lonMin =             getOrZero(newProject,"lonMin").getAsDouble();
-            var latMin =             getOrZero(newProject,"latMin").getAsDouble();
-            var lonMax =             getOrZero(newProject,"lonMax").getAsDouble();
-            var latMax =             getOrZero(newProject,"latMax").getAsDouble();
+            final var lonMin =             getOrZero(newProject,"lonMin").getAsDouble();
+            final var latMin =             getOrZero(newProject,"latMin").getAsDouble();
+            final var lonMax =             getOrZero(newProject,"lonMax").getAsDouble();
+            final var latMax =             getOrZero(newProject,"latMax").getAsDouble();
             newProject.addProperty("boundary", makeGeoJsonPolygon(lonMin, latMin, lonMax, latMax).toString());
 
             var SQL = "SELECT * FROM create_project(?,?,?,?,?,ST_SetSRID(ST_GeomFromGeoJSON(?), 4326),?,?,?,?,?,?,?,?,?,?::JSONB,?::jsonb)";
@@ -1079,37 +1047,31 @@ public class PostgresProjects implements Projects {
                                 copyPstmt.execute();
                             }
                         } else {
-                            // Upload the plot-distribution-csv-file if one was provided
+                            // Upload the *-distribution-csv-file if one was provided
                             // not stored in database
                             if (newProject.get("plotDistribution").getAsString().equals("csv")) {
-                                var csvFileName = writeFilePart(req,
+                                final var csvFileName = writeFilePart(req,
                                         "plot-distribution-csv-file",
                                         expandResourcePath("/csv"),
                                         "project-" + newProjectId + "-plots");
                                 newProject.addProperty("plots_file", csvFileName);
-                            } 
-
-                            // Upload the sample-distribution-csv-file if one was provided
-                            if (newProject.get("sampleDistribution").getAsString().equals("csv")) {
-                                var csvFileName = writeFilePart(req,
+                            } else if (newProject.get("sampleDistribution").getAsString().equals("csv")) {
+                                final var csvFileName = writeFilePart(req,
                                         "sample-distribution-csv-file",
                                         expandResourcePath("/csv"),
                                         "project-" + newProjectId + "-samples");
                                 newProject.addProperty("samples_file", csvFileName);
                             } 
 
-                            // Upload the plot-distribution-shp-file if one was provided (this should be a ZIP file)
+                            // Upload the *-distribution-shp-file if one was provided (this should be a ZIP file)
                             if (newProject.get("plotDistribution").getAsString().equals("shp")) {
-                                var shpFileName = writeFilePart(req,
+                                final var shpFileName = writeFilePart(req,
                                                                 "plot-distribution-shp-file",
                                                                 expandResourcePath("/shp"),
                                                                 "project-" + newProjectId + "-plots");
                                 newProject.addProperty("plots_file", shpFileName);
-                            }
-
-                            // Upload the sample-distribution-shp-file if one was provided (this should be a ZIP file)
-                            if (newProject.get("sampleDistribution").getAsString().equals("shp")) {
-                                var shpFileName = writeFilePart(req,
+                            } else if (newProject.get("sampleDistribution").getAsString().equals("shp")) {
+                                final var shpFileName = writeFilePart(req,
                                                                 "sample-distribution-shp-file",
                                                                 expandResourcePath("/shp"),
                                                                 "project-" + newProjectId + "-samples");

--- a/src/main/java/org/openforis/ceo/utils/ProjectUtils.java
+++ b/src/main/java/org/openforis/ceo/utils/ProjectUtils.java
@@ -364,7 +364,11 @@ public class ProjectUtils {
     }
 
     public static JsonElement getOrZero(JsonObject obj, String field) {
-        return !obj.has(field) || obj.get(field).isJsonNull() || obj.get(field) == null ? new JsonPrimitive(0) : obj.get(field);
+        try {
+            return obj.get(field).isJsonNull() || obj.get(field) == null ? new JsonPrimitive(0) : obj.get(field);
+        } catch(Exception e) {
+            return new JsonPrimitive(0);
+        }
     }
 
     public static JsonElement getOrEmptyString(JsonObject obj, String field) {

--- a/src/main/java/org/openforis/ceo/utils/ProjectUtils.java
+++ b/src/main/java/org/openforis/ceo/utils/ProjectUtils.java
@@ -121,17 +121,24 @@ public class ProjectUtils {
         return response;
     }
 
+    private static String csvQuotes(String input) {
+        return input.contains(",") ? "\"" + input + "\"" : input;
+    }
+
     public static HttpServletResponse outputAggregateCsv(Response res, JsonArray sampleValueGroups, JsonArray plotSummaries, String projectName, String[] externalHeaders){
         var sampleValueKeys = getSampleKeys(sampleValueGroups);
         // fileds are straight forward json values
-        var fields = Stream.concat(
+        final String[] fields = Stream.concat(
                         Arrays.stream(new String[]{"plot_id", "center_lon", "center_lat", "size_m", "shape", "flagged", "analyses", "sample_points", "user_id"}), 
                         Arrays.stream(externalHeaders))
                         .toArray(String[]::new);
         // labels require interpretation of the next json object
-        var labels = getValueDistributionLabels(sampleValueGroups, sampleValueKeys);
+        final String[] labels = getValueDistributionLabels(sampleValueGroups, sampleValueKeys);
 
-        var csvHeader = Stream.concat(Arrays.stream(fields), Arrays.stream(labels)).map(String::toUpperCase).collect(Collectors.joining(","));
+        final String csvHeader = Stream.concat(Arrays.stream(fields), Arrays.stream(labels))
+                                    .map(field -> csvQuotes(field).toUpperCase())
+                                    .collect(Collectors.joining(","));
+        
         var csvContent = toStream(plotSummaries)
                 .map(plotSummary -> {
                     var fieldStream = Arrays.stream(fields);
@@ -141,12 +148,12 @@ public class ProjectUtils {
                             fieldStream.map(field -> plotSummary.has(field) ?
                                     plotSummary.get(field).isJsonNull()
                                         ? ""
-                                        : plotSummary.get(field).getAsString()
+                                        : csvQuotes(plotSummary.get(field).getAsString())
                                     : ""),
                             labelStream.map(label -> distribution.has(label)
                                     ? distribution.getAsJsonObject().get(label).isJsonPrimitive() 
-                                        ? distribution.get(label).getAsString()
-                                        : distribution.getAsJsonObject().get(label).getAsJsonObject().get("answer").getAsString()
+                                        ? csvQuotes(distribution.get(label).getAsString())
+                                        : csvQuotes(distribution.getAsJsonObject().get(label).getAsJsonObject().get("answer").getAsString())
                                     : "0.0")
                             ).collect(Collectors.joining(","));
                     }).collect(Collectors.joining("\n"));
@@ -159,23 +166,24 @@ public class ProjectUtils {
     }
 
     public static HttpServletResponse outputRawCsv(Response res, JsonArray sampleValueGroups, JsonArray sampleSummaries, String projectName, String[] externalHeaders) {
-        var sampleValueKeys = getSampleKeys(sampleValueGroups);
-        var sampleValueGroupNames = toStream(sampleValueGroups)
+        final var sampleValueKeys = getSampleKeys(sampleValueGroups);
+        final var sampleValueGroupNames = toStream(sampleValueGroups)
         .collect(Collectors.toMap(sampleValueGroup -> sampleValueGroup.get("id").getAsInt(),
                 sampleValueGroup -> sampleValueGroup.get(sampleValueKeys[0]).getAsString(),
                 (a, b) -> b));
 
         // fileds are straight forward json values
-        var fields = Stream.concat(
+        final String[] fields = Stream.concat(
                         Arrays.stream(new String[]{"plot_id", "sample_id", "lon", "lat", "flagged", "analyses", "user_id"}), 
                         Arrays.stream(externalHeaders))
                         .toArray(String[]::new);
         // labels require interpretation of the next json object
-        var labels = sampleValueGroupNames.entrySet().stream()
+        final String[] labels = sampleValueGroupNames.entrySet().stream()
                         .sorted(Map.Entry.comparingByKey()).map(Map.Entry::getValue)
                         .toArray(String[]::new);
 
-        var csvHeader = Stream.concat(Arrays.stream(fields), Arrays.stream(labels)).map(String::toUpperCase)
+        final var csvHeader = Stream.concat(Arrays.stream(fields), Arrays.stream(labels))
+                        .map(field -> csvQuotes(field).toUpperCase())
                         .collect(Collectors.joining(","));
 
         var csvContent = toStream(sampleSummaries)
@@ -191,15 +199,15 @@ public class ProjectUtils {
                                 // original format is single integer index
                                 } else if (value.isJsonPrimitive()) {
                                     var sampleValueTranslations = getSampleValueTranslations(sampleValueGroups);
-                                    return sampleValueTranslations
+                                    return csvQuotes(sampleValueTranslations
                                             .getOrDefault(value.getAsInt(), "LULC:NoValue")
-                                            .split(":")[1];
+                                            .split(":")[1]);
                                 } else if (value.getAsJsonObject().has(label)) {
                                     if (value.getAsJsonObject().get(label).isJsonPrimitive()){
-                                        return value.getAsJsonObject().get(label).getAsString();
+                                        return csvQuotes(value.getAsJsonObject().get(label).getAsString());
                                     }
                                     // newest format nests the answer in another json object
-                                    return value.getAsJsonObject().get(label).getAsJsonObject().get("answer").getAsString();
+                                    return csvQuotes(value.getAsJsonObject().get(label).getAsJsonObject().get("answer").getAsString());
                                 } else {
                                     return "";
                                 }

--- a/src/main/java/org/openforis/ceo/utils/ProjectUtils.java
+++ b/src/main/java/org/openforis/ceo/utils/ProjectUtils.java
@@ -372,11 +372,7 @@ public class ProjectUtils {
     }
 
     public static JsonElement getOrZero(JsonObject obj, String field) {
-        try {
-            return obj.get(field).isJsonNull() || obj.get(field) == null ? new JsonPrimitive(0) : obj.get(field);
-        } catch(Exception e) {
-            return new JsonPrimitive(0);
-        }
+        return !obj.has(field) || obj.get(field).isJsonNull() || obj.get(field) == null ? new JsonPrimitive(0) : obj.get(field);
     }
 
     public static JsonElement getOrEmptyString(JsonObject obj, String field) {

--- a/src/main/java/org/openforis/ceo/utils/ProjectUtils.java
+++ b/src/main/java/org/openforis/ceo/utils/ProjectUtils.java
@@ -40,6 +40,7 @@ public class ProjectUtils {
         Collectors.groupingBy(Function.identity(), Collectors.counting());
 
     private static String[] getSampleKeys(JsonArray sampleValueGroups) {
+        if (sampleValueGroups.size() == 0) {throw new RuntimeException("Missing sample value groups");}
         var firstGroup = sampleValueGroups.get(0).getAsJsonObject();
         if (firstGroup.has("name")) {
             return new String[]{"name", "values", "name"};
@@ -124,7 +125,7 @@ public class ProjectUtils {
         var sampleValueKeys = getSampleKeys(sampleValueGroups);
         // fileds are straight forward json values
         var fields = Stream.concat(
-                        Arrays.stream(new String[]{"plot_id", "center_lon", "center_lat", "size_m", "shape", "flagged", "analyses", "sample_points", "user_id", "analysis_duration", "collection_time"}), 
+                        Arrays.stream(new String[]{"plot_id", "center_lon", "center_lat", "size_m", "shape", "flagged", "analyses", "sample_points", "user_id"}), 
                         Arrays.stream(externalHeaders))
                         .toArray(String[]::new);
         // labels require interpretation of the next json object
@@ -166,7 +167,7 @@ public class ProjectUtils {
 
         // fileds are straight forward json values
         var fields = Stream.concat(
-                        Arrays.stream(new String[]{"plot_id", "sample_id", "lon", "lat", "flagged", "analyses", "user_id", "analysis_duration", "collection_time"}), 
+                        Arrays.stream(new String[]{"plot_id", "sample_id", "lon", "lat", "flagged", "analyses", "user_id"}), 
                         Arrays.stream(externalHeaders))
                         .toArray(String[]::new);
         // labels require interpretation of the next json object

--- a/src/main/resources/scripts/data_migration.py
+++ b/src/main/resources/scripts/data_migration.py
@@ -3,6 +3,7 @@ import json
 import psycopg2
 import os
 import csv
+import re
 import subprocess
 from config import config
 params = config()
@@ -11,7 +12,6 @@ jsonpath = r'../../../../target/classes/json'
 csvpath = r'../../../../target/classes/csv'
 shppath = r'../../../../target/classes/shp'
 
-#jsonpath = r'../json'
 def insert_users():
     conn = None
     user_id=-1
@@ -38,7 +38,6 @@ def insert_users():
 
 def insert_institutions():
     conn = None
-    institution_id=-1
     try:
         conn = psycopg2.connect(**params)
         cur = conn.cursor()
@@ -72,8 +71,6 @@ def insert_institutions():
                     user_id=pending
                     role_id=3
                     cur1.execute("select * from add_institution_user(%s,%s,%s)", (institution['id'],user_id,role_id))
-            conn.commit()
-            institution_id = cur.fetchone()[0]
             conn.commit()
         cur.close()
     except (Exception, psycopg2.DatabaseError) as error:
@@ -137,7 +134,7 @@ def insert_projects():
         print(len(projectArr))
         for project in projectArr:
             try:
-                if project['id']>0:
+                if project['id'] > 0:
                     print("inserting project with project id"+str(project['id']))
                     if project['numPlots'] is None: project['numPlots']=0
                     if project['plotSpacing'] is None: project['plotSpacing']=0
@@ -162,11 +159,17 @@ def insert_projects():
                         if dash_id.isnumeric() and int(dash['projectID']) == int(project_id):
                             insert_project_widgets(project_id,dash_id,conn)
                             break
-
+                    ## insert data the entire json file at a time, much faster but requires permissions
                     insert_plots_samples_by_file(project_id, conn)
+                    
+                    ## insert data by row with loops
+                    # insert_plots(project_id, conn)
+                    
+                    ## merge in external files
                     merge_files(project, project_id, conn)
                     conn.commit()
             except(Exception, psycopg2.DatabaseError) as error:
+                conn.commit()
                 print("project for loop: "+ str(error))
         cur.close()
     except (Exception, psycopg2.DatabaseError) as error:
@@ -211,28 +214,32 @@ def insert_plots(project_id,conn):
                     plot['flagged']=0
                 else:
                     plot['flagged']=1
+                
+                if not ('collectionStart' in plot): plot['collectionStart']=None
+                if not ('collectionTime' in plot) or re.search('^\d+$', plot['collectionTime']) is None : plot['collectionTime']=None
 
                 cur_plot.execute("select * from create_project_plot(%s,ST_SetSRID(ST_GeomFromGeoJSON(%s), 4326))",
                 (project_id,plot['center']))
 
                 plot_id = cur_plot.fetchone()[0]
                 if plot['user'] is not None:
-                    user_plot_id=insert_user_plots(plot_id,plot['user'],boolean_Flagged,conn)
+                    user_plot_id=insert_user_plots(plot_id,plot,boolean_Flagged,conn)
                 insert_samples(plot_id,plot['samples'],user_plot_id,conn)
                 conn.commit()
             except (Exception, psycopg2.DatabaseError) as error:
                 print("plots error: "+ str(error))
     cur_plot.close()
 
-def insert_user_plots(plot_id,user,flagged,conn):
+def insert_user_plots(plot_id,plot,flagged,conn):
     user_plot_id=-1
     cur_up = conn.cursor()
     cur_user = conn.cursor()
-    cur_user.execute("select id from users where email=%s;",(user,))
+    cur_user.execute("select id from users where email=%s;",[plot['user']])
     rows = cur_user.fetchall()
     if len(rows)>0:
         try:
-            cur_up.execute("select * from add_user_plots_migration(%s,%s::text,%s)",(plot_id,user,flagged))
+            cur_up.execute("select * from add_user_plots_migration(%s,%s::text,to_timestamp(%s/1000.0)::timestamp,to_timestamp(%s/1000.0)::timestamp,%s)",
+                (plot_id,plot['user'],plot['collectionStart'],plot['collectionTime'],flagged))
             user_plot_id = cur_up.fetchone()[0]
             conn.commit()
         except (Exception, psycopg2.DatabaseError) as error:
@@ -250,16 +257,23 @@ def insert_samples(plot_id,samples,user_plot_id,conn):
 
             sample_id = cur_sample.fetchone()[0]
             if user_plot_id != -1 and 'value' in sample:
-                insert_sample_values(user_plot_id,sample_id,sample['value'],conn)
+                if not ('userImage' in sample):
+                    sample['image_id'] = None
+                    sample['image_attributes'] = None
+                else:
+                    sample['image_id'] = sample['userImage']['id']
+                    sample['image_attributes'] = sample['userImage']['attributes']
+                insert_sample_values(user_plot_id,sample_id,sample['value'],sample['image_id'],sample['image_attributes'],conn)
             conn.commit()
         except (Exception, psycopg2.DatabaseError) as error:
                 print("samples error: "+ str(error))
     cur_sample.close()
 
-def insert_sample_values(user_plot_id,sample_id,sample_value,conn):
+def insert_sample_values(user_plot_id,sample_id,sample_value,image_id,image_value,conn):
     cur_sv = conn.cursor()
     try:
-        cur_sv.execute("select * from add_sample_values_migration(%s,%s,%s::jsonb)",(user_plot_id,sample_id,json.dumps(sample_value)))
+        cur_sv.execute("select * from add_sample_values_migration(%s,%s,%s::jsonb,%s,%s::jsonb)",
+            (user_plot_id,sample_id,json.dumps(sample_value),image_id,json.dumps(image_value)))
     except (Exception, psycopg2.DatabaseError) as error:
                 print("sample values error: "+ str(error))
     conn.commit()
@@ -268,18 +282,22 @@ def insert_sample_values(user_plot_id,sample_id,sample_value,conn):
 # builds list of old name to become lon, lat
 def csvColRenameList(csvCols):
     renameCol = []
-    renameCol.append([csvCols[0], 'lon'])
-    renameCol.append([csvCols[1], 'lat'])
+    renameCol.append([csvCols[0].replace(" ", ""), 'lon'])
+    renameCol.append([csvCols[1].replace(" ", ""), 'lat'])
     return renameCol
 
 # files should have lat lon in the first 2 columns, returns string
 def csvHeaderToCol(csvCols):
     colsStr = ''
     for i, h in enumerate(csvCols):
-        if i <=1:
-            colsStr += h + ' float,'
-        else:
-            colsStr += h + ' text,'
+        h = h.replace(" ", "")
+        if len(h) > 0:
+            if i <=1:
+                colsStr += h + ' float,'
+            elif (i == 2 and h.upper() == "PLOTID") or (i == 3 and h.upper() == "SAMPLEID"):
+                colsStr += h + ' integer,'
+            else:
+                colsStr += h + ' text,'
     return colsStr[:-1]
 
 def checkRequiredCols(actualCols, reqCols):
@@ -474,19 +492,22 @@ def merge_files(project, project_id, conn):
         cur.execute("SELECT * FROM update_project_tables(%s,%s,%s)" , [project_id, plots_table, samples_table])
         conn.commit()
 
-        if need_to_update >= 2:
-            # clean up project tables
-            cur.execute("SELECT * FROM cleanup_project_tables(%s,%s)" , [project_id, project['plotSize']])
-            conn.commit()
+        try:
+            if need_to_update >= 2:
+                # clean up project tables
+                cur.execute("SELECT * FROM cleanup_project_tables(%s,%s)" , [project_id, project['plotSize']])
+                conn.commit()
 
-        if need_to_update == 3:
-            # merge files into plots and samples
-            cur.execute("SELECT * FROM merge_plot_and_file(%s)" , [project_id])
-            conn.commit()
-        else:
-            # merge files into plots
-            cur.execute("SELECT * FROM merge_plots_only(%s)" , [project_id])
-            conn.commit()
+            if need_to_update == 3:
+                # merge files into plots and samples
+                cur.execute("SELECT * FROM merge_plot_and_file(%s)" , [project_id])
+                conn.commit()
+            else:
+                # merge files into plots
+                cur.execute("SELECT * FROM merge_plots_only(%s)" , [project_id])
+                conn.commit()
+        finally:
+            pass
 
     except (Exception, psycopg2.DatabaseError) as error:
         print("merge file error: "+ str(error))


### PR DESCRIPTION
This PR contains changes to 
-  Add the new fields (collection start, confidence, and imagery data) to the JSON database
-  Merge the new fields into the aggregate CSV files on output.
-  Update the migration script to include new fields.
-  Update the output of aggregation to only show the new fields if they exist (PG and JSON)

-  change plotId to integer for both DB
-  Update PG to work with the new pre/next logic

-  Add additional Data checks when uploading and migrating data (such as checking if plotId and sampleId are integer)
-  Allow some variance on the names for the PG csv lon and lat columns. 
-  Add quotes around fields with commas for csv output