### PR TITLE
Add ability to use template plots and samples.  

### DIFF
--- a/src/main/java/org/openforis/ceo/Server.java
+++ b/src/main/java/org/openforis/ceo/Server.java
@@ -123,6 +123,7 @@ public class Server implements SparkApplication {
         // Routing Table: Users API
         get("/get-all-users",                         users::getAllUsers);
         get("/get-user-stats/:userid",                users::getUserStats);
+        get("/update-project-user-stats",             users::updateProjectUserStats);
         post("/update-user-institution-role",         users::updateInstitutionRole);
         post("/request-institution-membership",       users::requestInstitutionMembership);
 

--- a/src/main/java/org/openforis/ceo/Server.java
+++ b/src/main/java/org/openforis/ceo/Server.java
@@ -84,7 +84,7 @@ public class Server implements SparkApplication {
         get("/geo-dash",                              Views.geodash(freemarker));
         get("/widget-layout-editor",                  Views.editWidgetLayout(freemarker));
         get("/test-layout-editor",                    Views.testWidgetLayout(freemarker));
-        get("/create-project/:id",                    Views.createProject(freemarker));
+        get("/create-project",                        Views.createProject(freemarker));
         get("/review-project/:id",                    Views.reviewProject(freemarker));
         get("/project-dashboard/:id",                 Views.projectDashboard(freemarker));
         get("/login",                                 Views.login(freemarker));

--- a/src/main/java/org/openforis/ceo/Views.java
+++ b/src/main/java/org/openforis/ceo/Views.java
@@ -142,11 +142,9 @@ public class Views {
     }
 
     public static Route createProject(FreeMarkerEngine freemarker) {
-        Function<Request, String> getProjectId = (req) -> req.params(":id");
         Function<Request, String> getInstitutionId = (req) -> req.queryParams("institution");
         return makeAuthenticatedRoute("Create-Project", freemarker,
-                                      Map.of("project_id", getProjectId,
-                                             "institution_id", getInstitutionId));
+                                      Map.of("institution_id", getInstitutionId));
     }
 
     public static Route reviewProject(FreeMarkerEngine freemarker) {

--- a/src/main/java/org/openforis/ceo/Views.java
+++ b/src/main/java/org/openforis/ceo/Views.java
@@ -147,6 +147,8 @@ public class Views {
                                       Map.of("institution_id", getInstitutionId));
     }
 
+    // FIXME I do not beleive institution is needed unless we want to do some sort of validations with the imagery
+    // We could/should be loading the imagery list based on the project institution.
     public static Route reviewProject(FreeMarkerEngine freemarker) {
         Function<Request, String> getProjectId = (req) -> req.params(":id");
         Function<Request, String> getInstitutionId = (req) -> req.queryParams("institution");

--- a/src/main/java/org/openforis/ceo/db_api/Users.java
+++ b/src/main/java/org/openforis/ceo/db_api/Users.java
@@ -14,6 +14,7 @@ public interface Users {
     Request resetPassword(Request req, Response res);
     String getAllUsers(Request req, Response res);
     String getUserStats(Request req, Response res);
+    String updateProjectUserStats(Request req, Response res);
     Map<Integer, String> getInstitutionRoles(int userId);
     String updateInstitutionRole(Request req, Response res);
     String requestInstitutionMembership(Request req, Response res);

--- a/src/main/java/org/openforis/ceo/local/JsonImagery.java
+++ b/src/main/java/org/openforis/ceo/local/JsonImagery.java
@@ -28,6 +28,15 @@ public class JsonImagery implements Imagery {
         }
     }
 
+    public static String getImageryTitle(String id) {
+        var imageryList = readJsonFile("imagery-list.json").getAsJsonArray();
+
+        var matchingImagery = filterJsonArray(imageryList,
+                                imagery -> imagery.get("id").getAsString().equals(id));
+        return matchingImagery.get(0).getAsJsonObject().get("title").getAsString();
+        
+    }
+
     public synchronized String addInstitutionImagery(Request req, Response res) {
         try {
             var jsonInputs            = parseJson(req.body()).getAsJsonObject();

--- a/src/main/java/org/openforis/ceo/local/JsonProjects.java
+++ b/src/main/java/org/openforis/ceo/local/JsonProjects.java
@@ -577,8 +577,8 @@ public class JsonProjects implements Projects {
                         plotSummary.addProperty("analyses", getOrZero(project, "analyses").getAsInt());
                         plotSummary.addProperty("sample_points", samples.size());
                         plotSummary.add("user_id", plot.get("user"));
-                        plotSummary.addProperty("collection_time", simple.format(new Date(collectionTime)));
-                        plotSummary.addProperty("analysis_duration", finalAnalysisDuration);
+                        plotSummary.addProperty("collection_time", collectionTime > 0 ? simple.format(new Date(collectionTime)) : "");
+                        plotSummary.addProperty("analysis_duration", finalAnalysisDuration > 0 : finalAnalysisDuration : 0);
                         plotSummary.addProperty("confidence", confidence);
                         plotSummary.add("distribution",
                                 getValueDistribution(samples, getSampleValueTranslations(sampleValueGroups)));
@@ -668,7 +668,7 @@ public class JsonProjects implements Projects {
                             sampleSummary.add("user_id", userId);
                             sampleSummary.add("value", sample.get("value"));
                             
-                            sampleSummary.addProperty("collection_time", simple.format(new Date(collectionTime)));
+                            sampleSummary.addProperty("collection_time", collectionTime > 0 ? simple.format(new Date(collectionTime)) : "");
                             sampleSummary.addProperty("analysis_duration", finalAnalysisDuration);
                             sampleSummary.addProperty("confidence", confidence);
                             

--- a/src/main/java/org/openforis/ceo/local/JsonProjects.java
+++ b/src/main/java/org/openforis/ceo/local/JsonProjects.java
@@ -527,7 +527,15 @@ public class JsonProjects implements Projects {
             return new ArrayList<String>();
         }
     }
-
+    
+    // Some older data contains a useless string fromat for collection time. 
+    private Long collectTimeIgnoreString (JsonObject plot){
+        try {
+            return getOrZero(plot, "collectionTime").getAsLong();
+        } catch (Exception e) {
+            return 0L;
+        }
+    }
 
     public HttpServletResponse dumpProjectAggregateData(Request req, Response res) {
         final var projectId = req.params(":id");
@@ -550,7 +558,7 @@ public class JsonProjects implements Projects {
                         final var samples = plot.get("samples").getAsJsonArray();
                         final var center = parseJson(plot.get("center").getAsString()).getAsJsonObject();
                         final var coords = center.get("coordinates").getAsJsonArray();
-                        final var collectionTime = getOrZero(plot, "collectionTime").getAsLong();
+                        final var collectionTime = collectTimeIgnoreString(plot);
                         final var collectionStart = getOrZero(plot, "collectionStart").getAsLong();
                         final var confidence = getOrZero(plot, "confidence").getAsInt();
                         var analysisDuration = 0.0;
@@ -578,7 +586,7 @@ public class JsonProjects implements Projects {
                         plotSummary.addProperty("sample_points", samples.size());
                         plotSummary.add("user_id", plot.get("user"));
                         plotSummary.addProperty("collection_time", collectionTime > 0 ? simple.format(new Date(collectionTime)) : "");
-                        plotSummary.addProperty("analysis_duration", finalAnalysisDuration > 0 : finalAnalysisDuration : 0);
+                        plotSummary.addProperty("analysis_duration", finalAnalysisDuration > 0 ? finalAnalysisDuration : 0);
                         plotSummary.addProperty("confidence", confidence);
                         plotSummary.add("distribution",
                                 getValueDistribution(samples, getSampleValueTranslations(sampleValueGroups)));
@@ -636,7 +644,7 @@ public class JsonProjects implements Projects {
                         final var flagged = plot.get("flagged").getAsBoolean();
                         final var analyses = plot.get("analyses").getAsInt();
                         final var userId = plot.get("user");
-                        final var collectionTime = getOrZero(plot, "collectionTime").getAsLong();
+                        final var collectionTime = collectTimeIgnoreString(plot);
                         final var collectionStart = getOrZero(plot, "collectionStart").getAsLong();
                         final var confidence = getOrZero(plot, "confidence").getAsInt();
                         var analysisDuration = 0.0;

--- a/src/main/java/org/openforis/ceo/local/JsonProjects.java
+++ b/src/main/java/org/openforis/ceo/local/JsonProjects.java
@@ -338,7 +338,8 @@ public class JsonProjects implements Projects {
 
     /*  The following functions load data to merge with JSON plot/sample information.
         Even though the new data uses a integer hasmap to ensure correct order for other functions
-        we can leave the merge as a String HasMap because we are not doing any sorting on merge.
+        we can leave the merge as a String HasMap for backwords compatability
+        because we are not doing any sorting on merge.
     */
 
     // Old csv files do not include plotId or sampleId
@@ -346,10 +347,10 @@ public class JsonProjects implements Projects {
         try (var lines = Files.lines(Paths.get(expandResourcePath("/csv/" + filename)))) {
             var plotPoints = new HashMap<String, HashMap<String, String>>();
             var linesArr = lines.toArray(String[]::new);
-            var fieldNames =  Arrays.stream(linesArr[0].split(",")).toArray(String[]::new);
+            final var fieldNames =  Arrays.stream(linesArr[0].split(",")).toArray(String[]::new);
             for (int r = 1; r != linesArr.length ; r++) {
                 var plotField = new HashMap<String, String>();
-                var fieldData = Arrays.stream(linesArr[r].split(",")).toArray(String[]::new);
+                final var fieldData = Arrays.stream(linesArr[r].split(",")).toArray(String[]::new);
                 for (int i = 0; i != fieldNames.length ; i++) {
                     plotField.put(fieldNames[i], fieldData[i]);
                 }
@@ -366,11 +367,11 @@ public class JsonProjects implements Projects {
     private static HashMap<String, HashMap<String, String>> loadCsvPlotAllColumnsNew(String filename) {
         try (var lines = Files.lines(Paths.get(expandResourcePath("/csv/" + filename)))) {
             var plotPoints = new HashMap<String, HashMap<String, String>>();
-            var linesArr = lines.toArray(String[]::new);
-            var fieldNames =  Arrays.stream(linesArr[0].split(",")).toArray(String[]::new);
+            final var linesArr = lines.toArray(String[]::new);
+            final var fieldNames =  Arrays.stream(linesArr[0].split(",")).toArray(String[]::new);
             for (int r = 1; r != linesArr.length ; r++) {
                 var plotField = new HashMap<String, String>();
-                var fieldData = Arrays.stream(linesArr[r].split(",")).toArray(String[]::new);
+                final var fieldData = Arrays.stream(linesArr[r].split(",")).toArray(String[]::new);
                 for (int i = 0; i != fieldNames.length ; i++) {
                     plotField.put(fieldNames[i], fieldData[i]);
                 }
@@ -387,11 +388,11 @@ public class JsonProjects implements Projects {
     private static HashMap<String, HashMap<String, String>> loadCsvPlotAllSamplesNew(String filename) {
         try (var lines = Files.lines(Paths.get(expandResourcePath("/csv/" + filename)))) {
             var plotPoints = new HashMap<String, HashMap<String, String>>();
-            var linesArr = lines.toArray(String[]::new);
-            var fieldNames =  Arrays.stream(linesArr[0].split(",")).toArray(String[]::new);
+            final var linesArr = lines.toArray(String[]::new);
+            final var fieldNames =  Arrays.stream(linesArr[0].split(",")).toArray(String[]::new);
             for (int r = 1; r != linesArr.length ; r++) {
                 var plotField = new HashMap<String, String>();
-                var fieldData = Arrays.stream(linesArr[r].split(",")).toArray(String[]::new);
+                final var fieldData = Arrays.stream(linesArr[r].split(",")).toArray(String[]::new);
                 for (int i = 0; i != fieldNames.length ; i++) {
                     plotField.put(fieldNames[i], fieldData[i]);
                 }
@@ -407,12 +408,12 @@ public class JsonProjects implements Projects {
     private static List<String> getGeoJsonHeaders(int projectId, String plotOrSample) {
         var jsonKeys = new ArrayList<String>();
         try {
-            var geoJson = readJsonFile("../shp/project-" + projectId + "-" + plotOrSample
+            final var geoJson = readJsonFile("../shp/project-" + projectId + "-" + plotOrSample
                                        + "/project-" + projectId + "-" + plotOrSample + ".json").getAsJsonObject();
             if (geoJson.get("type").getAsString().equals("FeatureCollection")) {
-                var properties = toStream(geoJson.get("features").getAsJsonArray())
+                final var properties = toStream(geoJson.get("features").getAsJsonArray())
                     .filter(feature -> {
-                            var geometry = feature.get("geometry").getAsJsonObject();
+                            final var geometry = feature.get("geometry").getAsJsonObject();
                             return geometry.get("type").getAsString().equals("Polygon");
                         })
                     .findFirst().get();
@@ -427,17 +428,17 @@ public class JsonProjects implements Projects {
     private static HashMap<String, HashMap<String, String>>  getGeoJsonPlotData(int projectId) {
         var plotGeoms = new HashMap<String, HashMap<String, String>>();
         try {
-            var geoJson = readJsonFile("../shp/project-" + projectId + "-plots"
+            final var geoJson = readJsonFile("../shp/project-" + projectId + "-plots"
                                        + "/project-" + projectId + "-plots.json").getAsJsonObject();
             if (geoJson.get("type").getAsString().equals("FeatureCollection")) {
                 toStream(geoJson.get("features").getAsJsonArray())
                     .filter(feature -> {
-                            var geometry = feature.get("geometry").getAsJsonObject();
+                            final var geometry = feature.get("geometry").getAsJsonObject();
                             return geometry.get("type").getAsString().equals("Polygon");
                         })
                     .forEach(feature -> {
-                            var properties = feature.get("properties").getAsJsonObject();
-                            var plotId = properties.get("PLOTID").getAsString();
+                            final var properties = feature.get("properties").getAsJsonObject();
+                            final var plotId = properties.get("PLOTID").getAsString();
                             var propertyMap = new HashMap<String, String>();
                             properties.keySet().forEach(key -> {
                                 propertyMap.put(key, getOrEmptyString(properties, key).getAsString());
@@ -451,21 +452,20 @@ public class JsonProjects implements Projects {
         return plotGeoms;
     }
 
-
     private static HashMap<String, HashMap<String, String>>  getGeoJsonSampleData(int projectId) {
         var plotGeoms = new HashMap<String, HashMap<String, String>>();
         try {
-            var geoJson = readJsonFile("../shp/project-" + projectId + "-samples"
+            final var geoJson = readJsonFile("../shp/project-" + projectId + "-samples"
                                        + "/project-" + projectId + "-samples.json").getAsJsonObject();
             if (geoJson.get("type").getAsString().equals("FeatureCollection")) {
                 toStream(geoJson.get("features").getAsJsonArray())
                     .filter(feature -> {
-                            var geometry = feature.get("geometry").getAsJsonObject();
+                            final var geometry = feature.get("geometry").getAsJsonObject();
                             return geometry.get("type").getAsString().equals("Polygon");
                         })
                     .forEach(feature -> {
-                            var properties = feature.get("properties").getAsJsonObject();
-                            var sampleId = properties.get("SAMPLEID").getAsString();
+                            final var properties = feature.get("properties").getAsJsonObject();
+                            final var sampleId = properties.get("SAMPLEID").getAsString();
                             var propertyMap = new HashMap<String, String>();
                             properties.keySet().forEach(key -> {
                                 propertyMap.put(key, getOrEmptyString(properties, key).getAsString());
@@ -479,48 +479,80 @@ public class JsonProjects implements Projects {
         return plotGeoms;
     }
 
+    private static HashMap<String, HashMap<String, String>>  getDataHashMap(JsonObject project, String plotOrSample) {
+        if (plotOrSample.equals("plots")) {
+            if (project.has("csv") && project.get("plotDistribution").getAsString().equals("csv")){
+                return loadCsvPlotAllColumnsOld(project.get("csv").getAsString());
+            } else if (project.has("plots-csv") && project.get("plotDistribution").getAsString().equals("csv")) {
+                return loadCsvPlotAllColumnsNew(project.get("plots-csv").getAsString());
+            } else if (project.has("plots-shp") && project.get("plotDistribution").getAsString().equals("shp")) {
+                return getGeoJsonPlotData(project.get("id").getAsInt());
+            } else {
+                return new HashMap<String, HashMap<String, String>>();
+            }
+        } else if (plotOrSample.equals("samples")) {
+            if (project.has("samples-csv") && project.get("sampleDistribution").getAsString().equals("csv")) {
+                return loadCsvPlotAllSamplesNew(project.get("samples-csv").getAsString());
+            } else if (project.has("samples-csv") && project.get("sampleDistribution").getAsString().equals("shp")) {
+                return getGeoJsonSampleData(project.get("id").getAsInt());
+            } else {
+                return new HashMap<String, HashMap<String, String>>();
+            }
+        } else {
+            return new HashMap<String, HashMap<String, String>>();
+        }
+
+    }
+
+    private static List<String> getHeadersList(JsonObject project, String plotOrSample) {
+        if (plotOrSample.equals("plots")) {
+            if (project.has("csv") && project.get("plotDistribution").getAsString().equals("csv")){
+                return getCsvHeaders(project.get("csv").getAsString());
+            } else if (project.has("plots-csv") && project.get("plotDistribution").getAsString().equals("csv")) {
+                return getCsvHeaders(project.get("plots-csv").getAsString());
+            } else if (project.has("plots-shp") && project.get("plotDistribution").getAsString().equals("shp")) {
+                return getGeoJsonHeaders(project.get("id").getAsInt(), "plots");
+            } else {
+                return new ArrayList<String>();
+            }
+        } else if (plotOrSample.equals("samples")) {
+            if (project.has("samples-csv") && project.get("sampleDistribution").getAsString().equals("csv")) {
+                return getCsvHeaders(project.get("samples-csv").getAsString());
+            } else if (project.has("samples-csv") && project.get("sampleDistribution").getAsString().equals("shp")) {
+                return getGeoJsonHeaders(project.get("id").getAsInt(), "samples");
+            } else {
+                return new ArrayList<String>();
+            }
+        } else {
+            return new ArrayList<String>();
+        }
+    }
+
+
     public HttpServletResponse dumpProjectAggregateData(Request req, Response res) {
-        var projectId = req.params(":id");
-        var projects = readJsonFile("project-list.json").getAsJsonArray();
-        var matchingProject = findInJsonArray(projects, project -> project.get("id").getAsString().equals(projectId));
+        final var projectId = req.params(":id");
+        final var projects = readJsonFile("project-list.json").getAsJsonArray();
+        final var matchingProject = findInJsonArray(projects, project -> project.get("id").getAsString().equals(projectId));
         DateFormat simple = new SimpleDateFormat("dd MMM yyyy HH:mm:ss");
 
         if (matchingProject.isPresent()) {
-            var project = matchingProject.get();
-            var sampleValueGroups = project.get("sampleValues").getAsJsonArray();
-            var projectName = project.get("name").getAsString().replace(" ", "-").replace(",", "").toLowerCase();
+            final var project = matchingProject.get();
+            final var sampleValueGroups = project.get("sampleValues").getAsJsonArray();
+            final var projectName = project.get("name").getAsString().replace(" ", "-").replace(",", "").toLowerCase();
             var optionalHeaders = new ArrayList<String>();
 
-            List<String> plotHeaders =  new ArrayList<String>();
-            var plotData = new  HashMap<String, HashMap<String, String>>();
-            if (project.has("csv") && project.get("plotDistribution").getAsString().equals("csv")){
-                plotData = loadCsvPlotAllColumnsOld(project.get("csv").getAsString());
-                plotHeaders = getCsvHeaders(project.get("csv").getAsString());
-            } else if (project.has("plots-csv") && project.get("plotDistribution").getAsString().equals("csv")) {
-                plotData = loadCsvPlotAllColumnsNew(project.get("plots-csv").getAsString());
-                plotHeaders = getCsvHeaders(project.get("plots-csv").getAsString());
-            } else if (project.has("plots-shp") && project.get("plotDistribution").getAsString().equals("shp")) {
-                plotData = getGeoJsonPlotData(project.get("id").getAsInt());
-                plotHeaders = getGeoJsonHeaders(project.get("id").getAsInt(), "plots");
-            }
-            final var finalPlotHeaders = plotHeaders;
-            final var finalPlotData = plotData;
+            final var plotHeaders = getHeadersList(project, "plots");
+            final var plotData = getDataHashMap(project, "plots");
 
-            var plots = readJsonFile("plot-data-" + projectId + ".json").getAsJsonArray();
+            final var plots = readJsonFile("plot-data-" + projectId + ".json").getAsJsonArray();
             var plotSummaries = mapJsonArray(plots,
                     plot -> {
-                        var samples = plot.get("samples").getAsJsonArray();
-                        var center = parseJson(plot.get("center").getAsString()).getAsJsonObject();
-                        var coords = center.get("coordinates").getAsJsonArray();
-
-                        // unfortunately there is an (small) intermediate step where collection time was stored as unusalble string
-                        var collectionTime = 0L;
-                        try {collectionTime = getOrZero(plot, "collectionTime").getAsLong();}
-                        catch (Exception e) {collectionTime = 0L;}
-                        final var finalCollectionTime = collectionTime;
-
-                        var collectionStart = getOrZero(plot, "collectionStart").getAsLong();
-                        var confidence = getOrZero(plot, "confidence").getAsInt();
+                        final var samples = plot.get("samples").getAsJsonArray();
+                        final var center = parseJson(plot.get("center").getAsString()).getAsJsonObject();
+                        final var coords = center.get("coordinates").getAsJsonArray();
+                        final var collectionTime = getOrZero(plot, "collectionTime").getAsLong();
+                        final var collectionStart = getOrZero(plot, "collectionStart").getAsLong();
+                        final var confidence = getOrZero(plot, "confidence").getAsInt();
                         var analysisDuration = 0.0;
                         // Wait until these fields is found to add the column header
                         if (collectionTime > 0L){
@@ -545,18 +577,18 @@ public class JsonProjects implements Projects {
                         plotSummary.addProperty("analyses", getOrZero(project, "analyses").getAsInt());
                         plotSummary.addProperty("sample_points", samples.size());
                         plotSummary.add("user_id", plot.get("user"));
-                        plotSummary.addProperty("collection_time", simple.format(new Date(finalCollectionTime)));
+                        plotSummary.addProperty("collection_time", simple.format(new Date(collectionTime)));
                         plotSummary.addProperty("analysis_duration", finalAnalysisDuration);
                         plotSummary.addProperty("confidence", confidence);
                         plotSummary.add("distribution",
                                 getValueDistribution(samples, getSampleValueTranslations(sampleValueGroups)));
 
-                        if (finalPlotHeaders.size() > 0 && finalPlotData.containsKey(plot.has("plotId") 
+                        if (plotHeaders.size() > 0 && plotData.containsKey(plot.has("plotId") 
                                 ? plot.get("plotId").getAsString() 
                                 : plot.get("id").getAsString()))
                         {
-                            finalPlotHeaders.forEach(head ->
-                                plotSummary.addProperty("pl_" + head, finalPlotData.get(plot.has("plotId") 
+                            plotHeaders.forEach(head ->
+                                plotSummary.addProperty("pl_" + head, plotData.get(plot.has("plotId") 
                                     ? plot.get("plotId").getAsString() 
                                     : plot.get("id").getAsString())
                                 .get(head) )
@@ -565,7 +597,7 @@ public class JsonProjects implements Projects {
                         return plotSummary;
                     });
 
-            var combinedHeaders = Stream.concat(
+            final var combinedHeaders = Stream.concat(
                     optionalHeaders.stream(),
                     plotHeaders.stream()
                         .map(head -> !head.toString().contains("pl_") ? "pl_" + head : head)
@@ -580,60 +612,33 @@ public class JsonProjects implements Projects {
     }
 
     public HttpServletResponse dumpProjectRawData(Request req, Response res) {
-        var projectId = req.params(":id");
-        var projects = readJsonFile("project-list.json").getAsJsonArray();
-        var matchingProject = findInJsonArray(projects, project -> project.get("id").getAsString().equals(projectId));
+        final var projectId = req.params(":id");
+        final var projects = readJsonFile("project-list.json").getAsJsonArray();
+        final var matchingProject = findInJsonArray(projects, project -> project.get("id").getAsString().equals(projectId));
         DateFormat simple = new SimpleDateFormat("dd MMM yyyy HH:mm:ss");
 
         if (matchingProject.isPresent()) {
-            var project = matchingProject.get();
-            var sampleValueGroups = project.get("sampleValues").getAsJsonArray();
+            final var project = matchingProject.get();
+            final var sampleValueGroups = project.get("sampleValues").getAsJsonArray();
             
             var optionalHeaders = new ArrayList<String>();
 
-            List<String> plotHeaders =  new ArrayList<String>();
-            var plotData = new  HashMap<String, HashMap<String, String>>();
-            if (project.has("csv") && project.get("plotDistribution").getAsString().equals("csv")){
-                plotData = loadCsvPlotAllColumnsOld(project.get("csv").getAsString());
-                plotHeaders = getCsvHeaders(project.get("csv").getAsString());
-            } else if (project.has("plots-csv") && project.get("plotDistribution").getAsString().equals("csv")) {
-                plotData = loadCsvPlotAllColumnsNew(project.get("plots-csv").getAsString());
-                plotHeaders = getCsvHeaders(project.get("plots-csv").getAsString());
-            } else if (project.has("plots-shp") && project.get("plotDistribution").getAsString().equals("shp")) {
-                plotData = getGeoJsonPlotData(project.get("id").getAsInt());
-                plotHeaders = getGeoJsonHeaders(project.get("id").getAsInt(), "plots");
-            }
-            final var finalPlotHeaders = plotHeaders;
-            final var finalPlotData = plotData;
-            
-            List<String> sampleHeaders = new ArrayList<String>();
-            var sampleData = new  HashMap<String, HashMap<String, String>>();
-            if (project.has("samples-csv") && project.get("sampleDistribution").getAsString().equals("csv")) {
-                sampleData = loadCsvPlotAllSamplesNew(project.get("samples-csv").getAsString());
-                sampleHeaders = getCsvHeaders(project.get("samples-csv").getAsString());
-            } else if (project.has("samples-csv") && project.get("sampleDistribution").getAsString().equals("shp")) {
-                sampleData = getGeoJsonSampleData(project.get("id").getAsInt());
-                sampleHeaders = getGeoJsonHeaders(project.get("id").getAsInt(), "samples");
-            }
-            final var finalSampleHeaders = sampleHeaders;
-            final var finalSampleData = sampleData;
+            final var plotHeaders = getHeadersList(project, "plots");
+            final var plotData = getDataHashMap(project, "plots");
+
+            final var sampleHeaders = getHeadersList(project, "samples");
+            final var sampleData = getDataHashMap(project, "samples");
 
             var plots = readJsonFile("plot-data-" + projectId + ".json").getAsJsonArray();
             var sampleSummaries = flatMapJsonArray(plots,
                     plot -> {
-                        var plotId = plot.get("id").getAsInt();
-                        var flagged = plot.get("flagged").getAsBoolean();
-                        var analyses = plot.get("analyses").getAsInt();
-                        var userId = plot.get("user");
-
-                        // unfortunately there is a (small) intermediate step where collection time was stored as unusalble string
-                        var collectionTime = 0L;
-                        try {collectionTime = getOrZero(plot, "collectionTime").getAsLong();}
-                        catch (Exception e) {collectionTime = 0L;}
-                        final var finalCollectionTime = collectionTime;
-
-                        var collectionStart = getOrZero(plot, "collectionStart").getAsLong();
-                        var confidence = getOrZero(plot, "confidence").getAsInt();
+                        final var plotId = plot.get("id").getAsInt();
+                        final var flagged = plot.get("flagged").getAsBoolean();
+                        final var analyses = plot.get("analyses").getAsInt();
+                        final var userId = plot.get("user");
+                        final var collectionTime = getOrZero(plot, "collectionTime").getAsLong();
+                        final var collectionStart = getOrZero(plot, "collectionStart").getAsLong();
+                        final var confidence = getOrZero(plot, "confidence").getAsInt();
                         var analysisDuration = 0.0;
                         // Wait until these fields is found to add the column header
                         if (collectionTime > 0L){
@@ -648,11 +653,11 @@ public class JsonProjects implements Projects {
                             if (!optionalHeaders.contains("confidence")) optionalHeaders.add("confidence");
                         }
 
-                        var samples = plot.get("samples").getAsJsonArray();
+                        final var samples = plot.get("samples").getAsJsonArray();
                         return toStream(samples).map(sample -> {
-                            var center = parseJson(sample.get("point").getAsString())
+                            final var center = parseJson(sample.get("point").getAsString())
                                     .getAsJsonObject();
-                            var coords = center.get("coordinates").getAsJsonArray();
+                            final var coords = center.get("coordinates").getAsJsonArray();
                             var sampleSummary = new JsonObject();
                             sampleSummary.addProperty("plot_id", plotId);
                             sampleSummary.addProperty("sample_id", sample.get("id").getAsInt());
@@ -663,19 +668,19 @@ public class JsonProjects implements Projects {
                             sampleSummary.add("user_id", userId);
                             sampleSummary.add("value", sample.get("value"));
                             
-                            sampleSummary.addProperty("collection_time", simple.format(new Date(finalCollectionTime)));
+                            sampleSummary.addProperty("collection_time", simple.format(new Date(collectionTime)));
                             sampleSummary.addProperty("analysis_duration", finalAnalysisDuration);
                             sampleSummary.addProperty("confidence", confidence);
                             
                             // Add imagery data to output if it exists
                             if (sample.has("userImage")) {
-                                var imageData = sample.get("userImage").getAsJsonObject();
+                                final var imageData = sample.get("userImage").getAsJsonObject();
 
                                 sampleSummary.addProperty("imagery_title", getImageryTitle(imageData.get("id").getAsString()));
                                 if (!optionalHeaders.contains("imagery_title")) optionalHeaders.add("imagery_title");
                                 
                                 if (imageData.has("attributes")) {
-                                    var attributes = imageData.get("attributes").getAsJsonObject();
+                                    final var attributes = imageData.get("attributes").getAsJsonObject();
                                     attributes.keySet().forEach(key -> {
                                         sampleSummary.addProperty(key, attributes.get(key).getAsString());
                                         if (!optionalHeaders.contains(key)) optionalHeaders.add(key);
@@ -683,13 +688,13 @@ public class JsonProjects implements Projects {
                                 }
                             }
 
-                            if (finalPlotHeaders.size() > 0 && finalPlotData.containsKey(
+                            if (plotHeaders.size() > 0 && plotData.containsKey(
                                     plot.has("plotId") 
                                     ? plot.get("plotId").getAsString() 
                                     : plot.get("id").getAsString())
                                 ){
-                                finalPlotHeaders.forEach(head ->
-                                    sampleSummary.addProperty("pl_" + head, finalPlotData.get(
+                                plotHeaders.forEach(head ->
+                                    sampleSummary.addProperty("pl_" + head, plotData.get(
                                         plot.has("plotId") 
                                         ? plot.get("plotId").getAsString() 
                                         : plot.get("id").getAsString())
@@ -697,17 +702,15 @@ public class JsonProjects implements Projects {
                                 );
                             }
 
-                            if (finalSampleHeaders.size() > 0 && finalSampleData.containsKey(
+                            if (sampleHeaders.size() > 0 && sampleData.containsKey(
                                     sample.has("sampleId") 
                                     ? sample.get("sampleId").getAsString() 
                                     : "")
                                 ){
-                                finalSampleHeaders.forEach(head ->
-                                    sampleSummary.addProperty("smpl_" + head, finalSampleData.get(
-                                        sample.has("sampleId") 
-                                        ? sample.get("sampleId").getAsString() 
-                                        : sample.get("id").getAsString())
-                                    .get(head) )
+                                sampleHeaders.forEach(head ->
+                                    sampleSummary.addProperty("smpl_" + head, sampleData.get(
+                                                        sample.get("sampleId").getAsString() )
+                                    .get(head))
                                 );
                             }
 
@@ -715,9 +718,9 @@ public class JsonProjects implements Projects {
                         });
                     });
 
-            var projectName = project.get("name").getAsString().replace(" ", "-").replace(",", "").toLowerCase();
+            final var projectName = project.get("name").getAsString().replace(" ", "-").replace(",", "").toLowerCase();
 
-            var combinedHeaders = 
+            final var combinedHeaders = 
                         Stream.concat(
                             optionalHeaders.stream(),
                             Stream.concat(
@@ -852,9 +855,9 @@ public class JsonProjects implements Projects {
             lines
                 .skip(1)
                 .forEach(line -> {
-                        var fields = Arrays.stream(line.split(",")).map(String::trim).toArray(String[]::new);
-                        var plotId = Integer.parseInt(fields[2]);
-                        var plotCenter = new Double[]{Double.parseDouble(fields[0]),
+                        final var fields = Arrays.stream(line.split(",")).map(String::trim).toArray(String[]::new);
+                        final var plotId = Integer.parseInt(fields[2]);
+                        final var plotCenter = new Double[]{Double.parseDouble(fields[0]),
                                                       Double.parseDouble(fields[1])};
                         plotPoints.put(plotId, plotCenter);
                     });
@@ -871,10 +874,10 @@ public class JsonProjects implements Projects {
             lines
                 .skip(1)
                 .forEach(line -> {
-                        var fields = Arrays.stream(line.split(",")).map(String::trim).toArray(String[]::new);
-                        var plotId = Integer.parseInt(fields[2]);
-                        var sampleId = Integer.parseInt(fields[3]);
-                        var sampleCenter = new Double[]{Double.parseDouble(fields[0]),
+                        final var fields = Arrays.stream(line.split(",")).map(String::trim).toArray(String[]::new);
+                        final var plotId = Integer.parseInt(fields[2]);
+                        final var sampleId = Integer.parseInt(fields[3]);
+                        final var sampleCenter = new Double[]{Double.parseDouble(fields[0]),
                                                         Double.parseDouble(fields[1])};
                         if (samplesByPlot.containsKey(plotId)) {
                             var samplePoints = samplesByPlot.get(plotId);
@@ -894,19 +897,19 @@ public class JsonProjects implements Projects {
     // The uploaded GeoJson must contain Polygon geometries with PLOTID properties
     private static HashMap<Integer, JsonObject> getGeoJsonPlotGeometries(int projectId) {
         try {
-            var geoJson = readJsonFile("../shp/project-" + projectId + "-plots"
+            final var geoJson = readJsonFile("../shp/project-" + projectId + "-plots"
                                        + "/project-" + projectId + "-plots.json").getAsJsonObject();
             if (geoJson.get("type").getAsString().equals("FeatureCollection")) {
-                var plotGeoms = new HashMap<Integer, JsonObject>();
+                final var plotGeoms = new HashMap<Integer, JsonObject>();
                 toStream(geoJson.get("features").getAsJsonArray())
                     .filter(feature -> {
-                            var geometry = feature.get("geometry").getAsJsonObject();
+                            final var geometry = feature.get("geometry").getAsJsonObject();
                             return geometry.get("type").getAsString().equals("Polygon");
                         })
                     .forEach(feature -> {
-                            var geometry = feature.get("geometry").getAsJsonObject();
-                            var properties = feature.get("properties").getAsJsonObject();
-                            var plotId = properties.get("PLOTID").getAsInt();
+                            final var geometry = feature.get("geometry").getAsJsonObject();
+                            final var properties = feature.get("properties").getAsJsonObject();
+                            final var plotId = properties.get("PLOTID").getAsInt();
                             plotGeoms.put(plotId, geometry);
                         });
                 return plotGeoms;
@@ -922,22 +925,22 @@ public class JsonProjects implements Projects {
     // The uploaded GeoJson must contain Polygon geometries with PLOTID and SAMPLEID properties
     private static HashMap<Integer, HashMap<Integer, JsonObject>> getGeoJsonSampleGeometries(int projectId) {
         try {
-            var geoJson = readJsonFile("../shp/project-" + projectId + "-samples"
+            final var geoJson = readJsonFile("../shp/project-" + projectId + "-samples"
                                        + "/project-" + projectId + "-samples.json").getAsJsonObject();
             if (geoJson.get("type").getAsString().equals("FeatureCollection")) {
                 var sampleGeomsByPlot = new HashMap<Integer, HashMap<Integer, JsonObject>>();
                 toStream(geoJson.get("features").getAsJsonArray())
                     .filter(feature -> {
-                            var geometry = feature.get("geometry").getAsJsonObject();
+                            final var geometry = feature.get("geometry").getAsJsonObject();
                             return geometry.get("type").getAsString().equals("Polygon");
                         })
                     .forEach(feature -> {
-                            var geometry = feature.get("geometry").getAsJsonObject();
-                            var properties = feature.get("properties").getAsJsonObject();
-                            var plotId = properties.get("PLOTID").getAsInt();
-                            var sampleId = properties.get("SAMPLEID").getAsInt();
+                            final var geometry = feature.get("geometry").getAsJsonObject();
+                            final var properties = feature.get("properties").getAsJsonObject();
+                            final var plotId = properties.get("PLOTID").getAsInt();
+                            final var sampleId = properties.get("SAMPLEID").getAsInt();
                             if (sampleGeomsByPlot.containsKey(plotId)) {
-                                var sampleGeoms = sampleGeomsByPlot.get(plotId);
+                                final var sampleGeoms = sampleGeomsByPlot.get(plotId);
                                 sampleGeoms.put(sampleId, geometry);
                             } else {
                                 var sampleGeoms = new HashMap<Integer, JsonObject>();

--- a/src/main/java/org/openforis/ceo/local/JsonUsers.java
+++ b/src/main/java/org/openforis/ceo/local/JsonUsers.java
@@ -318,11 +318,17 @@ public class JsonUsers implements Users {
                 
                 projectObject.addProperty("plotCount", project.get("userPlots").getAsJsonObject().get(userName).getAsInt());    
                 
-                projectObject.addProperty("analysisAverage", Math.round(project.get("userMilliSeconds").getAsJsonObject().get(userName).getAsInt() / 
-                1.0 / project.get("timedUserPlots").getAsJsonObject().get(userName).getAsInt() / 100.0) / 10.0);
+                final var getMiliSec = project.get("userMilliSeconds").getAsJsonObject().get(userName).getAsInt();
+                final var curMiliSec = getMiliSec > 0 && getMiliSec < 1000000
+                                       ? getMiliSec
+                                       : 0;
+                final var timedPlots = project.get("timedUserPlots").getAsJsonObject().get(userName).getAsInt();
+                projectObject.addProperty("analysisAverage", timedPlots > 0 
+                            ? Math.round(curMiliSec / 1.0 / timedPlots / 100.0) / 10.0
+                            : 0);
 
-                projectObject.addProperty("totalMilliSecond",project.get("userMilliSeconds").getAsJsonObject().get(userName).getAsInt());   
-                projectObject.addProperty("timedUserPlots",project.get("timedUserPlots").getAsJsonObject().get(userName).getAsInt());   
+                projectObject.addProperty("totalMilliSecond", timedPlots > 0 ? curMiliSec : 0);   
+                projectObject.addProperty("timedUserPlots", timedPlots);   
 
 
                 return projectObject;

--- a/src/main/java/org/openforis/ceo/local/JsonUsers.java
+++ b/src/main/java/org/openforis/ceo/local/JsonUsers.java
@@ -376,15 +376,15 @@ public class JsonUsers implements Users {
         mapJsonFile("project-list.json",
                 project -> {
                     if (Paths.get(expandResourcePath("/json"), "plot-data-" + project.get("id").getAsString() + ".json").toFile().exists()) {
-                        System.out.println(project.get("id").getAsString());
                         var plots = readJsonFile("plot-data-" + project.get("id").getAsString() + ".json").getAsJsonArray();
-                        // System.out.println(plots.toString());
                         var plotsData = toStream(plots)
                             .filter(plot -> getOrEmptyString(plot, "user").getAsString().length() > 0)
                             .map(plot -> {
                                 var plotObject = new JsonObject();
 
-                                plotObject.addProperty("milliSecs", collectTimeIgnoreString(plot) - getOrZero(plot, "collectionStart").getAsLong());
+                                plotObject.addProperty("milliSecs", collectTimeIgnoreString(plot) > getOrZero(plot, "collectionStart").getAsLong()
+                                                                    ? collectTimeIgnoreString(plot) - getOrZero(plot, "collectionStart").getAsLong() 
+                                                                    : 0L);
                                 plotObject.addProperty("plots", 1);
                                 plotObject.addProperty("timedPlots", getOrZero(plot, "collectionStart").getAsLong() > 0 ? 1 : 0);
                                 

--- a/src/main/java/org/openforis/ceo/local/JsonUsers.java
+++ b/src/main/java/org/openforis/ceo/local/JsonUsers.java
@@ -1,5 +1,6 @@
 package org.openforis.ceo.local;
 
+import static org.openforis.ceo.utils.JsonUtils.expandResourcePath;
 import static org.openforis.ceo.utils.JsonUtils.findInJsonArray;
 import static org.openforis.ceo.utils.JsonUtils.getNextId;
 import static org.openforis.ceo.utils.JsonUtils.intoJsonArray;
@@ -10,10 +11,15 @@ import static org.openforis.ceo.utils.JsonUtils.toStream;
 import static org.openforis.ceo.utils.JsonUtils.writeJsonFile;
 import static org.openforis.ceo.utils.Mail.isEmail;
 import static org.openforis.ceo.utils.Mail.sendMail;
+import static org.openforis.ceo.utils.ProjectUtils.getOrZero;
+import static org.openforis.ceo.utils.ProjectUtils.getOrEmptyString;
+import static org.openforis.ceo.utils.ProjectUtils.collectTimeIgnoreString;
+
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
+import java.nio.file.Paths;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -122,6 +128,7 @@ public class JsonUsers implements Users {
         return req;
     }
 
+    // FIXME back port postgres checks that allow user to change only one part
     public synchronized Request updateAccount(Request req, Response res) {
         var userId = (String) req.session().attribute("userid");
         var inputEmail = req.queryParams("email");
@@ -294,7 +301,138 @@ public class JsonUsers implements Users {
     }
 
     public String getUserStats(Request req, Response res) {
-        return "";
+        final var userName =     req.params(":userid");
+        final var projects = readJsonFile("project-list.json").getAsJsonArray();
+               
+        // Pull out usefull data
+        final var projectData = toStream(projects)
+            .filter(project -> Paths.get(expandResourcePath("/json"), "plot-data-" + project.get("id").getAsString() + ".json").toFile().exists() 
+                                && project.has("userPlots") 
+                                && project.get("userPlots").getAsJsonObject().has(userName))
+            .map(project -> {
+                var projectDataObject = new JsonObject(); 
+                projectDataObject.addProperty("plotCount", project.get("userPlots").getAsJsonObject().get(userName).getAsInt());    
+                
+                projectDataObject.addProperty("analysisAverage", Math.round(project.get("userMilliSeconds").getAsJsonObject().get(userName).getAsInt() / 
+                1.0 / project.get("timedUserPlots").getAsJsonObject().get(userName).getAsInt() / 100.0) / 10.0);
+
+                projectDataObject.addProperty("totalMilliSecond",project.get("userMilliSeconds").getAsJsonObject().get(userName).getAsInt());   
+                projectDataObject.addProperty("timedUserPlots",project.get("timedUserPlots").getAsJsonObject().get(userName).getAsInt());   
+
+                var projectObject = new JsonObject();
+                projectObject.add(project.get("id").getAsString(), projectDataObject);
+                return projectObject;
+                }
+            )    
+            .collect(intoJsonArray);
+
+        final int totalPlots = toStream(projectData)
+            .map(project -> getOrZero(project.get(project.keySet().iterator().next().toString()).getAsJsonObject(), "plotCount").getAsInt())
+            .mapToInt(Integer::intValue).sum();
+
+        final int totalTimedPlots = toStream(projectData)
+            .map(project -> getOrZero(project.get(project.keySet().iterator().next().toString()).getAsJsonObject(), "timedUserPlots").getAsInt())
+            .mapToInt(Integer::intValue).sum();
+
+        final int totalMilliseconds = toStream(projectData)
+            .map(project -> getOrZero(project.get(project.keySet().iterator().next().toString()).getAsJsonObject(), "totalMilliSecond").getAsInt())
+            .mapToInt(Integer::intValue).sum();
+                
+        final var plotsByProject = toStream(projectData)
+                .map(project -> {
+                    return "\"" + project.keySet().iterator().next().toString() + "\" : " +
+                            project.get(project.keySet().iterator().next().toString()).getAsJsonObject().get("plotCount").getAsString();
+
+                }).collect(Collectors.joining(","));
+        
+        final var secondsByProject = toStream(projectData)
+                .map(project -> {
+                    return "\"" + project.keySet().iterator().next().toString() + "\" : " +
+                            project.get(project.keySet().iterator().next().toString()).getAsJsonObject().get("analysisAverage").getAsString();
+
+                }).collect(Collectors.joining(","));
+
+        var userStats = new JsonObject();
+        userStats.addProperty("totalProjects", projectData.size());
+        userStats.addProperty("totalPlots", totalPlots);
+        userStats.addProperty("averageTime", Math.round(totalMilliseconds / 100.0 / totalTimedPlots) / 10.0);
+        userStats.add("plotsByProject", parseJson("{" + plotsByProject + "}").getAsJsonObject());
+        userStats.add("timeByProject", parseJson("{" + secondsByProject + "}").getAsJsonObject());
+        return userStats.toString();
+    
+    }
+
+    private JsonObject mapToObject(Map<String, Integer> usermap) {
+        return parseJson("{" + 
+            usermap.entrySet().stream()
+                .map(user -> {
+                    return "\"" + user.getKey() + "\" : " + Integer.toString(user.getValue());
+                }).collect(Collectors.joining(",")) + "}"
+        ).getAsJsonObject();
+    }
+
+    public String updateProjectUserStats(Request req, Response res) {
+
+        mapJsonFile("project-list.json",
+                project -> {
+                    if (Paths.get(expandResourcePath("/json"), "plot-data-" + project.get("id").getAsString() + ".json").toFile().exists()) {
+                        System.out.println(project.get("id").getAsString());
+                        var plots = readJsonFile("plot-data-" + project.get("id").getAsString() + ".json").getAsJsonArray();
+                        // System.out.println(plots.toString());
+                        var plotsData = toStream(plots)
+                            .filter(plot -> getOrEmptyString(plot, "user").getAsString().length() > 0)
+                            .map(plot -> {
+                                var plotObject = new JsonObject();
+
+                                plotObject.addProperty("milliSecs", collectTimeIgnoreString(plot) - getOrZero(plot, "collectionStart").getAsLong());
+                                plotObject.addProperty("plots", 1);
+                                plotObject.addProperty("timedPlots", getOrZero(plot, "collectionStart").getAsLong() > 0 ? 1 : 0);
+                                
+                                var userObject = new JsonObject();
+                                userObject.add(plot.get("user").getAsString(), plotObject);
+                                return userObject;
+                                }
+                            )
+                            .collect(intoJsonArray);
+                        final var milliTotalByUser = toStream(plotsData)
+                            .collect(
+                                Collectors.toMap(
+                                    plot -> plot.keySet().iterator().next().toString(),
+                                    plot -> plot.get(plot.keySet().iterator().next().toString()).getAsJsonObject().get("milliSecs").getAsInt(),
+                                    (a, b) -> a + b
+                                )
+                            );
+
+                        final var plotsTotalByUser = toStream(plotsData)
+                            .collect(
+                                Collectors.toMap(
+                                    plot -> plot.keySet().iterator().next().toString(),
+                                    plot -> plot.get(plot.keySet().iterator().next().toString()).getAsJsonObject().get("plots").getAsInt(),
+                                    (a, b) -> a + b
+                                )
+                            );
+                            
+                        final var timedPlotsTotalByUser = toStream(plotsData)
+                            .collect(
+                                Collectors.toMap(
+                                    plot -> plot.keySet().iterator().next().toString(),
+                                    plot -> plot.get(plot.keySet().iterator().next().toString()).getAsJsonObject().get("timedPlots").getAsInt(),
+                                    (a, b) -> a + b
+                                )
+                            );
+
+                        project.add("userMilliSeconds", mapToObject(milliTotalByUser));
+                        project.add("userPlots", mapToObject(plotsTotalByUser));
+                        project.add("timedUserPlots", mapToObject(timedPlotsTotalByUser));
+
+                        return project;
+                    } else {
+                        return project;
+                    }
+                }
+            );
+
+            return "";
     }
     
     public Map<Integer, String> getInstitutionRoles(int userId) {

--- a/src/main/java/org/openforis/ceo/postgres/PostgresProjects.java
+++ b/src/main/java/org/openforis/ceo/postgres/PostgresProjects.java
@@ -426,8 +426,8 @@ public class PostgresProjects implements Projects {
             try(var rs = pstmt.executeQuery()){
                 if (rs.next()) {
                     var plotSummaries = new JsonArray();
-                    var sampleValueGroups = parseJson(rs.getString("sample_survey")).getAsJsonArray();
-                    var projectName = rs.getString("name").replace(" ", "-").replace(",", "").toLowerCase();
+                    final var sampleValueGroups = parseJson(rs.getString("sample_survey")).getAsJsonArray();
+                    final var projectName = rs.getString("name").replace(" ", "-").replace(",", "").toLowerCase();
                     var plotHeaders = getPlotHeaders(conn, projectId);
 
                     try(var pstmtDump = conn.prepareStatement("SELECT * FROM dump_project_plot_data(?)")){
@@ -479,7 +479,7 @@ public class PostgresProjects implements Projects {
         return res.raw();
     }
     
-     public HttpServletResponse dumpProjectRawData(Request req, Response res) {
+    public HttpServletResponse dumpProjectRawData(Request req, Response res) {
         var projectId =Integer.parseInt( req.params(":id"));
 
         try (var conn = connect();
@@ -489,11 +489,11 @@ public class PostgresProjects implements Projects {
             try(var rs = pstmt.executeQuery()){
                 if (rs.next()) {
                     var sampleSummaries = new JsonArray();
-                    var sampleValueGroups = parseJson(rs.getString("sample_survey")).getAsJsonArray();
-                    var projectName = rs.getString("name").replace(" ", "-").replace(",", "").toLowerCase();
-                    var plotHeaders = getPlotHeaders(conn, projectId);
-                    var sampleHeaders = getSampleHeaders(conn, projectId);
-                    var imageryHeaders = new ArrayList<String>();
+                    final var sampleValueGroups = parseJson(rs.getString("sample_survey")).getAsJsonArray();
+                    final var projectName = rs.getString("name").replace(" ", "-").replace(",", "").toLowerCase();
+                    final var plotHeaders = getPlotHeaders(conn, projectId);
+                    final var sampleHeaders = getSampleHeaders(conn, projectId);
+                    var optionalHeaders = new ArrayList<String>();
 
                     try(var pstmtDump = conn.prepareStatement("SELECT * FROM dump_project_sample_data(?)")){
                         pstmtDump.setInt(1, projectId);
@@ -515,22 +515,22 @@ public class PostgresProjects implements Projects {
                                 }
                                 if (!valueOrBlank(rsDump.getString("collection_time")).equals("")) {
                                     plotSummary.addProperty("collection_time", valueOrBlank(rsDump.getString("collection_time")));
-                                    if (!imageryHeaders.contains("collection_time")) imageryHeaders.add("collection_time");
+                                    if (!optionalHeaders.contains("collection_time")) optionalHeaders.add("collection_time");
                                 }
                                 if (!valueOrBlank(rsDump.getString("analysis_duration")).equals("")) {
                                     plotSummary.addProperty("analysis_duration", valueOrBlank(rsDump.getString("analysis_duration")));
-                                    if (!imageryHeaders.contains("analysis_duration")) imageryHeaders.add("analysis_duration");
+                                    if (!optionalHeaders.contains("analysis_duration")) optionalHeaders.add("analysis_duration");
                                 }
 
                                 if (valueOrBlank(rsDump.getString("imagery_title")) != "") {
                                     plotSummary.addProperty("imagery_title", rsDump.getString("imagery_title"));
-                                    if (!imageryHeaders.contains("imagery_title")) imageryHeaders.add("imagery_title");
+                                    if (!optionalHeaders.contains("imagery_title")) optionalHeaders.add("imagery_title");
                                     
                                     if (valueOrBlank(rsDump.getString("imagery_attributes")).length() > 2) {
                                         var attributes = parseJson(rsDump.getString("imagery_attributes")).getAsJsonObject();
                                         attributes.keySet().forEach(key -> {
                                             plotSummary.addProperty(key, attributes.get(key).getAsString());
-                                            if (!imageryHeaders.contains(key)) imageryHeaders.add(key);
+                                            if (!optionalHeaders.contains(key)) optionalHeaders.add(key);
                                         });
                                     }
                                 }
@@ -553,7 +553,7 @@ public class PostgresProjects implements Projects {
                         }
                         var combinedHeaders = 
                         Stream.concat(
-                            imageryHeaders.stream(),
+                            optionalHeaders.stream(),
                             Stream.concat(
                                     plotHeaders.stream()
                                     .map(head -> !head.toString().contains("pl_") ? "pl_" + head : head),
@@ -695,7 +695,7 @@ public class PostgresProjects implements Projects {
     private static String loadCsvHeaders(String filename, List<String> mustInclude) {
         try (var lines = Files.lines(Paths.get(expandResourcePath("/csv/" + filename)))) {
             
-            var colList = Arrays.stream(
+            final var colList = Arrays.stream(
                 lines.findFirst().orElse("").split(","))
                     .map(col -> {
                         return col.toUpperCase();
@@ -709,7 +709,7 @@ public class PostgresProjects implements Projects {
                 }   
             });
 
-            var fields = colList.stream()
+            final var fields = colList.stream()
                     .map(col -> {
                         if (List.of("LON", "LAT", "LATITUDE", "LONGITUDE", "LONG", "CENTER_X", "CENTER_Y").contains(col.toUpperCase())) {
                             return col.toUpperCase() + " float";
@@ -729,7 +729,7 @@ public class PostgresProjects implements Projects {
     private static String[] loadCsvHeadersToRename(String filename) {
         try (var lines = Files.lines(Paths.get(expandResourcePath("/csv/" + filename)))) {
             
-            var colList = lines.findFirst().orElse("").split(",");
+            final var colList = lines.findFirst().orElse("").split(",");
             return new String[] {colList[0],colList[1]};
 
         } catch (Exception e) {
@@ -757,55 +757,61 @@ public class PostgresProjects implements Projects {
         deleteFile("project-" + projectId + "-plots.zip");
         deleteFile("project-" + projectId + "-samples.zip");
     }
-
-    private static String loadPlots(Connection conn, String plotDistribution, Integer projectId, String plotsFile) {
+    
+    private static String loadExternalData(Connection conn, String distribution, Integer projectId, String extFile, String plotsOrSamples, List<String> mustInclude) {
         try {
-            var plots_table = "";
-            if (plotDistribution.equals("csv")) {
-                plots_table = "project_" +  projectId + "_plots_csv";
+            if (distribution.equals("csv")) {
+                final var table_name = "project_" +  projectId + "_" + plotsOrSamples + "_csv";
                 // add empty table to the database
                 try(var pstmt = conn.prepareStatement("SELECT * FROM create_new_table(?,?)")){
-                    pstmt.setString(1, plots_table);
-                    pstmt.setString(2, loadCsvHeaders(plotsFile, List.of("plotId")));
+                    pstmt.setString(1, table_name);
+                    pstmt.setString(2, loadCsvHeaders(extFile, mustInclude));
                     pstmt.execute();
                 } 
                 // import csv file
-                runBashScriptForProject(projectId, "plots", "csv2postgres.sh", "/csv");
-                var renameFrom = loadCsvHeadersToRename(plotsFile);
+                runBashScriptForProject(projectId, plotsOrSamples, "csv2postgres.sh", "/csv");
+                var renameFrom = loadCsvHeadersToRename(extFile);
                 // rename columns
                 try(var pstmt = conn.prepareStatement("SELECT * FROM rename_col(?,?,?)")){
-                    pstmt.setString(1,plots_table);
+                    pstmt.setString(1,table_name);
                     pstmt.setString(2,renameFrom[0]);
                     pstmt.setString(3,"lon");
                     pstmt.execute();
-                } catch (SQLException s) {
-                    System.out.println(s.getMessage());
-                    throw new RuntimeException("Error with column names 1");
                 }
                 try(var pstmt = conn.prepareStatement("SELECT * FROM rename_col(?,?,?)")){
-                    pstmt.setString(1,plots_table);
+                    pstmt.setString(1,table_name);
                     pstmt.setString(2,renameFrom[1]);
                     pstmt.setString(3,"lat");
                     pstmt.execute();
-                } catch (SQLException s) {
-                    System.out.println(s.getMessage());
-                    throw new RuntimeException("Error with column names 2");
-                }
-
+                } 
                 // add index for reference
                 try(var pstmt = conn.prepareStatement("SELECT * FROM add_index_col(?)")){
-                    pstmt.setString(1,plots_table);
+                    pstmt.setString(1,table_name);
                     pstmt.execute();
                 } 
-            } else if (plotDistribution.equals("shp")) {
-                runBashScriptForProject(projectId, "plots", "shp2postgres.sh", "/shp");
-                plots_table = "project_" +  projectId + "_plots_shp";
-                // run query to make sure all requred fields exist
+
+                return table_name;
+
+            } else if (distribution.equals("shp")) {
+                runBashScriptForProject(projectId, plotsOrSamples, "shp2postgres.sh", "/shp");
+                return "project_" +  projectId + "_" + plotsOrSamples + "_shp";
+            } else {
+                return "";
             }
+        } catch (SQLException s) {
+            System.out.println(s.getMessage());
+            throw new RuntimeException("Error importing file into SQL");
+        }
+    }
+
+    private static String checkLoadPlots(Connection conn, String plotDistribution, Integer projectId, String plotsFile) {
+        try {
+          
             if (List.of("csv", "shp").contains(plotDistribution)){
                 // check if data is also correct after being loaded
+                final var plots_table = loadExternalData(conn, plotDistribution, projectId, plotsFile, "plot", List.of("plotId"));
                 try(var pstmt = conn.prepareStatement("SELECT * FROM select_partial_table_by_name(?)")){
-                    pstmt.setString(1,plots_table);
+                    pstmt.setString(1, plots_table);
                     pstmt.execute();
                 } catch (SQLException s) {
                     System.out.println(s.getMessage());
@@ -824,46 +830,9 @@ public class PostgresProjects implements Projects {
         } 
     }
 
-    private static String loadSamples(Connection conn, String sampleDistribution, Integer projectId, String samplesFile) {
+    private static String checkLoadSamples(Connection conn, String sampleDistribution, Integer projectId, String samplesFile) {
         try {
-            var samples_table = "";
-            if (sampleDistribution.equals("csv")) {
-                samples_table = "project_" +  projectId + "_samples_csv";
-                // create new table
-                try(var pstmt = conn.prepareStatement("SELECT * FROM create_new_table(?,?)")){
-                    pstmt.setString(1,samples_table);
-                    pstmt.setString(2, loadCsvHeaders(samplesFile, List.of("plotId", "sampleId")));
-                    pstmt.execute();
-                }
-                // fill table
-                runBashScriptForProject(projectId, "samples", "csv2postgres.sh", "/csv");
-                // add index for reference
-                // rename columns
-                var renameFrom = loadCsvHeadersToRename(samplesFile);
-                try(var pstmt = conn.prepareStatement("SELECT * FROM rename_col(?,?,?)")){
-                    pstmt.setString(1,samples_table);
-                    pstmt.setString(2,renameFrom[0]);
-                    pstmt.setString(3,"lon");
-                    pstmt.execute();
-                } catch (SQLException s) {
-                    throw new RuntimeException("Error with column names");
-                }
-                try(var pstmt = conn.prepareStatement("SELECT * FROM rename_col(?,?,?)")){
-                    pstmt.setString(1,samples_table);
-                    pstmt.setString(2,renameFrom[1]);
-                    pstmt.setString(3,"lat");
-                    pstmt.execute();
-                } catch (SQLException s) {
-                    throw new RuntimeException("Error with column names");
-                }
-                try(var pstmt = conn.prepareStatement("SELECT * FROM add_index_col(?)")){
-                    pstmt.setString(1,"project_" +  projectId + "_samples_csv");
-                    pstmt.execute();
-                }
-            } else if (sampleDistribution.equals("shp")) {
-                runBashScriptForProject(projectId, "samples", "shp2postgres.sh", "/shp");
-                samples_table = "project_" +  projectId + "_samples_shp";
-            }
+            final var samples_table = loadExternalData(conn, sampleDistribution, projectId, samplesFile, "plot", List.of("plotId", "sampleId"));
             if (List.of("csv", "shp").contains(sampleDistribution)){
                 // check if data is also correct after being loaded
                 try(var pstmt = conn.prepareStatement("SELECT * FROM select_partial_table_by_name(?)")){
@@ -907,8 +876,8 @@ public class PostgresProjects implements Projects {
             try (var pstmt = 
                 conn.prepareStatement("SELECT * FROM update_project_tables(?,?::text,?::text)")) {
                 pstmt.setInt(1, projectId);     
-                pstmt.setString(2, loadPlots(conn, plotDistribution, projectId, plotsFile));
-                pstmt.setString(3, loadSamples(conn, sampleDistribution, projectId, samplesFile));
+                pstmt.setString(2, checkLoadPlots(conn, plotDistribution, projectId, plotsFile));
+                pstmt.setString(3, checkLoadSamples(conn, sampleDistribution, projectId, samplesFile));
                 pstmt.execute();
             } catch (SQLException e) {
                 System.out.println("catch update");
@@ -952,29 +921,28 @@ public class PostgresProjects implements Projects {
                 } 
             } else {
                 // Convert the lat/lon boundary coordinates to Web Mercator (units: meters) and apply an interior buffer of plotSize / 2
-                var bounds = reprojectBounds(lonMin, latMin, lonMax, latMax, 4326, 3857);
-                var paddedBounds = padBounds(bounds[0], bounds[1], bounds[2], bounds[3], plotSize / 2.0);
-                var left = paddedBounds[0];
-                var bottom = paddedBounds[1];
-                var right = paddedBounds[2];
-                var top = paddedBounds[3];
+                final var bounds = reprojectBounds(lonMin, latMin, lonMax, latMax, 4326, 3857);
+                final var paddedBounds = padBounds(bounds[0], bounds[1], bounds[2], bounds[3], plotSize / 2.0);
+                final var left = paddedBounds[0];
+                final var bottom = paddedBounds[1];
+                final var right = paddedBounds[2];
+                final var top = paddedBounds[3];
 
                 // Generate the plot objects and their associated sample points
-                var newPlotCenters =
-                plotDistribution.equals("random") 
-                ? createRandomPointsInBounds(left, bottom, right, top, numPlots)
-                : createGriddedPointsInBounds(left, bottom, right, top, plotSpacing);
+                final var newPlotCenters =
+                    plotDistribution.equals("random") 
+                    ? createRandomPointsInBounds(left, bottom, right, top, numPlots)
+                    : createGriddedPointsInBounds(left, bottom, right, top, plotSpacing);
 
                 Arrays.stream(newPlotCenters)
-                .forEach(plotEntry -> {
-                    var plotCenter = plotEntry;
-                        var SqlPlots = "SELECT * FROM create_project_plot(?,ST_SetSRID(ST_GeomFromGeoJSON(?), 4326))";
+                .forEach(plotCenter -> {
+                        final var SqlPlots = "SELECT * FROM create_project_plot(?,ST_SetSRID(ST_GeomFromGeoJSON(?), 4326))";
                         try(var pstmtPlots = conn.prepareStatement(SqlPlots)) {
                         pstmtPlots.setInt(1, projectId);    
                         pstmtPlots.setString(2, makeGeoJsonPoint(plotCenter[0], plotCenter[1]).toString());       
                         try(var rsPlots = pstmtPlots.executeQuery()){
                             if (rsPlots.next()) {
-                                var newPlotId = rsPlots.getInt("create_project_plot");
+                                final var newPlotId = rsPlots.getInt("create_project_plot");
                                 createProjectSamples(conn, newPlotId, sampleDistribution, 
                                     plotCenter, plotShape, plotSize, samplesPerPlot, sampleResolution, false);
                             }
@@ -1039,10 +1007,10 @@ public class PostgresProjects implements Projects {
             newProject.addProperty("description", partToString(req.raw().getPart("description")));
             newProject.addProperty("availability", "unpublished");
 
-            var lonMin =             getOrZero(newProject,"lonMin").getAsDouble();
-            var latMin =             getOrZero(newProject,"latMin").getAsDouble();
-            var lonMax =             getOrZero(newProject,"lonMax").getAsDouble();
-            var latMax =             getOrZero(newProject,"latMax").getAsDouble();
+            final var lonMin =             getOrZero(newProject,"lonMin").getAsDouble();
+            final var latMin =             getOrZero(newProject,"latMin").getAsDouble();
+            final var lonMax =             getOrZero(newProject,"lonMax").getAsDouble();
+            final var latMax =             getOrZero(newProject,"latMax").getAsDouble();
             newProject.addProperty("boundary", makeGeoJsonPolygon(lonMin, latMin, lonMax, latMax).toString());
 
             var SQL = "SELECT * FROM create_project(?,?,?,?,?,ST_SetSRID(ST_GeomFromGeoJSON(?), 4326),?,?,?,?,?,?,?,?,?,?::JSONB,?::jsonb)";
@@ -1079,37 +1047,31 @@ public class PostgresProjects implements Projects {
                                 copyPstmt.execute();
                             }
                         } else {
-                            // Upload the plot-distribution-csv-file if one was provided
+                            // Upload the *-distribution-csv-file if one was provided
                             // not stored in database
                             if (newProject.get("plotDistribution").getAsString().equals("csv")) {
-                                var csvFileName = writeFilePart(req,
+                                final var csvFileName = writeFilePart(req,
                                         "plot-distribution-csv-file",
                                         expandResourcePath("/csv"),
                                         "project-" + newProjectId + "-plots");
                                 newProject.addProperty("plots_file", csvFileName);
-                            } 
-
-                            // Upload the sample-distribution-csv-file if one was provided
-                            if (newProject.get("sampleDistribution").getAsString().equals("csv")) {
-                                var csvFileName = writeFilePart(req,
+                            } else if (newProject.get("sampleDistribution").getAsString().equals("csv")) {
+                                final var csvFileName = writeFilePart(req,
                                         "sample-distribution-csv-file",
                                         expandResourcePath("/csv"),
                                         "project-" + newProjectId + "-samples");
                                 newProject.addProperty("samples_file", csvFileName);
                             } 
 
-                            // Upload the plot-distribution-shp-file if one was provided (this should be a ZIP file)
+                            // Upload the *-distribution-shp-file if one was provided (this should be a ZIP file)
                             if (newProject.get("plotDistribution").getAsString().equals("shp")) {
-                                var shpFileName = writeFilePart(req,
+                                final var shpFileName = writeFilePart(req,
                                                                 "plot-distribution-shp-file",
                                                                 expandResourcePath("/shp"),
                                                                 "project-" + newProjectId + "-plots");
                                 newProject.addProperty("plots_file", shpFileName);
-                            }
-
-                            // Upload the sample-distribution-shp-file if one was provided (this should be a ZIP file)
-                            if (newProject.get("sampleDistribution").getAsString().equals("shp")) {
-                                var shpFileName = writeFilePart(req,
+                            } else if (newProject.get("sampleDistribution").getAsString().equals("shp")) {
+                                final var shpFileName = writeFilePart(req,
                                                                 "sample-distribution-shp-file",
                                                                 expandResourcePath("/shp"),
                                                                 "project-" + newProjectId + "-samples");

--- a/src/main/java/org/openforis/ceo/postgres/PostgresProjects.java
+++ b/src/main/java/org/openforis/ceo/postgres/PostgresProjects.java
@@ -868,8 +868,8 @@ public class PostgresProjects implements Projects {
         var sampleDistribution = getOrEmptyString(newProject, "sampleDistribution").getAsString();
         var samplesPerPlot =     getOrZero(newProject,"samplesPerPlot").getAsInt();
         var sampleResolution =   getOrZero(newProject,"sampleResolution").getAsDouble();
-        var plotsFile =          newProject.has("plots_file") ? newProject.get("plots_file").getAsString() : "";
-        var samplesFile =        newProject.has("samples_file") ? newProject.get("samples_file").getAsString() : "";
+        var plotsFile =          getOrEmptyString(newProject, "plots_file").getAsString();
+        var samplesFile =        getOrEmptyString(newProject,"samples_file").getAsString();
         try (var conn = connect()) {
             // load files into the database (loadPlot, loadSamples) and update projects
             try (var pstmt = 

--- a/src/main/java/org/openforis/ceo/postgres/PostgresProjects.java
+++ b/src/main/java/org/openforis/ceo/postgres/PostgresProjects.java
@@ -4,7 +4,6 @@ import static javax.servlet.http.HttpServletResponse.SC_NO_CONTENT;
 import static org.openforis.ceo.utils.DatabaseUtils.connect;
 import static org.openforis.ceo.utils.JsonUtils.expandResourcePath;
 import static org.openforis.ceo.utils.JsonUtils.parseJson;
-import static org.openforis.ceo.utils.JsonUtils.toStream;
 import static org.openforis.ceo.utils.PartUtils.partToString;
 import static org.openforis.ceo.utils.PartUtils.partsToJsonObject;
 import static org.openforis.ceo.utils.PartUtils.writeFilePart;
@@ -720,7 +719,7 @@ public class PostgresProjects implements Projects {
                     })
                     .collect(Collectors.joining(","));
             
-            return String.join(",", fields);
+            return fields;
         } catch (Exception e) {
             throw new RuntimeException("Error reading csv file", e);
         }

--- a/src/main/java/org/openforis/ceo/postgres/PostgresProjects.java
+++ b/src/main/java/org/openforis/ceo/postgres/PostgresProjects.java
@@ -1039,7 +1039,8 @@ public class PostgresProjects implements Projects {
                     if (rs.next()){
                         newProjectId = Integer.toString(rs.getInt("create_project"));
                         newProject.addProperty("id", newProjectId);
-                        if (getOrZero(newProject, "useTemplatePlots").getAsBoolean()) {
+                        if (getOrZero(newProject, "useTemplatePlots").getAsBoolean() 
+                                && getOrZero(newProject, "project-template").getAsInt() > 0) {
                             try(var copyPstmt = conn.prepareStatement("SELECT * FROM copy_template_plots(?,?)")){
                                 copyPstmt.setInt(1, newProject.get("projectTemplate").getAsInt());
                                 copyPstmt.setInt(2, Integer.parseInt(newProjectId));

--- a/src/main/java/org/openforis/ceo/postgres/PostgresUsers.java
+++ b/src/main/java/org/openforis/ceo/postgres/PostgresUsers.java
@@ -322,6 +322,9 @@ public class PostgresUsers implements Users {
         }
         return "";
     }
+
+    public String updateProjectUserStats(Request req, Response res) { return "";}
+
     // FIXME this appears to be unused.  Not tested
     public Map<Integer, String> getInstitutionRoles(int userId) {
         var inst = new HashMap<Integer,String>();

--- a/src/main/java/org/openforis/ceo/postgres/PostgresUsers.java
+++ b/src/main/java/org/openforis/ceo/postgres/PostgresUsers.java
@@ -312,8 +312,7 @@ public class PostgresUsers implements Users {
                     userJson.addProperty("totalProjects", rs.getInt("total_projects"));
                     userJson.addProperty("totalPlots", rs.getInt("total_plots"));
                     userJson.addProperty("averageTime", rs.getInt("average_time"));
-                    userJson.add("plotsByProject", parseJson(rs.getString("plots_by_project")).getAsJsonObject());
-                    userJson.add("timeByProject", parseJson(rs.getString("time_by_project")).getAsJsonObject());
+                    userJson.add("perProject", parseJson(rs.getString("per_project")).getAsJsonArray());
                 }
                 return userJson.toString();
             }

--- a/src/main/java/org/openforis/ceo/users/OfUsers.java
+++ b/src/main/java/org/openforis/ceo/users/OfUsers.java
@@ -269,6 +269,8 @@ public class OfUsers implements Users {
 
     public String getUserStats(Request req, Response res) { return "";}
 
+    public String updateProjectUserStats(Request req, Response res) { return "";}
+
     public String getAllUsers(Request req, Response res) {
         var institutionId = req.queryParams("institutionId");
         try {

--- a/src/main/java/org/openforis/ceo/utils/ProjectUtils.java
+++ b/src/main/java/org/openforis/ceo/utils/ProjectUtils.java
@@ -364,7 +364,11 @@ public class ProjectUtils {
     }
 
     public static JsonElement getOrZero(JsonObject obj, String field) {
-        return !obj.has(field) || obj.get(field).isJsonNull() || obj.get(field) == null ? new JsonPrimitive(0) : obj.get(field);
+        try {
+            return obj.get(field).isJsonNull() || obj.get(field) == null ? new JsonPrimitive(0) : obj.get(field);
+        } catch(Exception e) {
+            return new JsonPrimitive(0);
+        }
     }
 
     public static JsonElement getOrEmptyString(JsonObject obj, String field) {

--- a/src/main/java/org/openforis/ceo/utils/ProjectUtils.java
+++ b/src/main/java/org/openforis/ceo/utils/ProjectUtils.java
@@ -121,17 +121,24 @@ public class ProjectUtils {
         return response;
     }
 
+    private static String csvQuotes(String input) {
+        return input.contains(",") ? "\"" + input + "\"" : input;
+    }
+
     public static HttpServletResponse outputAggregateCsv(Response res, JsonArray sampleValueGroups, JsonArray plotSummaries, String projectName, String[] externalHeaders){
         var sampleValueKeys = getSampleKeys(sampleValueGroups);
         // fileds are straight forward json values
-        var fields = Stream.concat(
+        final String[] fields = Stream.concat(
                         Arrays.stream(new String[]{"plot_id", "center_lon", "center_lat", "size_m", "shape", "flagged", "analyses", "sample_points", "user_id"}), 
                         Arrays.stream(externalHeaders))
                         .toArray(String[]::new);
         // labels require interpretation of the next json object
-        var labels = getValueDistributionLabels(sampleValueGroups, sampleValueKeys);
+        final String[] labels = getValueDistributionLabels(sampleValueGroups, sampleValueKeys);
 
-        var csvHeader = Stream.concat(Arrays.stream(fields), Arrays.stream(labels)).map(String::toUpperCase).collect(Collectors.joining(","));
+        final String csvHeader = Stream.concat(Arrays.stream(fields), Arrays.stream(labels))
+                                    .map(field -> csvQuotes(field).toUpperCase())
+                                    .collect(Collectors.joining(","));
+        
         var csvContent = toStream(plotSummaries)
                 .map(plotSummary -> {
                     var fieldStream = Arrays.stream(fields);
@@ -141,12 +148,12 @@ public class ProjectUtils {
                             fieldStream.map(field -> plotSummary.has(field) ?
                                     plotSummary.get(field).isJsonNull()
                                         ? ""
-                                        : plotSummary.get(field).getAsString()
+                                        : csvQuotes(plotSummary.get(field).getAsString())
                                     : ""),
                             labelStream.map(label -> distribution.has(label)
                                     ? distribution.getAsJsonObject().get(label).isJsonPrimitive() 
-                                        ? distribution.get(label).getAsString()
-                                        : distribution.getAsJsonObject().get(label).getAsJsonObject().get("answer").getAsString()
+                                        ? csvQuotes(distribution.get(label).getAsString())
+                                        : csvQuotes(distribution.getAsJsonObject().get(label).getAsJsonObject().get("answer").getAsString())
                                     : "0.0")
                             ).collect(Collectors.joining(","));
                     }).collect(Collectors.joining("\n"));
@@ -159,23 +166,24 @@ public class ProjectUtils {
     }
 
     public static HttpServletResponse outputRawCsv(Response res, JsonArray sampleValueGroups, JsonArray sampleSummaries, String projectName, String[] externalHeaders) {
-        var sampleValueKeys = getSampleKeys(sampleValueGroups);
-        var sampleValueGroupNames = toStream(sampleValueGroups)
+        final var sampleValueKeys = getSampleKeys(sampleValueGroups);
+        final var sampleValueGroupNames = toStream(sampleValueGroups)
         .collect(Collectors.toMap(sampleValueGroup -> sampleValueGroup.get("id").getAsInt(),
                 sampleValueGroup -> sampleValueGroup.get(sampleValueKeys[0]).getAsString(),
                 (a, b) -> b));
 
         // fileds are straight forward json values
-        var fields = Stream.concat(
+        final String[] fields = Stream.concat(
                         Arrays.stream(new String[]{"plot_id", "sample_id", "lon", "lat", "flagged", "analyses", "user_id"}), 
                         Arrays.stream(externalHeaders))
                         .toArray(String[]::new);
         // labels require interpretation of the next json object
-        var labels = sampleValueGroupNames.entrySet().stream()
+        final String[] labels = sampleValueGroupNames.entrySet().stream()
                         .sorted(Map.Entry.comparingByKey()).map(Map.Entry::getValue)
                         .toArray(String[]::new);
 
-        var csvHeader = Stream.concat(Arrays.stream(fields), Arrays.stream(labels)).map(String::toUpperCase)
+        final var csvHeader = Stream.concat(Arrays.stream(fields), Arrays.stream(labels))
+                        .map(field -> csvQuotes(field).toUpperCase())
                         .collect(Collectors.joining(","));
 
         var csvContent = toStream(sampleSummaries)
@@ -191,15 +199,15 @@ public class ProjectUtils {
                                 // original format is single integer index
                                 } else if (value.isJsonPrimitive()) {
                                     var sampleValueTranslations = getSampleValueTranslations(sampleValueGroups);
-                                    return sampleValueTranslations
+                                    return csvQuotes(sampleValueTranslations
                                             .getOrDefault(value.getAsInt(), "LULC:NoValue")
-                                            .split(":")[1];
+                                            .split(":")[1]);
                                 } else if (value.getAsJsonObject().has(label)) {
                                     if (value.getAsJsonObject().get(label).isJsonPrimitive()){
-                                        return value.getAsJsonObject().get(label).getAsString();
+                                        return csvQuotes(value.getAsJsonObject().get(label).getAsString());
                                     }
                                     // newest format nests the answer in another json object
-                                    return value.getAsJsonObject().get(label).getAsJsonObject().get("answer").getAsString();
+                                    return csvQuotes(value.getAsJsonObject().get(label).getAsJsonObject().get("answer").getAsString());
                                 } else {
                                     return "";
                                 }

--- a/src/main/java/org/openforis/ceo/utils/ProjectUtils.java
+++ b/src/main/java/org/openforis/ceo/utils/ProjectUtils.java
@@ -372,11 +372,7 @@ public class ProjectUtils {
     }
 
     public static JsonElement getOrZero(JsonObject obj, String field) {
-        try {
-            return obj.get(field).isJsonNull() || obj.get(field) == null ? new JsonPrimitive(0) : obj.get(field);
-        } catch(Exception e) {
-            return new JsonPrimitive(0);
-        }
+        return !obj.has(field) || obj.get(field).isJsonNull() || obj.get(field) == null ? new JsonPrimitive(0) : obj.get(field);
     }
 
     public static JsonElement getOrEmptyString(JsonObject obj, String field) {

--- a/src/main/java/org/openforis/ceo/utils/ProjectUtils.java
+++ b/src/main/java/org/openforis/ceo/utils/ProjectUtils.java
@@ -435,6 +435,14 @@ public class ProjectUtils {
         deleteShapeFileDirectory("project-" + projectId + "-plots");
         deleteShapeFileDirectory("project-" + projectId + "-samples");
     }
-
+        
+    // Some older data contains a useless string fromat for collection time. 
+    public static Long collectTimeIgnoreString (JsonObject plot){
+        try {
+            return getOrZero(plot, "collectionTime").getAsLong();
+        } catch (Exception e) {
+            return 0L;
+        }
+    }
     
 }

--- a/src/main/java/org/openforis/ceo/utils/ProjectUtils.java
+++ b/src/main/java/org/openforis/ceo/utils/ProjectUtils.java
@@ -40,6 +40,7 @@ public class ProjectUtils {
         Collectors.groupingBy(Function.identity(), Collectors.counting());
 
     private static String[] getSampleKeys(JsonArray sampleValueGroups) {
+        if (sampleValueGroups.size() == 0) {throw new RuntimeException("Missing sample value groups");}
         var firstGroup = sampleValueGroups.get(0).getAsJsonObject();
         if (firstGroup.has("name")) {
             return new String[]{"name", "values", "name"};
@@ -124,7 +125,7 @@ public class ProjectUtils {
         var sampleValueKeys = getSampleKeys(sampleValueGroups);
         // fileds are straight forward json values
         var fields = Stream.concat(
-                        Arrays.stream(new String[]{"plot_id", "center_lon", "center_lat", "size_m", "shape", "flagged", "analyses", "sample_points", "user_id", "analysis_duration", "collection_time"}), 
+                        Arrays.stream(new String[]{"plot_id", "center_lon", "center_lat", "size_m", "shape", "flagged", "analyses", "sample_points", "user_id"}), 
                         Arrays.stream(externalHeaders))
                         .toArray(String[]::new);
         // labels require interpretation of the next json object
@@ -166,7 +167,7 @@ public class ProjectUtils {
 
         // fileds are straight forward json values
         var fields = Stream.concat(
-                        Arrays.stream(new String[]{"plot_id", "sample_id", "lon", "lat", "flagged", "analyses", "user_id", "analysis_duration", "collection_time"}), 
+                        Arrays.stream(new String[]{"plot_id", "sample_id", "lon", "lat", "flagged", "analyses", "user_id"}), 
                         Arrays.stream(externalHeaders))
                         .toArray(String[]::new);
         // labels require interpretation of the next json object

--- a/src/main/resources/public/css/stylesheet.css
+++ b/src/main/resources/public/css/stylesheet.css
@@ -1616,6 +1616,12 @@ div#institution:before {
     width: 50%;
 }
 
+#project #project-design #project-imagery-review {
+    float: left;
+    width: 50%;
+    font-size: 1rem;
+}
+
 #project #project-design #project-imagery select {
     height: 1.6rem;
     width: 90%;

--- a/src/main/resources/public/jsx/account.js
+++ b/src/main/resources/public/jsx/account.js
@@ -1,20 +1,134 @@
-import React from "react";
+import React, { Fragment } from "react";
 import ReactDOM from "react-dom";
 
 function Account(props) {
     return (
-        <React.Fragment>
+        <Fragment>
             <div className="bg-darkgreen mb-3 no-container-margin">
-                <h1>Your account</h1>
+                <h1>Your account!</h1>
             </div>
-            <UserStats/>
-            <AccountForm documentRoot={props.documentRoot} userId={props.userId}
-                         accountId={props.accountId} userName={props.userName}/>
-        </React.Fragment>
+            <UserStats 
+                documentRoot={props.documentRoot}
+                userName={props.userName}
+            />
+            <AccountForm 
+                documentRoot={props.documentRoot} 
+                userId={props.userId}
+                accountId={props.accountId} 
+                userName={props.userName}
+            />
+        </Fragment>
     );
 }
 
-function UserStats() {
+class UserStats extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            stats: {},
+        };
+        this.getUserStats = this.getUserStats.bind(this);
+
+    }
+    componentDidMount() {
+        this.getUserStats();
+    }
+
+    getUserStats() {
+        fetch(this.props.documentRoot + "/get-user-stats/" + this.props.userName)
+            .then(response => {
+                if (response.ok) {
+                    return response.json();
+                } else {
+                    console.log(response);
+                    alert("Error retrieving the user stat info. See console for details.");
+                    return new Promise(resolve => resolve(null));
+                }
+            })
+            .then(stats => {
+                if (stats == null) {
+                    alert("No user found with ID " + this.props.userName + ".");
+                    window.location = this.props.documentRoot + "/home";
+                } else {
+                    this.setState({stats: stats});
+                }
+            });
+    }
+    render () {
+        let { totalProjects, totalPlots, averageTime, perProject } = this.state.stats;
+        return (
+            <div id="user-stats" className="col mb-3">
+                <h2 className="header px-0">User Stats</h2>
+                <table id="user-stats-table" className="table table-sm">
+                <tbody>
+                    <tr>
+                        <td className="w-80">Projects Worked So Far</td>
+                        <td className="w-20 text-center">
+                            <span className="badge badge-pill bg-lightgreen">{totalProjects} projects</span>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>Plots Completed Total</td> 
+                        <td className="text-center">
+                            <span className="badge badge-pill bg-lightgreen">{totalPlots} plots</span>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>Average Analysis Duration</td>
+                        <td className="text-center">
+                            <span className="badge badge-pill bg-lightgreen">{averageTime} secs/plot</span>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>Plots Completed Per Project</td>
+                        <td className="text-center">
+                            <span className="badge badge-pill bg-lightgreen">{Number(((totalPlots / totalProjects)).toFixed(1)) || 0} plots</span>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <strong>Individual Project Stats:</strong>
+                            <table id="project-stats-table" className="nested-table bg-light ml-1">
+                                <tbody>
+                                {perProject && perProject.map(project => {
+                                    return (
+                                    <ProjectRow 
+                                        project = {project}
+                                    />)
+                                })}
+
+                                </tbody>
+                            </table>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+                    
+            </div>
+        )
+    }
+}
+
+function ProjectRow({ project }) {
+    return (
+        <tr>
+            <td>{`#${project.id} - ${project.name}`}</td>
+            <td className="text-center">
+                <span className="badge badge-pill bg-lightgreen">{project.plotCount || ""} plots </span>
+            </td>
+            <td className="text-center">
+                {project.analysisAverage ? 
+                    (
+                    <span className="badge badge-pill bg-lightgreen">{project.analysisAverage} sec/plot </span>
+                    )
+                    : ("Untimed")
+                }
+            </td>
+        </tr>
+    )
+}
+
+function ExpandedUserStats() {
     return (
         <div id="user-stats" className="col" style={{display:"None"}}>
             <h2 className="header px-0">Here is your progress</h2>

--- a/src/main/resources/public/jsx/account.js
+++ b/src/main/resources/public/jsx/account.js
@@ -109,17 +109,17 @@ class UserStats extends React.Component {
     }
 }
 
-function ProjectRow({ project }) {
+function ProjectRow({ project: {id, name, plotCount, analysisAverage} }) {
     return (
         <tr>
-            <td>{`#${project.id} - ${project.name}`}</td>
+            <td>{`#${id} - ${name}`}</td>
             <td className="text-center">
-                <span className="badge badge-pill bg-lightgreen">{project.plotCount || ""} plots </span>
+                <span className="badge badge-pill bg-lightgreen">{plotCount || ""} plots </span>
             </td>
             <td className="text-center">
-                {project.analysisAverage ? 
+                {analysisAverage ? 
                     (
-                    <span className="badge badge-pill bg-lightgreen">{project.analysisAverage} sec/plot </span>
+                    <span className="badge badge-pill bg-lightgreen">{analysisAverage} sec/plot </span>
                     )
                     : ("Untimed")
                 }

--- a/src/main/resources/public/jsx/account.js
+++ b/src/main/resources/public/jsx/account.js
@@ -1,12 +1,11 @@
 import React, { Fragment } from "react";
 import ReactDOM from "react-dom";
+import FormLayout from "./components/FormLayout"
+import SectionBlock from "./components/SectionBlock"
 
 function Account(props) {
     return (
-        <Fragment>
-            <div className="bg-darkgreen mb-3 no-container-margin">
-                <h1>Your account!</h1>
-            </div>
+        <FormLayout title="Your account!" className="px-2 pb-2">
             <UserStats 
                 documentRoot={props.documentRoot}
                 userName={props.userName}
@@ -17,7 +16,7 @@ function Account(props) {
                 accountId={props.accountId} 
                 userName={props.userName}
             />
-        </Fragment>
+        </FormLayout>
     );
 }
 
@@ -57,8 +56,7 @@ class UserStats extends React.Component {
     render () {
         let { totalProjects, totalPlots, averageTime, perProject } = this.state.stats;
         return (
-            <div id="user-stats" className="col mb-3">
-                <h2 className="header px-0">User Stats</h2>
+            <SectionBlock title="User Stats">
                 <table id="user-stats-table" className="table table-sm">
                 <tbody>
                     <tr>
@@ -103,8 +101,7 @@ class UserStats extends React.Component {
                     </tr>
                 </tbody>
             </table>
-                    
-            </div>
+        </SectionBlock>
         )
     }
 }
@@ -192,51 +189,47 @@ function ExpandedUserStats() {
 }
 
 function AccountForm(props) {
-    if (props.userId == props.accountId) {
-        return (
-            <div id="account-form" className="col mb-3">
-                <h2 className="header px-0">Account Settings</h2>
-                <h1>{props.userName}</h1>
-                <form action={props.documentRoot + "/account/" + props.accountId} method="post">
-                    <div className="form-group">
-                        <label htmlFor="email">Reset email</label>
-                        <input autoComplete="off" id="email" name="email" placeholder="New email" defaultValue=""
-                               type="email"
-                               className="form-control"/>
-                    </div>
-                    <div className="form-group">
-                        <label htmlFor="password">Reset password</label>
-                        <div className="form-row">
-                            <div className="col">
-                                <input autoComplete="off" id="password" name="password" placeholder="New password"
-                                       defaultValue=""
-                                       type="password" className="form-control mb-1"/>
-                            </div>
-                            <div className="col">
-                                <input autoComplete="off" id="password-confirmation" name="password-confirmation"
-                                       placeholder="New password confirmation" defaultValue="" type="password"
-                                       className="form-control"/>
+    return (
+        <SectionBlock title="Account Settings">
+            {props.userId == props.accountId ?
+                <Fragment>
+                    <h1>{props.userName}</h1>
+                    <form action={props.documentRoot + "/account/" + props.accountId} method="post">
+                        <div className="form-group">
+                            <label htmlFor="email">Reset email</label>
+                            <input autoComplete="off" id="email" name="email" placeholder="New email" defaultValue=""
+                                    type="email"
+                                    className="form-control"/>
+                        </div>
+                        <div className="form-group">
+                            <label htmlFor="password">Reset password</label>
+                            <div className="form-row">
+                                <div className="col">
+                                    <input autoComplete="off" id="password" name="password" placeholder="New password"
+                                            defaultValue=""
+                                            type="password" className="form-control mb-1"/>
+                                </div>
+                                <div className="col">
+                                    <input autoComplete="off" id="password-confirmation" name="password-confirmation"
+                                            placeholder="New password confirmation" defaultValue="" type="password"
+                                            className="form-control"/>
+                                </div>
                             </div>
                         </div>
-                    </div>
-                    <div className="form-group">
-                        <label htmlFor = "current-password">Verify your identity</label>
-                        <input autoComplete=" off" id="current-password" name="current-password"
-                               placeholder="Current password" defaultValue="" type="password" className="form-control"/>
-                    </div>
-                    <input className="btn btn-outline-lightgreen btn-block" name="update-account"
-                           defaultValue="Update account settings" type="submit"/>
-                </form>
-            </div>
-        );
-    } else {
-        return (
-            <div id="account-form" className="col mb-3">
-                <h2 className="header px-0">Account Settings</h2>
-                <h1>{props.userName}</h1>
-            </div>
-        );
-    }
+                        <div className="form-group">
+                            <label htmlFor = "current-password">Verify your identity</label>
+                            <input autoComplete=" off" id="current-password" name="current-password"
+                                    placeholder="Current password" defaultValue="" type="password" className="form-control"/>
+                        </div>
+                        <input className="btn btn-outline-lightgreen btn-block" name="update-account"
+                                defaultValue="Update account settings" type="submit"/>
+                    </form>
+                </Fragment>
+        : 
+            <h1>{props.userName}</h1>
+        }
+        </SectionBlock>
+    );
 }
 
 export function renderAccountPage(args) {

--- a/src/main/resources/public/jsx/components/FormLayout.js
+++ b/src/main/resources/public/jsx/components/FormLayout.js
@@ -3,11 +3,13 @@ import React from 'react';
 
 function FormLayout({ title, children }) {
     return (
-        <div className="col-xl-6 col-lg-8 border bg-lightgray mb-5">
-            <div className="bg-darkgreen mb-3 no-container-margin">
-                <h1>{title}</h1>
+        <div class="row justify-content-center">
+            <div className="col-xl-6 col-lg-8 border bg-lightgray mb-5">
+                <div className="bg-darkgreen mb-3 no-container-margin">
+                    <h1>{title}</h1>
+                </div>
+                {children}
             </div>
-            {children}
         </div>
     )
 }

--- a/src/main/resources/public/jsx/components/FormLayout.js
+++ b/src/main/resources/public/jsx/components/FormLayout.js
@@ -1,0 +1,20 @@
+import React from 'react';
+// import PropTypes from 'prop-types'
+
+function FormLayout({ title, children }) {
+    return (
+        <div className="col-xl-6 col-lg-8 border bg-lightgray mb-5">
+            <div className="bg-darkgreen mb-3 no-container-margin">
+                <h1>{title}</h1>
+            </div>
+            {children}
+        </div>
+    )
+}
+
+// FIXME loading proptype breaks the component
+// FormLayout.propTypes = {
+//     title: PropTypes.string.isRequired,
+//     }
+
+export default FormLayout

--- a/src/main/resources/public/jsx/components/SectionBlock.js
+++ b/src/main/resources/public/jsx/components/SectionBlock.js
@@ -1,0 +1,19 @@
+import React from 'react';
+// import PropTypes from 'prop-types'
+
+function SectionBlock({ title, children }) {
+    return (
+        <div className={"row mb-3"}>
+            <div className="col">
+                <h2 className="header px-0">{title}</h2>
+                {children}
+            </div>
+        </div>
+    )
+}
+
+// SectionBlock.propTypes = {
+//     title: PropTypes.string.isRequired,
+//     }
+
+export default SectionBlock

--- a/src/main/resources/public/jsx/create-project.js
+++ b/src/main/resources/public/jsx/create-project.js
@@ -492,13 +492,13 @@ class Project extends React.Component {
             mercator.zoomMapToLayer(this.state.mapConfig, "currentAOI");
 
             // Get the new plotlist
-            this.showPlotCenters(projectId, 100);
+            this.showPlotCenters(projectId, 300);
         }
     }
 
     updateUnmanagedComponents(projectId) {
         if (this.state.templateDetails != null) {
-            if (this.state.imageryList.length > 0) {
+            if (this.state.imageryList && this.state.imageryList.length > 0) {
                 var detailsNew = this.state.templateDetails;
                 // If baseMapSource isn't provided by the project, just use the first entry in the imageryList
                 detailsNew.baseMapSource = this.state.templateDetails.baseMapSource || this.state.imageryList[0].title;
@@ -836,7 +836,7 @@ class PlotDesign extends React.Component {
                                         <small>Upload CSV</small>
                                         <input 
                                             type="file" accept="text/csv" id="plot-distribution-csv-file"
-                                            defaultVale=""
+                                            defaultValue=""
                                             name="plot-distribution-csv-file"
                                             onChange={this.encodeImageFileAsURL}
                                             style={{display: "none"}} 
@@ -855,7 +855,7 @@ class PlotDesign extends React.Component {
                                         <small>Upload SHP</small>
                                         <input 
                                             type="file" accept="application/zip" id="plot-distribution-shp-file"
-                                            defaultVale=""
+                                            defaultValue=""
                                             name="plot-distribution-shp-file"
                                             onChange={this.encodeImageFileAsURL}
                                             style={{display: "none"}} 
@@ -983,7 +983,7 @@ class SampleDesign extends React.Component{
                             <small>Upload CSV</small>
                             <input type="file" accept="text/csv" id="sample-distribution-csv-file"
                                     name="sample-distribution-csv-file"
-                                    defaultVale=""
+                                    defaultValue=""
                                     onChange={this.encodeImageFileAsURL}
                                     style={{display: "none"}} 
                                     disabled={sampleDistribution != 'csv'}
@@ -1002,7 +1002,7 @@ class SampleDesign extends React.Component{
                             <small>Upload SHP</small>
                             <input type="file" accept="application/zip" id="sample-distribution-shp-file"
                                     name="sample-distribution-shp-file"
-                                    defaultVale=""
+                                    defaultValue=""
                                     onChange={this.encodeImageFileAsURL}
                                     style={{display: "none"}} 
                                     disabled = {sampleDistribution != 'shp'}

--- a/src/main/resources/public/jsx/create-project.js
+++ b/src/main/resources/public/jsx/create-project.js
@@ -1,11 +1,10 @@
 import React, { Fragment } from 'react';
 import ReactDOM from 'react-dom';
-import { mercator, ceoMapStyles } from "../js/mercator-openlayers.js";
 
-import { utils } from "../js/utils.js";
 import FormLayout from "./components/FormLayout"
 import SectionBlock from "./components/SectionBlock"
-
+import { mercator, ceoMapStyles } from "../js/mercator-openlayers.js";
+import { utils } from "../js/utils.js";
 
 class Project extends React.Component {
     constructor(props) {
@@ -62,7 +61,6 @@ class Project extends React.Component {
             var formData = new FormData(document.getElementById("project-design-form"));
             formData.append("institution", this.props.institutionId);
             formData.append("sample-values", JSON.stringify(this.state.templateDetails.sampleValues));
-            console.log(formData);
             var ref = this;
             $.ajax({
                 url: this.props.documentRoot + "/create-project",
@@ -719,28 +717,36 @@ function ProjectAOI({ project: { latMax, lonMin, lonMax, latMin } }) {
                     <div className="form-group mx-4">
                         <div className="row">
                             <div className="col-md-6 offset-md-3">
-                                <input className="form-control form-control-sm" type="number" id="lat-max" name="lat-max"
+                                <input 
+                                    className="form-control form-control-sm" type="number" id="lat-max" name="lat-max"
                                     defaultValue={latMax} placeholder="North" autoComplete="off" min="-90.0"
-                                    max="90.0" step="any"/>
+                                    max="90.0" step="any"
+                                />
                             </div>
                         </div>
                         <div className="row">
                             <div className="col-md-6">
-                                <input className="form-control form-control-sm" type="number" id="lon-min" name="lon-min"
+                                <input 
+                                    className="form-control form-control-sm" type="number" id="lon-min" name="lon-min"
                                     defaultValue={lonMin} placeholder="West" autoComplete="off" min="-180.0"
-                                    max="180.0" step="any"/>
+                                    max="180.0" step="any"
+                                />
                             </div>
                             <div className="col-md-6">
-                                <input className="form-control form-control-sm" type="number" id="lon-max" name="lon-max"
+                                <input 
+                                    className="form-control form-control-sm" type="number" id="lon-max" name="lon-max"
                                     defaultValue={lonMax} placeholder="East" autoComplete="off" min="-180.0"
-                                    max="180.0" step="any"/>
+                                    max="180.0" step="any"
+                                />
                             </div>
                         </div>
                         <div className="row">
                             <div className="col-md-6 offset-md-3">
-                                <input className="form-control form-control-sm" type="number" id="lat-min" name="lat-min"
+                                <input 
+                                    className="form-control form-control-sm" type="number" id="lat-min" name="lat-min"
                                     defaultValue={latMin} placeholder="South" autoComplete="off" min="-90.0"
-                                    max="90.0" step="any"/>
+                                    max="90.0" step="any"
+                                />
                             </div>
                         </div>
                     </div>
@@ -757,13 +763,13 @@ function ProjectImagery({ project, setBaseMapSource }) {
                 <div className="form-group">
                     <h3 htmlFor="base-map-source">Basemap Source</h3>
                     <select className="form-control form-control-sm" id="base-map-source" name="base-map-source"
-                            size="1"
-                            value={project.templateDetails && project.templateDetails.baseMapSource != null 
-                                    ? project.templateDetails.baseMapSource 
-                                    : ""} 
-                            onChange={setBaseMapSource}>
+                        size="1"
+                        value={project.templateDetails && project.templateDetails.baseMapSource != null
+                            ? project.templateDetails.baseMapSource
+                            : ""}
+                        onChange={setBaseMapSource}>
                         {
-                            project.imageryList.map((imagery,uid) =>
+                            project.imageryList.map((imagery, uid) =>
                                 <option key={uid} value={imagery.title}>{imagery.title}</option>
                             )
                         }
@@ -775,163 +781,248 @@ function ProjectImagery({ project, setBaseMapSource }) {
 }
 
 class PlotDesign extends React.Component {
-    constructor(props) {
-        super(props);
+  constructor(props) {
+    super(props);
+  }
+
+  encodeImageFileAsURL(event) {
+    var file = event.target.files[0];
+    let reader = new FileReader();
+    reader.onloadend = function() {
+      let base64Data = reader.result;
+      console.log("RESULT", base64Data);
     };
+    reader.readAsDataURL(file);
+  }
 
-    encodeImageFileAsURL(event) {
-        var file = event.target.files[0];
-        let reader = new FileReader();
-        reader.onloadend = function () {
-            let base64Data = reader.result;
-            console.log('RESULT', base64Data);
-        };
-        reader.readAsDataURL(file);
-    }
+  render() {
+    var {
+      project: {
+        useTemplatePlots,
+        templateDetails,
+        templateDetails: { plotDistribution, plotShape }
+      }
+    } = this.props;
+    return (
+      <SectionBlock title="Plot Design">
+        <div id="plot-design">
+          <div className="row">
+            <div id="plot-design-col1" className="col">
+              <h3>Template Plots</h3>
+              <div className="form-check form-check-inline">
+                <input
+                  className="form-check-input"
+                  type="checkbox"
+                  id="use-template-plots"
+                  name="use-template-plots"
+                  defaultValue={useTemplatePlots}
+                  onChange={() =>
+                    this.props.setTemplatePlots(!useTemplatePlots)
+                  }
+                  checked={useTemplatePlots}
+                />
+                <label
+                  className="form-check-label small"
+                  htmlFor="use-template-plots"
+                >
+                  Use Template Plots and Samples
+                </label>
+              </div>
 
-    render() {
-        var { project: { useTemplatePlots, templateDetails, templateDetails : { plotDistribution, plotShape }}} = this.props;
-        return (
-            <SectionBlock title="Plot Design">
-                <div id="plot-design">
-                    <div className="row">
-                        <div id="plot-design-col1" className="col">
-                            <h3>Template Plots</h3>
-                            <div className="form-check form-check-inline">
-                                <input className="form-check-input" type="checkbox" id="use-template-plots"
-                                        name="use-template-plots" defaultValue={useTemplatePlots}
-                                        onChange={() => this.props.setTemplatePlots(!useTemplatePlots)}
-                                        checked={useTemplatePlots}/>
-                                <label className="form-check-label small"
-                                        htmlFor="use-template-plots">Use Template Plots and Samples</label>
-                            </div>
+              {!useTemplatePlots && (
+                <Fragment>
+                  <h3>Spatial Distribution</h3>
+                  <div className="form-check form-check-inline">
+                    <input
+                      className="form-check-input"
+                      type="radio"
+                      id="plot-distribution-random"
+                      name="plot-distribution"
+                      defaultValue="random"
+                      onChange={() => this.props.setPlotDistribution("random")}
+                      checked={plotDistribution === "random"}
+                    />
+                    <label
+                      className="form-check-label small"
+                      htmlFor="plot-distribution-random"
+                    >
+                      Random
+                    </label>
+                  </div>
+                  <div className="form-check form-check-inline">
+                    <input
+                      className="form-check-input"
+                      type="radio"
+                      id="plot-distribution-gridded"
+                      name="plot-distribution"
+                      defaultValue="gridded"
+                      onChange={() => this.props.setPlotDistribution("gridded")}
+                      checked={plotDistribution === "gridded"}
+                    />
+                    <label
+                      className="form-check-label small"
+                      htmlFor="plot-distribution-gridded"
+                    >
+                      Gridded
+                    </label>
+                  </div>
+                  <div className="form-check form-check-inline">
+                    <input
+                      className="form-check-input"
+                      type="radio"
+                      id="plot-distribution-csv"
+                      name="plot-distribution"
+                      defaultValue="csv"
+                      onChange={() => this.props.setPlotDistribution("csv")}
+                      checked={plotDistribution === "csv"}
+                    />
+                    <label
+                      className="btn btn-sm btn-block btn-outline-lightgreen btn-file py-0 my-0"
+                      id="custom-csv-upload"
+                    >
+                      <small>Upload CSV</small>
+                      <input
+                        type="file"
+                        accept="text/csv"
+                        id="plot-distribution-csv-file"
+                        defaultValue=""
+                        name="plot-distribution-csv-file"
+                        onChange={this.encodeImageFileAsURL}
+                        style={{ display: "none" }}
+                        disabled={plotDistribution != "csv"}
+                      />
+                    </label>
+                  </div>
+                  <div className="form-check form-check-inline">
+                    <input
+                      className="form-check-input"
+                      type="radio"
+                      id="plot-distribution-shp"
+                      name="plot-distribution"
+                      defaultValue="shp"
+                      onChange={() => this.props.setPlotDistribution("shp")}
+                      checked={plotDistribution === "shp"}
+                    />
+                    <label
+                      className="btn btn-sm btn-block btn-outline-lightgreen btn-file py-0 my-0"
+                      id="custom-shp-upload"
+                    >
+                      <small>Upload SHP</small>
+                      <input
+                        type="file"
+                        accept="application/zip"
+                        id="plot-distribution-shp-file"
+                        defaultValue=""
+                        name="plot-distribution-shp-file"
+                        onChange={this.encodeImageFileAsURL}
+                        style={{ display: "none" }}
+                        disabled={plotDistribution != "shp"}
+                      />
+                    </label>
+                  </div>
+                  <p id="plot-design-text">
+                    {plotDistribution === "random" &&
+                      "Plot centers will be randomly distributed within the AOI."}
+                    {plotDistribution === "gridded" &&
+                      "Plot centers will be arranged on a grid within the AOI using the plot spacing selected below."}
+                    {plotDistribution === "csv" &&
+                      "Specify your own plot centers by uploading a CSV with these fields: LONGITUDE,LATITUDE,PLOTID."}
+                    {plotDistribution === "shp" &&
+                      "Specify your own plot boundaries by uploading a zipped Shapefile (containing SHP, SHX, DBF, and PRJ files) of polygon features. Each feature must have a unique PLOTID field."}
+                  </p>
 
-                            {!useTemplatePlots &&
-                            <Fragment>
-                                <h3>Spatial Distribution</h3>
-                                <div className="form-check form-check-inline">
-                                    <input className="form-check-input" type="radio" id="plot-distribution-random"
-                                            name="plot-distribution" defaultValue="random"
-                                            onChange={() => this.props.setPlotDistribution('random')}
-                                            checked={plotDistribution === 'random'}/>
-                                    <label className="form-check-label small"
-                                            htmlFor="plot-distribution-random">Random</label>
-                                </div>
-                                <div className="form-check form-check-inline">
-                                    <input className="form-check-input" type="radio" id="plot-distribution-gridded"
-                                            name="plot-distribution" defaultValue="gridded"
-                                            onChange={() => this.props.setPlotDistribution('gridded')}
-                                            checked={plotDistribution === 'gridded'}/>
-                                    <label className="form-check-label small"
-                                            htmlFor="plot-distribution-gridded">Gridded</label>
-                                </div>
-                                <div className="form-check form-check-inline">
-                                    <input className="form-check-input" type="radio" id="plot-distribution-csv"
-                                            name="plot-distribution" defaultValue="csv"
-                                            onChange={() => this.props.setPlotDistribution('csv')}
-                                            checked={plotDistribution === 'csv'}/>
-                                    <label
-                                        className="btn btn-sm btn-block btn-outline-lightgreen btn-file py-0 my-0"
-                                        id="custom-csv-upload">
-                                        <small>Upload CSV</small>
-                                        <input 
-                                            type="file" accept="text/csv" id="plot-distribution-csv-file"
-                                            defaultValue=""
-                                            name="plot-distribution-csv-file"
-                                            onChange={this.encodeImageFileAsURL}
-                                            style={{display: "none"}} 
-                                            disabled={plotDistribution != 'csv'}
-                                        />
-                                    </label>
-                                </div>
-                                <div className="form-check form-check-inline">
-                                    <input className="form-check-input" type="radio" id="plot-distribution-shp"
-                                            name="plot-distribution" defaultValue="shp"
-                                            onChange={() => this.props.setPlotDistribution('shp')}
-                                            checked={plotDistribution === 'shp'}/>
-                                    <label
-                                        className="btn btn-sm btn-block btn-outline-lightgreen btn-file py-0 my-0"
-                                        id="custom-shp-upload">
-                                        <small>Upload SHP</small>
-                                        <input 
-                                            type="file" accept="application/zip" id="plot-distribution-shp-file"
-                                            defaultValue=""
-                                            name="plot-distribution-shp-file"
-                                            onChange={this.encodeImageFileAsURL}
-                                            style={{display: "none"}} 
-                                            disabled = {plotDistribution != 'shp'}/>
-                                    </label>
-                                </div>
-                                <p id="plot-design-text">
-                                    {plotDistribution === 'random' && 
-                                        'Plot centers will be randomly distributed within the AOI.'}
-                                    {plotDistribution === 'gridded' && 
-                                        'Plot centers will be arranged on a grid within the AOI using the plot spacing selected below.'}
-                                    {plotDistribution === 'csv' && 
-                                        'Specify your own plot centers by uploading a CSV with these fields: LONGITUDE,LATITUDE,PLOTID.'}
-                                    {plotDistribution === 'shp' && 
-                                        'Specify your own plot boundaries by uploading a zipped Shapefile (containing SHP, SHX, DBF, and PRJ files) of polygon features. Each feature must have a unique PLOTID field.'}
-                                </p>
-
-                                <div className="form-group mb-1">
-                                    <p htmlFor="num-plots">Number of plots</p>
-                                    <input className="form-control form-control-sm" type="number" id="num-plots"
-                                            name="num-plots" autoComplete="off" min="0" step="1"
-                                            defaultValue={templateDetails.numPlots || ""}
-                                            disabled={plotDistribution != 'random'}
-                                        />
-                                </div>
-                                <div className="form-group mb-1">
-                                    <p htmlFor="plot-spacing">Plot spacing (m)</p>
-                                    <input className="form-control form-control-sm" type="number" id="plot-spacing"
-                                            name="plot-spacing" autoComplete="off" min="0.0" step="any"
-                                            defaultValue={templateDetails.plotSpacing || ""}
-                                            disabled={plotDistribution != 'gridded'}
-                                            />
-                                </div>
-                                <hr/>
-                                <h3>Plot Shape</h3>
-                                <div className="form-check form-check-inline">
-                                    <input className="form-check-input" type="radio" id="plot-shape-circle"
-                                            name="plot-shape" defaultValue="circle"
-                                            onChange={() => this.props.setPlotShape('circle')}
-                                            checked={plotShape === 'circle'}
-                                            disabled ={plotDistribution === 'shp'}
-                                            />
-                                    <label className="form-check-label small"
-                                            htmlFor="plot-shape-circle">Circle</label>
-                                </div>
-                                <div className="form-check form-check-inline">
-                                    <input className="form-check-input" type="radio" id="plot-shape-square"
-                                            name="plot-shape" defaultValue="square"
-                                            onChange={() => this.props.setPlotShape('square')}
-                                            checked={plotShape === 'square'}
-                                            disabled ={plotDistribution === 'shp'}
-                                            />
-                                    <label className="form-check-label small"
-                                            htmlFor="plot-shape-square">Square</label>
-                                </div>
-                                <p htmlFor="plot-size">
-                                    {plotShape == 'circle' ? 'Diameter (m)' : 'Width (m)'}
-                                </p>
-                                <input className="form-control form-control-sm" type="number" id="plot-size"
-                                    name="plot-size" autoComplete="off" min="0.0" step="any"
-                                    defaultValue={templateDetails.plotSize}
-                                    disabled ={plotDistribution === 'shp'}
-                                    />
-                            </Fragment>
-                        }
-                        </div>
-                    </div>
-                </div>
-            </SectionBlock>
-        );
-    }
-
+                  <div className="form-group mb-1">
+                    <p htmlFor="num-plots">Number of plots</p>
+                    <input
+                      className="form-control form-control-sm"
+                      type="number"
+                      id="num-plots"
+                      name="num-plots"
+                      autoComplete="off"
+                      min="0"
+                      step="1"
+                      defaultValue={templateDetails.numPlots || ""}
+                      disabled={plotDistribution != "random"}
+                    />
+                  </div>
+                  <div className="form-group mb-1">
+                    <p htmlFor="plot-spacing">Plot spacing (m)</p>
+                    <input
+                      className="form-control form-control-sm"
+                      type="number"
+                      id="plot-spacing"
+                      name="plot-spacing"
+                      autoComplete="off"
+                      min="0.0"
+                      step="any"
+                      defaultValue={templateDetails.plotSpacing || ""}
+                      disabled={plotDistribution != "gridded"}
+                    />
+                  </div>
+                  <hr />
+                  <h3>Plot Shape</h3>
+                  <div className="form-check form-check-inline">
+                    <input
+                      className="form-check-input"
+                      type="radio"
+                      id="plot-shape-circle"
+                      name="plot-shape"
+                      defaultValue="circle"
+                      onChange={() => this.props.setPlotShape("circle")}
+                      checked={plotShape === "circle"}
+                      disabled={plotDistribution === "shp"}
+                    />
+                    <label
+                      className="form-check-label small"
+                      htmlFor="plot-shape-circle"
+                    >
+                      Circle
+                    </label>
+                  </div>
+                  <div className="form-check form-check-inline">
+                    <input
+                      className="form-check-input"
+                      type="radio"
+                      id="plot-shape-square"
+                      name="plot-shape"
+                      defaultValue="square"
+                      onChange={() => this.props.setPlotShape("square")}
+                      checked={plotShape === "square"}
+                      disabled={plotDistribution === "shp"}
+                    />
+                    <label
+                      className="form-check-label small"
+                      htmlFor="plot-shape-square"
+                    >
+                      Square
+                    </label>
+                  </div>
+                  <p htmlFor="plot-size">
+                    {plotShape == "circle" ? "Diameter (m)" : "Width (m)"}
+                  </p>
+                  <input
+                    className="form-control form-control-sm"
+                    type="number"
+                    id="plot-size"
+                    name="plot-size"
+                    autoComplete="off"
+                    min="0.0"
+                    step="any"
+                    defaultValue={templateDetails.plotSize}
+                    disabled={plotDistribution === "shp"}
+                  />
+                </Fragment>
+              )}
+            </div>
+          </div>
+        </div>
+      </SectionBlock>
+    );
+  }
 }
 
 
-class SampleDesign extends React.Component{
+class SampleDesign extends React.Component {
     constructor(props) {
         super(props);
     };
@@ -944,94 +1035,107 @@ class SampleDesign extends React.Component{
         };
         reader.readAsDataURL(file);
     }
-    render()
-    {
-        const { project: { templateDetails : { plotDistribution, sampleDistribution, samplesPerPlot, sampleResolution }}} = this.props;
+    render() {
+        const { project: { templateDetails: { plotDistribution, sampleDistribution, samplesPerPlot, sampleResolution } } } = this.props;
         return (
             <SectionBlock title="Sample Design">
                 <div id="sample-design">
                     <h3>Spatial Distribution</h3>
                     <div className="form-check form-check-inline">
-                        <input className="form-check-input" type="radio" id="sample-distribution-random"
-                                name="sample-distribution" defaultValue="random"
-                                onChange={() => this.props.setSampleDistribution('random')}
-                                checked={sampleDistribution === 'random'}
-                                disabled={plotDistribution === 'shp'}
-                                />
+                        <input
+                            className="form-check-input" type="radio" id="sample-distribution-random"
+                            name="sample-distribution" defaultValue="random"
+                            onChange={() => this.props.setSampleDistribution('random')}
+                            checked={sampleDistribution === 'random'}
+                            disabled={plotDistribution === 'shp'}
+                        />
                         <label className="form-check-label small"
-                                htmlFor="sample-distribution-random">Random</label>
+                            htmlFor="sample-distribution-random">
+                            Random
+                        </label>
                     </div>
                     <div className="form-check form-check-inline">
-                        <input className="form-check-input" type="radio" id="sample-distribution-gridded"
-                                name="sample-distribution" defaultValue="gridded"
-                                onChange={() => this.props.setSampleDistribution('gridded')}
-                                checked={sampleDistribution === 'gridded'}
-                                disabled={plotDistribution === 'shp'}
-                                />
+                        <input
+                            className="form-check-input" type="radio" id="sample-distribution-gridded"
+                            name="sample-distribution" defaultValue="gridded"
+                            onChange={() => this.props.setSampleDistribution('gridded')}
+                            checked={sampleDistribution === 'gridded'}
+                            disabled={plotDistribution === 'shp'}
+                        />
                         <label className="form-check-label small"
-                                htmlFor="sample-distribution-gridded">Gridded</label>
+                            htmlFor="sample-distribution-gridded">
+                            Gridded
+                        </label>
                     </div>
                     <div className="form-check form-check-inline">
-                        <input className="form-check-input" type="radio" id="sample-distribution-csv"
-                                name="sample-distribution" defaultValue="csv"
-                                onChange={() => this.props.setSampleDistribution('csv')}
-                                checked={sampleDistribution === 'csv'}
-                                disabled={plotDistribution === 'random' || plotDistribution === 'gridded'}
-                                />
+                        <input
+                            className="form-check-input" type="radio" id="sample-distribution-csv"
+                            name="sample-distribution" defaultValue="csv"
+                            onChange={() => this.props.setSampleDistribution('csv')}
+                            checked={sampleDistribution === 'csv'}
+                            disabled={plotDistribution === 'random' || plotDistribution === 'gridded'}
+                        />
                         <label className="btn btn-sm btn-block btn-outline-lightgreen btn-file py-0 my-0"
-                                id="sample-custom-csv-upload">
+                            id="sample-custom-csv-upload">
                             <small>Upload CSV</small>
-                            <input type="file" accept="text/csv" id="sample-distribution-csv-file"
-                                    name="sample-distribution-csv-file"
-                                    defaultValue=""
-                                    onChange={this.encodeImageFileAsURL}
-                                    style={{display: "none"}} 
-                                    disabled={sampleDistribution != 'csv'}
+                            <input 
+                                type="file" accept="text/csv" id="sample-distribution-csv-file"
+                                name="sample-distribution-csv-file"
+                                defaultValue=""
+                                onChange={this.encodeImageFileAsURL}
+                                style={{ display: "none" }}
+                                disabled={sampleDistribution != 'csv'}
                             />
                         </label>
                     </div>
                     <div className="form-check form-check-inline">
-                        <input className="form-check-input" type="radio" id="sample-distribution-shp"
-                                name="sample-distribution" defaultValue="shp"
-                                onChange={() => this.props.setSampleDistribution('shp')}
-                                checked={sampleDistribution === 'shp'}
-                                disabled={plotDistribution === 'random' || plotDistribution === 'gridded'}
-                                />
+                        <input
+                            className="form-check-input" type="radio" id="sample-distribution-shp"
+                            name="sample-distribution" defaultValue="shp"
+                            onChange={() => this.props.setSampleDistribution('shp')}
+                            checked={sampleDistribution === 'shp'}
+                            disabled={plotDistribution === 'random' || plotDistribution === 'gridded'}
+                        />
                         <label className="btn btn-sm btn-block btn-outline-lightgreen btn-file py-0 my-0"
-                                id="sample-custom-shp-upload">
+                            id="sample-custom-shp-upload">
                             <small>Upload SHP</small>
-                            <input type="file" accept="application/zip" id="sample-distribution-shp-file"
-                                    name="sample-distribution-shp-file"
-                                    defaultValue=""
-                                    onChange={this.encodeImageFileAsURL}
-                                    style={{display: "none"}} 
-                                    disabled = {sampleDistribution != 'shp'}
-                                    />
+                            <input
+                                type="file" accept="application/zip" id="sample-distribution-shp-file"
+                                name="sample-distribution-shp-file"
+                                defaultValue=""
+                                onChange={this.encodeImageFileAsURL}
+                                style={{ display: "none" }}
+                                disabled={sampleDistribution != 'shp'}
+                            />
                         </label>
                     </div>
                     <p id="sample-design-text">
-                    {sampleDistribution === 'random' && 
-                        'Sample points will be randomly distributed within the plot boundary.'}
-                    {sampleDistribution === 'gridded' && 
-                        'Sample points will be arranged on a grid within the plot boundary using the sample resolution selected below.'}
-                    {sampleDistribution === 'csv' && 
-                        'Specify your own sample points by uploading a CSV with these fields: LONGITUDE,LATITUDE,PLOTID,SAMPLEID.'}
-                    {sampleDistribution === 'shp' && 
-                        'Specify your own sample shapes by uploading a zipped Shapefile (containing SHP, SHX, DBF, and PRJ files) of polygon features. Each feature must have PLOTID and SAMPLEID fields.'}
+                        {sampleDistribution === 'random' &&
+                            'Sample points will be randomly distributed within the plot boundary.'}
+                        {sampleDistribution === 'gridded' &&
+                            'Sample points will be arranged on a grid within the plot boundary using the sample resolution selected below.'}
+                        {sampleDistribution === 'csv' &&
+                            'Specify your own sample points by uploading a CSV with these fields: LONGITUDE,LATITUDE,PLOTID,SAMPLEID.'}
+                        {sampleDistribution === 'shp' &&
+                            'Specify your own sample shapes by uploading a zipped Shapefile (containing SHP, SHX, DBF, and PRJ files) of polygon features. Each feature must have PLOTID and SAMPLEID fields.'}
                     </p>
                     <div className="form-group mb-1">
                         <p htmlFor="samples-per-plot">Samples per plot</p>
-                        <input className="form-control form-control-sm" type="number" id="samples-per-plot"
-                                name="samples-per-plot" autoComplete="off" min="0" step="1"
-                                defaultValue={samplesPerPlot || ""}
-                                disabled={sampleDistribution != 'random'}/>
+                        <input
+                            className="form-control form-control-sm" type="number" id="samples-per-plot"
+                            name="samples-per-plot" autoComplete="off" min="0" step="1"
+                            defaultValue={samplesPerPlot || ""}
+                            disabled={sampleDistribution != 'random'}
+                        />
                     </div>
                     <div className="form-group mb-1">
                         <p htmlFor="sample-resolution">Sample resolution (m)</p>
-                        <input className="form-control form-control-sm" type="number" id="sample-resolution"
-                                name="sample-resolution" autoComplete="off" min="0.0" step="any"
-                                defaultValue={sampleResolution || ""} 
-                                disabled={sampleDistribution != 'gridded'}/>
+                        <input
+                            className="form-control form-control-sm" type="number" id="sample-resolution"
+                            name="sample-resolution" autoComplete="off" min="0.0" step="any"
+                            defaultValue={sampleResolution || ""}
+                            disabled={sampleDistribution != 'gridded'}
+                        />
                     </div>
                 </div>
             </SectionBlock>
@@ -1069,13 +1173,14 @@ function SurveyDesign(props){
                                 <label htmlFor="value-parent">Parent Question:</label>
                             </td>
                             <td>
-                                <select id="value-parent" className="form-control form-control-sm" size="1"
-                                        onChange={(e) => props.handleInputParent(e)}>
+                                <select
+                                    id="value-parent" className="form-control form-control-sm" size="1"
+                                    onChange={(e) => props.handleInputParent(e)}>
                                     <option value="">None</option>
                                     {
                                         (props.project.templateDetails.sampleValues).map((parentSurveyQuestion, uid) =>
                                             <option key={uid}
-                                                    value={parentSurveyQuestion.id}>{parentSurveyQuestion.question}
+                                                value={parentSurveyQuestion.id}>{parentSurveyQuestion.question}
                                             </option>
                                         )
                                     }
@@ -1139,8 +1244,8 @@ class SurveyQuestionTree extends React.Component {
     }
 }
 
-function SurveyQuestion({ parentProps, parentProps: { project }, surveyQuestion}) {
-    if(surveyQuestion.answers==null){
+function SurveyQuestion({ parentProps, parentProps: { project }, surveyQuestion }) {
+    if (surveyQuestion.answers == null) {
         console.log("answers null");
     }
     return (
@@ -1154,22 +1259,22 @@ function SurveyQuestion({ parentProps, parentProps: { project }, surveyQuestion}
             </h3>
             <table className="table table-sm">
                 <thead>
-                <tr>
-                    <th scope="col"></th>
-                    <th scope="col">Answer</th>
-                    <th scope="col">Color</th>
-                    <th scope="col">&nbsp;</th>
-                </tr>
+                    <tr>
+                        <th scope="col"></th>
+                        <th scope="col">Answer</th>
+                        <th scope="col">Color</th>
+                        <th scope="col">&nbsp;</th>
+                    </tr>
                 </thead>
                 <tbody>
-                {
+                    {
 
-                    (surveyQuestion.answers).map((surveyAnswer, uid) => {
+                        (surveyQuestion.answers).map((surveyAnswer, uid) => {
 
                             return <tr key={uid}>
                                 <td>
-                                    {surveyAnswer && 
-                                        <RemoveSurveyQuestionRowButton 
+                                    {surveyAnswer &&
+                                        <RemoveSurveyQuestionRowButton
                                             removeSurveyQuestionRow={parentProps.removeSurveyQuestionRow}
                                             surveyQuestion={surveyQuestion}
                                             surveyAnswer={surveyAnswer}
@@ -1182,24 +1287,24 @@ function SurveyQuestion({ parentProps, parentProps: { project }, surveyQuestion}
                                 </td>
                                 <td>
                                     <div className="circle"
-                                            style={{backgroundColor: surveyAnswer.color, border: "solid 1px"}}></div>
+                                        style={{ backgroundColor: surveyAnswer.color, border: "solid 1px" }}></div>
                                 </td>
                                 <td>
                                     &nbsp;
                                 </td>
                             </tr>
                         }
-                    )
-                }
-                <SurveyQuestionTable 
-                    project={project}
-                    surveyQuestion={surveyQuestion}
-                    getParentSurveyQuestions={parentProps.getParentSurveyQuestions}
-                    addSurveyQuestionRow={parentProps.addSurveyQuestionRow}
-                    handleInputName={parentProps.handleInputName}
-                    handleInputColor={parentProps.handleInputColor}
-                    handleInputParent={parentProps.handleInputParent}
-                />
+                        )
+                    }
+                    <SurveyQuestionTable
+                        project={project}
+                        surveyQuestion={surveyQuestion}
+                        getParentSurveyQuestions={parentProps.getParentSurveyQuestions}
+                        addSurveyQuestionRow={parentProps.addSurveyQuestionRow}
+                        handleInputName={parentProps.handleInputName}
+                        handleInputColor={parentProps.handleInputColor}
+                        handleInputParent={parentProps.handleInputParent}
+                    />
                 </tbody>
             </table>
         </div>

--- a/src/main/resources/public/jsx/create-project.js
+++ b/src/main/resources/public/jsx/create-project.js
@@ -1,8 +1,11 @@
 import React, { Fragment } from 'react';
 import ReactDOM from 'react-dom';
 import { mercator, ceoMapStyles } from "../js/mercator-openlayers.js";
-// FIXME use props instead of directly modifying DOM elements
+
 import { utils } from "../js/utils.js";
+import FormLayout from "./components/FormLayout"
+import SectionBlock from "./components/SectionBlock"
+
 
 class Project extends React.Component {
     constructor(props) {
@@ -495,15 +498,6 @@ class Project extends React.Component {
 
     updateUnmanagedComponents(projectId) {
         if (this.state.templateDetails != null) {
-            // Enable the input fields that are connected to the radio buttons if their values are not null
-            
-            if (this.state.templateDetails.plotDistribution == "gridded") {
-                utils.enable_element("plot-spacing");
-            }
-            if (this.state.templateDetails.sampleDistribution == "gridded") {
-                utils.enable_element("sample-resolution");
-            }
-
             if (this.state.imageryList.length > 0) {
                 var detailsNew = this.state.templateDetails;
                 // If baseMapSource isn't provided by the project, just use the first entry in the imageryList
@@ -553,30 +547,34 @@ class Project extends React.Component {
 
     render() {
         return (
-            <div id="project-design" className="col-xl-6 col-lg-8 border bg-lightgray mb-5">
-                <div className="bg-darkgreen mb-3 no-container-margin">
-                    <h1>Create Project</h1>
-                </div>
-                <ProjectDesignForm project={this.state}
-                                   project_template_visibility={true}
-                                   setProjectTemplate={this.setProjectTemplate} setPrivacyLevel={this.setPrivacyLevel}
-                                   setSampleDistribution={this.setSampleDistribution}
-                                   addSurveyQuestionRow={this.addSurveyQuestionRow}
-                                   setBaseMapSource={this.setBaseMapSource}
-                                   setPlotDistribution={this.setPlotDistribution} 
-                                   setPlotShape={this.setPlotShape}
-                                   setTemplatePlots={this.setTemplatePlots}
-                                   addSurveyQuestion={this.addSurveyQuestion}
-                                   topoSort={this.topoSort} getParentSurveyQuestions={this.getParentSurveyQuestions} getParentSurveyQuestionAnswers={this.getParentSurveyQuestionAnswers}
-                                   removeSurveyQuestion={this.removeSurveyQuestion}
-                                   removeSurveyQuestionRow={this.removeSurveyQuestionRow}
-                                   handleInputColor={this.handleInputColor} handleInputName={this.handleInputName}
-                                   handleChange={this.handleChange} handleInputParent={this.handleInputParent}/>
-                <ProjectManagement project={this.state}
-                                   configureGeoDash={this.configureGeoDash} downloadPlotData={this.downloadPlotData}
-                                   downloadSampleData={this.downloadSampleData}
-                                   createProject={this.createProject}/>
-            </div>
+            <FormLayout id="project-design" title="Create Project">
+                {this.state.templateDetails && 
+                    <Fragment>
+                        <ProjectDesignForm 
+                            project={this.state}
+                            setProjectTemplate={this.setProjectTemplate} 
+                            setPrivacyLevel={this.setPrivacyLevel}
+                            setSampleDistribution={this.setSampleDistribution}
+                            addSurveyQuestionRow={this.addSurveyQuestionRow}
+                            setBaseMapSource={this.setBaseMapSource}
+                            setPlotDistribution={this.setPlotDistribution} 
+                            setPlotShape={this.setPlotShape}
+                            setTemplatePlots={this.setTemplatePlots}
+                            addSurveyQuestion={this.addSurveyQuestion}
+                            topoSort={this.topoSort} 
+                            getParentSurveyQuestions={this.getParentSurveyQuestions} 
+                            getParentSurveyQuestionAnswers={this.getParentSurveyQuestionAnswers}
+                            removeSurveyQuestion={this.removeSurveyQuestion}
+                            removeSurveyQuestionRow={this.removeSurveyQuestionRow}
+                            handleInputColor={this.handleInputColor} 
+                            handleInputName={this.handleInputName}
+                            handleChange={this.handleChange} 
+                            handleInputParent={this.handleInputParent}
+                        />
+                        <ProjectManagement project={this.state} createProject={this.createProject} />
+                    </Fragment>
+                }
+            </FormLayout>
         );
     }
 }
@@ -586,59 +584,45 @@ function ProjectDesignForm(props) {
         <form id="project-design-form" className="px-2 pb-2" method="post"
               action={props.documentRoot + "/create-project"}
               encType="multipart/form-data">
-            {props.project.templateDetails && 
-                <Fragment>
-                    {props.project.projectList && 
-                        <ProjectTemplateVisibility 
-                            project={props.project} 
-                            setProjectTemplate={props.setProjectTemplate} 
-                        />
-                    }
-                    <ProjectInfo project={props.project} handleChange={props.handleChange}/>
-                    <ProjectVisibility project={props.project} setPrivacyLevel={props.setPrivacyLevel}/>
-                    <ProjectAOI project={props.project}/>
-                    {props.project.imageryList && 
-                        <ProjectImagery project={props.project} setBaseMapSource={props.setBaseMapSource}/>
-                    }
-                    <PlotDesign 
+        
+                {props.project.projectList && 
+                    <ProjectTemplateVisibility 
                         project={props.project} 
-                        useTemplatePlots={props.useTemplatePlots}
-                        setPlotDistribution={props.setPlotDistribution}
-                        setPlotShape={props.setPlotShape}
-                        setTemplatePlots={props.setTemplatePlots}
+                        setProjectTemplate={props.setProjectTemplate} 
                     />
-                    {!props.project.useTemplatePlots && 
-                        <SampleDesign project={props.project} setSampleDistribution={props.setSampleDistribution}/>
-                    }
-                    <SurveyDesign 
-                        project={props.project}
-                        addSurveyQuestionRow={props.addSurveyQuestionRow}
-                        addSurveyQuestion ={props.addSurveyQuestion} 
-                        topoSort={props.topoSort}
-                        getParentSurveyQuestions={props.getParentSurveyQuestions} 
-                        getParentSurveyQuestionAnswers={props.getParentSurveyQuestionAnswers}
-                        removeSurveyQuestion={props.removeSurveyQuestion}
-                        removeSurveyQuestionRow={props.removeSurveyQuestionRow}
-                        handleInputColor={props.handleInputColor}
-                        handleInputName={props.handleInputName}
-                        handleInputParent={props.handleInputParent}
-                    />
-                </Fragment>
-            }
+                }
+                <ProjectInfo project={props.project} handleChange={props.handleChange}/>
+                <ProjectVisibility project={props.project} setPrivacyLevel={props.setPrivacyLevel}/>
+                <ProjectAOI project={props.project}/>
+                {props.project.imageryList && 
+                    <ProjectImagery project={props.project} setBaseMapSource={props.setBaseMapSource}/>
+                }
+                <PlotDesign 
+                    project={props.project} 
+                    useTemplatePlots={props.useTemplatePlots}
+                    setPlotDistribution={props.setPlotDistribution}
+                    setPlotShape={props.setPlotShape}
+                    setTemplatePlots={props.setTemplatePlots}
+                />
+                {!props.project.useTemplatePlots && 
+                    <SampleDesign project={props.project} setSampleDistribution={props.setSampleDistribution}/>
+                }
+                <SurveyDesign 
+                    project={props.project}
+                    addSurveyQuestionRow={props.addSurveyQuestionRow}
+                    addSurveyQuestion ={props.addSurveyQuestion} 
+                    topoSort={props.topoSort}
+                    getParentSurveyQuestions={props.getParentSurveyQuestions} 
+                    getParentSurveyQuestionAnswers={props.getParentSurveyQuestionAnswers}
+                    removeSurveyQuestion={props.removeSurveyQuestion}
+                    removeSurveyQuestionRow={props.removeSurveyQuestionRow}
+                    handleInputColor={props.handleInputColor}
+                    handleInputName={props.handleInputName}
+                    handleInputParent={props.handleInputParent}
+                />
 
         </form>
     );
-}
-
-function SectionBlock({ title, children }) {
-    return (
-        <div className={"row mb-3"}>
-            <div className="col">
-                <h2 className="header px-0">{title}</h2>
-                {children}
-            </div>
-        </div>
-    )
 }
 
 function ProjectTemplateVisibility({ project, setProjectTemplate }) {
@@ -1025,7 +1009,16 @@ class SampleDesign extends React.Component{
                                     />
                         </label>
                     </div>
-                    <p id="sample-design-text">Sample points will be randomly distributed within the plot boundary.</p>
+                    <p id="sample-design-text">
+                    {sampleDistribution === 'random' && 
+                        'Sample points will be randomly distributed within the plot boundary.'}
+                    {sampleDistribution === 'gridded' && 
+                        'Sample points will be arranged on a grid within the plot boundary using the sample resolution selected below.'}
+                    {sampleDistribution === 'csv' && 
+                        'Specify your own sample points by uploading a CSV with these fields: LONGITUDE,LATITUDE,PLOTID,SAMPLEID.'}
+                    {sampleDistribution === 'shp' && 
+                        'Specify your own sample shapes by uploading a zipped Shapefile (containing SHP, SHX, DBF, and PRJ files) of polygon features. Each feature must have PLOTID and SAMPLEID fields.'}
+                    </p>
                     <div className="form-group mb-1">
                         <p htmlFor="samples-per-plot">Samples per plot</p>
                         <input className="form-control form-control-sm" type="number" id="samples-per-plot"

--- a/src/main/resources/public/jsx/create-project.js
+++ b/src/main/resources/public/jsx/create-project.js
@@ -1,17 +1,16 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import ReactDOM from 'react-dom';
 import { mercator, ceoMapStyles } from "../js/mercator-openlayers.js";
+// FIXME use props instead of directly modifying DOM elements
 import { utils } from "../js/utils.js";
 
 class Project extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            userId: this.props.userId,
-            projectId: this.props.projectId,
-            institutionId: this.props.institutionId,
-            details: null,
-            stats: null,
+            templateDetails: null,
+            templateId: "0",
+            useTemplatePlots: false,
             imageryList: null,
             mapConfig: null,
             plotList: null,
@@ -22,26 +21,14 @@ class Project extends React.Component {
             newSurveyQuestionName: "",
             newValueEntry: {},
             projectList: null,
-            templateId: "0",
-            // FIXME: Add these attributes to the JSON database
-            dateCreated: null,
-            datePublished: null,
-            dateClosed: null,
-            dateArchived: null,
-            stateTransitions: {
-                nonexistent: "Create",
-                unpublished: "Publish",
-                published: "Close",
-                closed: "Archive",
-                archived: "Archive"
-            },
         };
         this.setPrivacyLevel = this.setPrivacyLevel.bind(this);
+        this.setTemplatePlots = this.setTemplatePlots.bind(this);
         this.setPlotDistribution = this.setPlotDistribution.bind(this);
         this.setPlotShape = this.setPlotShape.bind(this);
         this.setSampleDistribution = this.setSampleDistribution.bind(this);
-        this.changeAvailability = this.changeAvailability.bind(this);
         this.setBaseMapSource = this.setBaseMapSource.bind(this);
+        this.showProjectMap = this.showProjectMap.bind(this);
         this.addSurveyQuestion = this.addSurveyQuestion.bind(this);
         this.removeSurveyQuestion = this.removeSurveyQuestion.bind(this);
         this.addSurveyQuestionRow = this.addSurveyQuestionRow.bind(this);
@@ -60,53 +47,10 @@ class Project extends React.Component {
     };
 
     componentDidMount() {
-        this.getProjectList(this.state.userId, this.state.projectId);
-        let institution = this.state.institutionId;
-        if (this.state.details == null) {
-            this.getProjectById(this.state.projectId);
-        }
-        else {
-            if (this.state.details.id == 0) {
-                institution = this.state.institutionId;
-                this.state.details.privacyLevel = "private";
-                this.state.details.projectDistribution = "random";
-                if (document.getElementById("sample-distribution-random") != null) {
-                    document.getElementById("sample-distribution-random").disabled = false;
-                    document.getElementById("sample-distribution-gridded").disabled = false;
-                    document.getElementById("sample-distribution-csv").disabled = true;
-                    document.getElementById("sample-distribution-shp").disabled = true;
-                }
-                this.state.details.plotShape = "circle";
-                this.state.details.sampleDistribution = "random";
-            }
-            if (this.state.details.id != 0) {
-                institution = this.state.details.institution;
-                if (document.getElementById("num-plots") != null) {
-                    if (document.getElementById("plot-distribution-gridded").checked)
-                        document.getElementById("plot-design-text").innerHTML = "Plot centers will be arranged on a grid within the AOI using the plot spacing selected below.";
-                    if (document.getElementById("plot-distribution-random").checked) {
-                        document.getElementById("plot-design-text").innerHTML = "Plot centers will be randomly distributed within the AOI.";
-                    }
-                    if (document.getElementById("plot-distribution-csv").checked)
-                        document.getElementById("plot-design-text").innerHTML = "Specify your own plot centers by uploading a CSV with these fields: LONGITUDE,LATITUDE,PLOTID.";
-                    if (document.getElementById("plot-distribution-shp").checked)
-                        document.getElementById("plot-design-text").innerHTML = "Specify your own plot boundaries by uploading a zipped Shapefile (containing SHP, SHX, DBF, and PRJ files) of polygon features. Each feature must have a unique PLOTID field.";
-                    if (document.getElementById("sample-distribution-gridded").checked)
-                        document.getElementById("sample-design-text").innerHTML = "Sample points will be arranged on a grid within the plot boundary using the sample resolution selected below.";
-                    if (document.getElementById("sample-distribution-random").checked)
-                        document.getElementById("sample-design-text").innerHTML = "Sample points will be randomly distributed within the plot boundary.";
-                    if (document.getElementById("sample-distribution-csv").checked)
-                        document.getElementById("sample-design-text").innerHTML = "Specify your own sample points by uploading a CSV with these fields: LONGITUDE,LATITUDE,PLOTID,SAMPLEID.";
-                    if (document.getElementById("sample-distribution-shp").checked)
-                        document.getElementById("sample-design-text").innerHTML = "Specify your own sample shapes by uploading a zipped Shapefile (containing SHP, SHX, DBF, and PRJ files) of polygon features. Each feature must have PLOTID and SAMPLEID fields.";
-                }
-                this.getProjectStats(this.state.projectId);
-            }
-
-        }
-        if (this.state.imageryList == null) {
-            this.getImageryList(institution);
-        }
+        // FIXME, combine promises to load map only once after all data is back
+        this.getImageryList();
+        this.getProjectById();
+        this.getProjectList();
     }
 
     createProject() {
@@ -114,11 +58,8 @@ class Project extends React.Component {
             utils.show_element("spinner");
             var formData = new FormData(document.getElementById("project-design-form"));
             formData.append("institution", this.props.institutionId);
-            formData.append("plot-distribution-csv-file", document.getElementById("plot-distribution-csv-file").files[0]);
-            formData.append("plot-distribution-shp-file", document.getElementById("plot-distribution-shp-file").files[0]);
-            formData.append("sample-distribution-csv-file", document.getElementById("sample-distribution-csv-file").files[0]);
-            formData.append("sample-distribution-shp-file", document.getElementById("sample-distribution-shp-file").files[0]);
-            formData.append("sample-values", JSON.stringify(this.state.details.sampleValues));
+            formData.append("sample-values", JSON.stringify(this.state.templateDetails.sampleValues));
+            console.log(formData);
             var ref = this;
             $.ajax({
                 url: this.props.documentRoot + "/create-project",
@@ -133,9 +74,9 @@ class Project extends React.Component {
                 alert("Error creating project. See console for details.");
             }).done(function (data) {
                 if (parseInt(data)) {
-                    var detailsNew = ref.state.details;
+                    var detailsNew = ref.state.templateDetails;
                     detailsNew.availability = "unpublished";
-                    ref.setState({details: detailsNew});
+                    ref.setState({templateDetails: detailsNew});
                     utils.hide_element("spinner");
                     var newProjectId = data;
                     window.location = ref.props.documentRoot + "/review-project/" + newProjectId;
@@ -144,66 +85,6 @@ class Project extends React.Component {
                     alert(data);
                 }
             });
-        }
-    }
-
-    publishProject() {
-        if (confirm("Do you REALLY want to publish this project?")) {
-            utils.show_element("spinner");
-            var ref = this;
-            $.ajax({
-                url: this.props.documentRoot + "/publish-project/" + this.state.details.id,
-                type: "POST",
-                async: true,
-                crossDomain: true,
-                contentType: "application/json",
-            }).fail(function (response) {
-                utils.hide_element("spinner");
-                console.log(response);
-                alert("Error publishing project. See console for details.");
-            }).done(function (data) {
-                var detailsNew = ref.state.details;
-                detailsNew.availability = "published";
-                ref.setState({details: detailsNew});
-                utils.hide_element("spinner");
-            });
-        }
-    }
-
-    archiveProject() {
-        if (confirm("Do you REALLY want to archive this project?!")) {
-            utils.show_element("spinner");
-            var ref = this;
-            $.ajax({
-                url: this.props.documentRoot + "/archive-project/" + this.state.details.id,
-                type: "POST",
-                async: true,
-                crossDomain: true,
-                contentType: "application/json",
-            }).fail(function (response) {
-                utils.hide_element("spinner");
-                console.log(response);
-                alert("Error archiving project. See console for details.");
-            }).done(function (data) {
-                var detailsNew = ref.state.details;
-                detailsNew.availability = "archived";
-                ref.setState({details: detailsNew});
-                utils.hide_element("spinner");
-                alert("Project " + ref.state.details.id + " has been archived.");
-                window.location = ref.props.documentRoot + "/home";
-            });
-        }
-    }
-
-    changeAvailability() {
-        if (this.state.details.availability == "nonexistent") {
-            this.createProject();
-        } else if (this.state.details.availability == "unpublished") {
-            this.publishProject();
-        } else if (this.state.details.availability == "published") {
-            this.closeProject();
-        } else if (this.state.details.availability == "closed") {
-            this.archiveProject();
         }
     }
 
@@ -253,7 +134,7 @@ class Project extends React.Component {
         }
 
         templateProject.sampleValues=newSV;
-        this.setState({details: JSON.parse(JSON.stringify(templateProject))},
+        this.setState({templateDetails: JSON.parse(JSON.stringify(templateProject))},
             function () {
                 this.updateUnmanagedComponents(this.state.templateId);
             }
@@ -262,129 +143,50 @@ class Project extends React.Component {
     }
 
     setPrivacyLevel(privacyLevel) {
-        if (this.state.details != null) {
-            var detailsNew = this.state.details;
+        if (this.state.templateDetails != null) {
+            var detailsNew = this.state.templateDetails;
             detailsNew.privacyLevel = privacyLevel;
-            this.setState({details: detailsNew});
+            this.setState({templateDetails: detailsNew});
         }
     }
 
     setBaseMapSource() {
         var e = document.getElementById("base-map-source");
         var bms = e.options[e.selectedIndex].value;
-        var detailsNew = this.state.details;
+        var detailsNew = this.state.templateDetails;
         detailsNew.baseMapSource = bms;
 
-        this.setState({details: detailsNew});
-        mercator.setVisibleLayer(this.state.mapConfig, this.state.details.baseMapSource);
+        this.setState({templateDetails: detailsNew});
+        mercator.setVisibleLayer(this.state.mapConfig, this.state.templateDetails.baseMapSource);
+    }
+
+    setTemplatePlots(useTemplatePlots) {
+        this.setState({useTemplatePlots: useTemplatePlots});
     }
 
     setPlotDistribution(plotDistribution) {
-        if (this.state.details != null) {
-            var detailsNew = this.state.details;
+        if (this.state.templateDetails != null) {
+            var detailsNew = this.state.templateDetails;
             detailsNew.plotDistribution = plotDistribution;
-            this.setState({details: detailsNew});
-            if (document.getElementById("num-plots") != null) {
-                if (plotDistribution == "random") {
-                    utils.enable_element("plot-size");
-                    utils.enable_element("num-plots");
-                    utils.disable_element("plot-spacing");
-                    utils.disable_element("plot-distribution-csv-file");
-                    utils.disable_element("plot-distribution-shp-file");
-                    document.getElementById("sample-distribution-random").disabled=false;
-                    document.getElementById("sample-distribution-gridded").disabled=false;
-                    document.getElementById("sample-distribution-csv").disabled=true;
-                    document.getElementById("sample-distribution-shp").disabled=true;
-                    document.getElementById("plot-design-text").innerHTML="Plot centers will be randomly distributed within the AOI.";
-
-                } else if (plotDistribution == "gridded") {
-                    utils.enable_element("plot-size");
-                    utils.disable_element("num-plots");
-                    utils.enable_element("plot-spacing");
-                    utils.disable_element("plot-distribution-csv-file");
-                    utils.disable_element("plot-distribution-shp-file");
-                    document.getElementById("sample-distribution-random").disabled=false;
-                    document.getElementById("sample-distribution-gridded").disabled=false;
-                    document.getElementById("sample-distribution-csv").disabled=true;
-                    document.getElementById("sample-distribution-shp").disabled=true;
-                    document.getElementById("plot-design-text").innerHTML="Plot centers will be arranged on a grid within the AOI using the plot spacing selected below.";
-                } else if(plotDistribution == "csv"){
-                    utils.enable_element("plot-size");
-                    utils.disable_element("num-plots");
-                    utils.disable_element("plot-spacing");
-                    utils.disable_element("plot-distribution-shp-file");
-                    utils.enable_element("plot-distribution-csv-file");
-                    document.getElementById("sample-distribution-random").disabled=false;
-                    document.getElementById("sample-distribution-gridded").disabled=false;
-                    document.getElementById("sample-distribution-csv").disabled=false;
-                    document.getElementById("sample-distribution-shp").disabled=false;
-                    document.getElementById("plot-design-text").innerHTML="Specify your own plot centers by uploading a CSV with these fields: LONGITUDE,LATITUDE,PLOTID.";
-
-                }
-                else{
-                    utils.disable_element("plot-size");
-                    utils.disable_element("num-plots");
-                    utils.disable_element("plot-spacing");
-                    utils.disable_element("plot-distribution-csv-file");
-                    utils.enable_element("plot-distribution-shp-file");
-                    document.getElementById("sample-distribution-random").disabled=true;
-                    document.getElementById("sample-distribution-gridded").disabled=true;
-                    document.getElementById("sample-distribution-csv").disabled=false;
-                    document.getElementById("sample-distribution-shp").disabled=false;
-                    document.getElementById("plot-design-text").innerHTML="Specify your own plot boundaries by uploading a zipped Shapefile (containing SHP, SHX, DBF, and PRJ files) of polygon features. Each feature must have a unique PLOTID field.";
-
-                }
-            }
+            this.setState({templateDetails: detailsNew});
         }
     }
 
     setPlotShape(plotShape) {
-        if (this.state.details != null) {
-            var detailsNew = this.state.details;
+        if (this.state.templateDetails != null) {
+            var detailsNew = this.state.templateDetails;
             detailsNew.plotShape = plotShape;
-            this.setState({details: detailsNew});
+            this.setState({templateDetails: detailsNew});
         }
     }
 
     setSampleDistribution(sampleDistribution) {
-        if (this.state.details != null) {
-            var detailsNew = this.state.details;
+        if (this.state.templateDetails != null) {
+            var detailsNew = this.state.templateDetails;
             detailsNew.sampleDistribution = sampleDistribution;
-            this.setState({details: detailsNew});
-            if (document.getElementById("samples-per-plot") != null && document.getElementById("sample-resolution") != null)
-                if (sampleDistribution == "random") {
-                    utils.enable_element("samples-per-plot");
-                    utils.disable_element("sample-resolution");
-                    utils.disable_element("sample-distribution-csv-file");
-                    utils.disable_element("sample-distribution-shp-file");
-
-                    document.getElementById("sample-design-text").innerHTML="Sample points will be randomly distributed within the plot boundary.";
-
-                } else if(sampleDistribution == "gridded") {
-                    utils.disable_element("samples-per-plot");
-                    utils.enable_element("sample-resolution");
-                    utils.disable_element("sample-distribution-csv-file");
-                    utils.disable_element("sample-distribution-shp-file");
-                    document.getElementById("sample-design-text").innerHTML="Sample points will be arranged on a grid within the plot boundary using the sample resolution selected below.";
-                }
-                else if(sampleDistribution == "csv"){
-                    utils.disable_element("samples-per-plot");
-                    utils.disable_element("sample-resolution");
-                    utils.disable_element("sample-distribution-shp-file");
-                    utils.enable_element("sample-distribution-csv-file");
-                    document.getElementById("sample-design-text").innerHTML="Specify your own sample points by uploading a CSV with these fields: LONGITUDE,LATITUDE,PLOTID,SAMPLEID.";
-                }
-                else{
-                    utils.disable_element("samples-per-plot");
-                    utils.disable_element("sample-resolution");
-                    utils.disable_element("sample-distribution-csv-file");
-                    utils.enable_element("sample-distribution-shp-file");
-
-                    document.getElementById("sample-design-text").innerHTML="Specify your own sample shapes by uploading a zipped Shapefile (containing SHP, SHX, DBF, and PRJ files) of polygon features. Each feature must have PLOTID and SAMPLEID fields.";
-                }
+            this.setState({templateDetails: detailsNew});
         }
     }
-
 
     getParentSurveyQuestions(sampleSurvey) {
         return sampleSurvey.filter(
@@ -422,7 +224,6 @@ class Project extends React.Component {
         return ans;
     }
 
-
     getChildSurveyQuestions(sampleSurvey, parentSurveyQuestion) {
         return sampleSurvey.filter(
             function (surveyQuestion) {
@@ -431,29 +232,6 @@ class Project extends React.Component {
         );
     }
 
-    // topoSort(sampleSurvey) {
-    //     var parentSurveyQuestions = this.getParentSurveyQuestions(sampleSurvey);
-    //     console.log(parentSurveyQuestions);
-    //     var parentChildGroups = this.getParentChildGroups(parentSurveyQuestions,sampleSurvey);
-    //     return parentChildGroups;
-    // }
-    // getParentChildGroups(parentSurveyQuestions,sampleSurvey){
-    //     var parentChildGroups = parentSurveyQuestions.map(
-    //         function (parentSurveyQuestion) {
-    //             var childSurveyQuestions = sampleSurvey.filter(
-    //                 function (sampleValue) {
-    //                     return sampleValue.parent_question == parentSurveyQuestion.id && sampleValue.parent_question!=-1;
-    //                 }
-    //             );
-    //             console.log("from topo");
-    //             console.log((parentSurveyQuestions).concat(childSurveyQuestions));
-    //             return (parentSurveyQuestions).concat(childSurveyQuestions);
-    //         },
-    //         this
-    //     );
-    //     return [].concat.apply([], parentChildGroups);
-    //
-    // }
     topoSort(sampleSurvey) {
         var parentSurveyQuestions = this.getParentSurveyQuestions(sampleSurvey);
         var parentChildGroups = parentSurveyQuestions.map(
@@ -469,8 +247,9 @@ class Project extends React.Component {
         );
         return [].concat.apply([], parentChildGroups);
     }
+
     addSurveyQuestion(){
-        if (this.state.details != null) {
+        if (this.state.templateDetails != null) {
             var questionText = document.getElementById("surveyQuestionText").value;
             var parent_value = document.getElementById("value-parent");
 
@@ -482,7 +261,7 @@ class Project extends React.Component {
             if (questionText != "") {
                 var newValueEntryNew = this.state.newValueEntry;
                 newValueEntryNew[questionText] = {id:-1,answer: "", color: "#000000"};
-                var detailsNew = this.state.details;
+                var detailsNew = this.state.templateDetails;
                 var _id = detailsNew.sampleValues.length + 1;
                 var question_id = -1,answer_id=-1;
                 detailsNew.sampleValues.map((sq) => {
@@ -499,9 +278,7 @@ class Project extends React.Component {
                 );
 
                 detailsNew.sampleValues.push({id: _id, question: questionText, answers: [], parent_question: question_id,parent_answer:answer_id});
-                this.setState({newValueEntry: newValueEntryNew, details: detailsNew, newSurveyQuestionName: ""});
-                console.log("JSON object");
-                console.log(this.state.details.sampleValues);
+                this.setState({newValueEntry: newValueEntryNew, templateDetails: detailsNew, newSurveyQuestionName: ""});
                 document.getElementById("surveyQuestionText").value = "";
                 parent_value.options[0].selected = true;
             } else {
@@ -511,21 +288,21 @@ class Project extends React.Component {
     }
 
     removeSurveyQuestion(surveyQuestionName) {
-        if (this.state.details != null) {
-            var detailsNew = this.state.details;
+        if (this.state.templateDetails != null) {
+            var detailsNew = this.state.templateDetails;
             detailsNew.sampleValues = detailsNew.sampleValues.filter(
                 function (surveyQuestion) {
                     return surveyQuestion.question != surveyQuestionName;
                 }
             );
             this.setState({
-                details: detailsNew
+                templateDetails: detailsNew
             });
         }
     }
 
     getSurveyQuestionByName(surveyQuestionName) {
-        return this.state.details.sampleValues.find(
+        return this.state.templateDetails.sampleValues.find(
             function (surveyQuestion) {
                 return surveyQuestion.question == surveyQuestionName;
             }
@@ -562,7 +339,8 @@ class Project extends React.Component {
         this.setState({newValueEntry: dNew});
     }
 
-    getProjectById(projectId) {
+    getProjectById() {
+        const projectId = "0";
         fetch(this.props.documentRoot + "/get-project-by-id/" + projectId)
             .then(response => {
                 if (response.ok) {
@@ -608,13 +386,14 @@ class Project extends React.Component {
                         );
                     }
                     detailsNew.sampleValues=newSV;
-                    this.setState({details: detailsNew});
-                    this.updateUnmanagedComponents(this.state.projectId);
+                    this.setState({templateDetails: detailsNew});
+                    this.updateUnmanagedComponents("0");
                 }
             });
     }
 
-    getProjectList(userId, projectId) {
+    getProjectList() {
+        const { userId } = this.props
         fetch(this.props.documentRoot + "/get-all-projects?userId=" + userId)
             .then(response => {
                 if (response.ok) {
@@ -627,15 +406,15 @@ class Project extends React.Component {
             .then(data => {
 
                 this.setState({projectList: data});
-                console.log(data);
                 let projList = this.state.projectList;
-                projList.unshift(JSON.parse(JSON.stringify(this.state.details)));
-                this.setState({projectList: projList,userId: userId,projectId: "" + projectId});;
-                this.updateUnmanagedComponents(this.state.projectId);
+                projList.unshift(JSON.parse(JSON.stringify(this.state.templateDetails)));
+                this.setState({projectList: projList});
+                this.updateUnmanagedComponents("0");
             });
     }
 
-    getImageryList(institutionId) {
+    getImageryList() {
+        const { institutionId } = this.props
         fetch(this.props.documentRoot + "/get-all-imagery?institutionId=" + institutionId)
             .then(response => {
                 if (response.ok) {
@@ -650,7 +429,7 @@ class Project extends React.Component {
             });
     }
 
-    getPlotList(projectId, maxPlots) {
+    showPlotCenters(projectId, maxPlots) {
         fetch(this.props.documentRoot + "/get-project-plots/" + projectId + "/" + maxPlots)
             .then(response => {
                 if (response.ok) {
@@ -662,21 +441,9 @@ class Project extends React.Component {
             })
             .then(data => {
                 this.setState({plotList: data});
-                this.showPlotCenters(projectId, maxPlots);
-            });
-    }
-
-    showPlotCenters(projectId, maxPlots) {
-        if (this.state.plotList == null) {
-            // Load the current project plots
-            this.getPlotList(projectId, maxPlots);
-        } else {
-            // Draw the plot shapes on the map
-            mercator.removeLayerByTitle(this.state.mapConfig, "flaggedPlots");
-            mercator.removeLayerByTitle(this.state.mapConfig, "analyzedPlots");
-            mercator.removeLayerByTitle(this.state.mapConfig, "unanalyzedPlots");
-            mercator.addPlotOverviewLayers(this.state.mapConfig, this.state.plotList, this.state.details.plotShape);
-        }
+                mercator.addPlotOverviewLayers(this.state.mapConfig, this.state.plotList, this.state.details.plotShape);
+            })
+            .catch(e => this.setState({plotList: null}));
     }
 
     showProjectMap(projectId) {
@@ -685,8 +452,13 @@ class Project extends React.Component {
             this.setState({mapConfig: mercator.createMap("project-map", [0.0, 0.0], 1, this.state.imageryList)});
         }
 
-        mercator.setVisibleLayer(this.state.mapConfig, this.state.details.baseMapSource);
-        if (this.state.details.id == 0) {
+        mercator.setVisibleLayer(this.state.mapConfig, this.state.templateDetails.baseMapSource);
+        mercator.removeLayerByTitle(this.state.mapConfig, "currentAOI");
+        mercator.removeLayerByTitle(this.state.mapConfig, "flaggedPlots");
+        mercator.removeLayerByTitle(this.state.mapConfig, "analyzedPlots");
+        mercator.removeLayerByTitle(this.state.mapConfig, "unanalyzedPlots");
+
+        if (this.state.templateDetails.id == 0) {
             // Enable dragbox interaction if we are creating a new project
             var displayDragBoxBounds = function (dragBox) {
                 var extent = dragBox.getGeometry().clone().transform("EPSG:3857", "EPSG:4326").getExtent();
@@ -696,15 +468,13 @@ class Project extends React.Component {
                 document.getElementById("lon-max").value = extent[2];
                 document.getElementById("lat-max").value = extent[3];
             };
-            mercator.removeLayerByTitle(this.state.mapConfig, "currentAOI");
-            mercator.removeLayerByTitle(this.state.mapConfig, "flaggedPlots");
-            mercator.removeLayerByTitle(this.state.mapConfig, "analyzedPlots");
-            mercator.removeLayerByTitle(this.state.mapConfig, "unanalyzedPlots");
+            
             mercator.disableDragBoxDraw(this.state.mapConfig);
             mercator.enableDragBoxDraw(this.state.mapConfig, displayDragBoxBounds);
         } else {
             // Extract bounding box coordinates from the project boundary and show on the map
-            var boundaryExtent = mercator.parseGeoJson(this.state.details.boundary, false).getExtent();
+            var boundaryExtent = mercator.parseGeoJson(this.state.templateDetails.boundary, false).getExtent();
+            // FIXME like above, these values are stored in the state but never used.
             this.setState({lonMin: boundaryExtent[0]});
             this.setState({latMin: boundaryExtent[1]});
             this.setState({lonMax: boundaryExtent[2]});
@@ -714,35 +484,32 @@ class Project extends React.Component {
             mercator.removeLayerByTitle(this.state.mapConfig, "currentAOI");
             mercator.addVectorLayer(this.state.mapConfig,
                 "currentAOI",
-                mercator.geometryToVectorSource(mercator.parseGeoJson(this.state.details.boundary, true)),
+                mercator.geometryToVectorSource(mercator.parseGeoJson(this.state.templateDetails.boundary, true)),
                 ceoMapStyles.yellowPolygon);
             mercator.zoomMapToLayer(this.state.mapConfig, "currentAOI");
 
-            // Force reloading of the plotList
-            this.setState({plotList: null});
-
-            // Show the plot centers on the map (but constrain to <= 100 points)
+            // Get the new plotlist
             this.showPlotCenters(projectId, 100);
         }
     }
 
     updateUnmanagedComponents(projectId) {
-        if (this.state.details != null) {
+        if (this.state.templateDetails != null) {
             // Enable the input fields that are connected to the radio buttons if their values are not null
-            if (this.state.details.plotDistribution == "gridded") {
+            
+            if (this.state.templateDetails.plotDistribution == "gridded") {
                 utils.enable_element("plot-spacing");
             }
-            if (this.state.details.sampleDistribution == "gridded") {
+            if (this.state.templateDetails.sampleDistribution == "gridded") {
                 utils.enable_element("sample-resolution");
             }
 
             if (this.state.imageryList.length > 0) {
-                var detailsNew = this.state.details;
-                detailsNew.baseMapSource = this.state.details.baseMapSource || this.state.imageryList[0].title;
+                var detailsNew = this.state.templateDetails;
                 // If baseMapSource isn't provided by the project, just use the first entry in the imageryList
-                this.setState({details: detailsNew},
-                    this.showProjectMap(projectId)
-                );
+                detailsNew.baseMapSource = this.state.templateDetails.baseMapSource || this.state.imageryList[0].title;
+                this.setState({templateDetails: detailsNew});
+                this.showProjectMap(projectId);
                 // Draw a map with the project AOI and a sampling of its plots
             }
         }
@@ -767,12 +534,12 @@ class Project extends React.Component {
     }
 
     handleInputParent(event) {
-        var detailsNew = this.state.details;
-        this.setState({details: detailsNew});
+        var detailsNew = this.state.templateDetails;
+        this.setState({templateDetails: detailsNew});
     }
 
     handleChange(event) {
-        var detailsNew = this.state.details;
+        var detailsNew = this.state.templateDetails;
 
         if (event.target.id == "project-name") {
             detailsNew.name = event.target.value;
@@ -780,276 +547,247 @@ class Project extends React.Component {
         else if (event.target.id = "project-description") {
             detailsNew.description = event.target.value;
         }
-        this.setState({details: detailsNew});
+        this.setState({templateDetails: detailsNew});
 
     }
 
     render() {
-        var header;
-        if (this.props.projectId == "0") {
-            header = <h1>Create Project</h1>
-        }
-        else {
-            header = <h1>Review Project</h1>
-        }
         return (
             <div id="project-design" className="col-xl-6 col-lg-8 border bg-lightgray mb-5">
                 <div className="bg-darkgreen mb-3 no-container-margin">
-                    {header}
+                    <h1>Create Project</h1>
                 </div>
-                <ProjectDesignForm projectId={this.props.projectId} project={this.state}
-                                   project_template_visibility={this.props.project_template_visibility}
+                <ProjectDesignForm project={this.state}
+                                   project_template_visibility={true}
                                    setProjectTemplate={this.setProjectTemplate} setPrivacyLevel={this.setPrivacyLevel}
                                    setSampleDistribution={this.setSampleDistribution}
                                    addSurveyQuestionRow={this.addSurveyQuestionRow}
                                    setBaseMapSource={this.setBaseMapSource}
-                                   setPlotDistribution={this.setPlotDistribution} setPlotShape={this.setPlotShape}
+                                   setPlotDistribution={this.setPlotDistribution} 
+                                   setPlotShape={this.setPlotShape}
+                                   setTemplatePlots={this.setTemplatePlots}
                                    addSurveyQuestion={this.addSurveyQuestion}
                                    topoSort={this.topoSort} getParentSurveyQuestions={this.getParentSurveyQuestions} getParentSurveyQuestionAnswers={this.getParentSurveyQuestionAnswers}
                                    removeSurveyQuestion={this.removeSurveyQuestion}
                                    removeSurveyQuestionRow={this.removeSurveyQuestionRow}
                                    handleInputColor={this.handleInputColor} handleInputName={this.handleInputName}
                                    handleChange={this.handleChange} handleInputParent={this.handleInputParent}/>
-                <ProjectManagement project={this.state} projectId={this.props.projectId}
+                <ProjectManagement project={this.state}
                                    configureGeoDash={this.configureGeoDash} downloadPlotData={this.downloadPlotData}
                                    downloadSampleData={this.downloadSampleData}
-                                   changeAvailability={this.changeAvailability} createProject={this.createProject}/>
+                                   createProject={this.createProject}/>
             </div>
         );
     }
 }
 
 function ProjectDesignForm(props) {
-    var addSurveyQuestionButton;
-    if (props.projectId == "0") {
-        addSurveyQuestionButton = <React.Fragment>
-            <tr>
-                <td><label htmlFor="value-SQ">New Question:</label></td>
-                <td>
-                    <div id="add-sample-value-group">
-                        <input type="text" id="surveyQuestionText" autoComplete="off"
-                               value={project.newSurveyQuestionName}/>
-                    </div>
-                </td>
-            </tr>
-            <tr>
-                <td><input type="button" className="button" value="Add Survey Question"
-                           onClick={props.addSurveyQuestion}/></td>
-                <td></td>
-            </tr>
-        </React.Fragment>;
-    }
     return (
         <form id="project-design-form" className="px-2 pb-2" method="post"
               action={props.documentRoot + "/create-project"}
               encType="multipart/form-data">
-            <ProjectTemplateVisibility project={props.project} setProjectTemplate={props.setProjectTemplate} project_template_visibility={props.project_template_visibility}/>
-            <ProjectInfo project={props.project} handleChange={props.handleChange}/>
-            <ProjectVisibility project={props.project} setPrivacyLevel={props.setPrivacyLevel}/>
-            <ProjectAOI projectId={props.projectId} project={props.project}/>
-            <ProjectImagery project={props.project} setBaseMapSource={props.setBaseMapSource}/>
-            <PlotDesign project={props.project} setPlotDistribution={props.setPlotDistribution}
-                        setPlotShape={props.setPlotShape}/>
-            <SampleDesign project={props.project} setSampleDistribution={props.setSampleDistribution}/>
-            <SurveyDesign project={props.project} projectId={props.projectId}
-                          addSurveyQuestionRow={props.addSurveyQuestionRow} topoSort={props.topoSort}
-                          getParentSurveyQuestions={props.getParentSurveyQuestions} getParentSurveyQuestionAnswers={props.getParentSurveyQuestionAnswers}
-                          removeSurveyQuestion={props.removeSurveyQuestion}
-                          removeSurveyQuestionRow={props.removeSurveyQuestionRow}
-                          handleInputColor={props.handleInputColor}
-                          handleInputName={props.handleInputName}
-                          handleInputParent={props.handleInputParent} addSurveyQuestionButton={addSurveyQuestionButton}/>
+            {props.project.templateDetails && 
+                <Fragment>
+                    {props.project.projectList && 
+                        <ProjectTemplateVisibility 
+                            project={props.project} 
+                            setProjectTemplate={props.setProjectTemplate} 
+                        />
+                    }
+                    <ProjectInfo project={props.project} handleChange={props.handleChange}/>
+                    <ProjectVisibility project={props.project} setPrivacyLevel={props.setPrivacyLevel}/>
+                    <ProjectAOI project={props.project}/>
+                    {props.project.imageryList && 
+                        <ProjectImagery project={props.project} setBaseMapSource={props.setBaseMapSource}/>
+                    }
+                    <PlotDesign 
+                        project={props.project} 
+                        useTemplatePlots={props.useTemplatePlots}
+                        setPlotDistribution={props.setPlotDistribution}
+                        setPlotShape={props.setPlotShape}
+                        setTemplatePlots={props.setTemplatePlots}
+                    />
+                    {!props.project.useTemplatePlots && 
+                        <SampleDesign project={props.project} setSampleDistribution={props.setSampleDistribution}/>
+                    }
+                    <SurveyDesign 
+                        project={props.project}
+                        addSurveyQuestionRow={props.addSurveyQuestionRow}
+                        addSurveyQuestion ={props.addSurveyQuestion} 
+                        topoSort={props.topoSort}
+                        getParentSurveyQuestions={props.getParentSurveyQuestions} 
+                        getParentSurveyQuestionAnswers={props.getParentSurveyQuestionAnswers}
+                        removeSurveyQuestion={props.removeSurveyQuestion}
+                        removeSurveyQuestionRow={props.removeSurveyQuestionRow}
+                        handleInputColor={props.handleInputColor}
+                        handleInputName={props.handleInputName}
+                        handleInputParent={props.handleInputParent}
+                    />
+                </Fragment>
+            }
 
         </form>
     );
 }
 
-function ProjectTemplateVisibility(props) {
-    let project = props.project;
-    console.log(project);
-    if (project.projectList != null) {
-        return (
-            <div className={"row " + props.project_template_visibility}>
-                <div className="col">
-                    <h2 className="header px-0">Use Project Template (Optional)</h2>
-                    <div id="project-template-selector">
-                        <div className="form-group">
-                            <h3 htmlFor="project-template">Select Project</h3>
-                            <select className="form-control form-control-sm" id="project-template"
-                                    name="project-template"
-                                    size="1" value={project.templateId} onChange={props.setProjectTemplate}>
-                                {
-                                    project.projectList.map((proj,uid) =>
-                                        <option key={uid} value={proj.id}>{proj.name}</option>
-                                    )
-                                }
-                            </select>
-                        </div>
-                    </div>
+function SectionBlock({ title, children }) {
+    return (
+        <div className={"row mb-3"}>
+            <div className="col">
+                <h2 className="header px-0">{title}</h2>
+                {children}
+            </div>
+        </div>
+    )
+}
+
+function ProjectTemplateVisibility({ project, setProjectTemplate }) {
+    return (
+        <SectionBlock title = "Use Project Template (Optional)">
+            <div id="project-template-selector">
+                <div className="form-group">
+                    <h3 htmlFor="project-template">Select Project</h3>
+                    <select className="form-control form-control-sm" id="project-template"
+                            name="project-template"
+                            size="1" value={project.templateId} onChange={setProjectTemplate}>
+                        {
+                            project.projectList
+                                .filter(proj => proj != null)
+                                .map((proj,uid) =>
+                                    <option key={uid} value={proj.id}>{proj.name}</option>
+                                )
+                        }
+                    </select>
                 </div>
             </div>
-        );
-    }
-    else {
-        return (<span></span>);
-    }
+        </SectionBlock>
+    );
 }
+
 
 function ProjectInfo(props) {
-    var project = props.project;
-    if (project.details != null) {
-        return (
-            <div className="row">
-                <div className="col">
-                    <h2 className="header px-0">Project Info</h2>
-                    <div id="project-info">
-                        <div className="form-group">
-                            <h3 htmlFor="project-name">Name</h3>
-                            <input className="form-control form-control-sm" type="text" id="project-name" name="name"
-                                   autoComplete="off" defaultValue={project.details.name}
-                                   onChange={props.handleChange}/>
-                        </div>
-                        <div className="form-group">
-                            <h3 htmlFor="project-description">Description</h3>
-                            <textarea className="form-control form-control-sm" id="project-description"
-                                      name="description"
-                                      value={project.details.description} onChange={props.handleChange}></textarea>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        );
-    }
-    else {
-        return (<span></span>);
-    }
-}
-
-function ProjectVisibility(props) {
-    if (props.project.details != null) {
-        return (
-            <div className="row">
-                <div className="col">
-                    <h2 className="header px-0">Project Visibility</h2>
-                    <h3>Privacy Level</h3>
-                    <div id="project-visibility" className="mb-3">
-                        <div className="form-check form-check-inline">
-                            <input className="form-check-input" type="radio" id="privacy-public" name="privacy-level"
-                                   value="public" checked={props.project.details.privacyLevel === 'public'}
-                                   onChange={() => props.setPrivacyLevel('public')}/>
-                            <label className="form-check-label small" htmlFor="privacy-public">Public: <i>All Users</i></label>
-                        </div>
-                        <div className="form-check form-check-inline">
-                            <input className="form-check-input" type="radio" id="privacy-private" name="privacy-level"
-                                   value="private" onChange={() => props.setPrivacyLevel('private')}
-                                   checked={props.project.details.privacyLevel === 'private'}/>
-                            <label className="form-check-label small" htmlFor="privacy-private">Private: <i>Group
-                                Admins</i></label>
-                        </div>
-                        <div className="form-check form-check-inline">
-                            <input className="form-check-input" type="radio" id="privacy-institution"
-                                   name="privacy-level"
-                                   value="institution" onChange={() => props.setPrivacyLevel('institution')}
-                                   checked={props.project.details.privacyLevel === 'institution'}/>
-                            <label className="form-check-label small" htmlFor="privacy-institution">Institution: <i>Group
-                                Members</i></label>
-                        </div>
-                        <div className="form-check form-check-inline">
-                            <input className="form-check-input" type="radio" id="privacy-invitation"
-                                   name="privacy-level"
-                                   value="invitation" onChange={() => props.setPrivacyLevel('invitation')} disabled
-                                   checked={props.project.details.privacyLevel === 'invitation'}/>
-                            <label className="form-check-label small" htmlFor="privacy-invitation">Invitation: <i>Coming
-                                Soon</i></label>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        );
-    }
-    return (<span></span>);
-}
-
-function ProjectAOI(props) {
-    var project = props.project;
-    var msg = "";
-    if (props.projectId == "0") {
-        msg = <div className="row">
-            <div className="col small text-center mb-2">Hold CTRL and click-and-drag a bounding box on the map</div>
-        </div>;
-    }
+    const { project: { templateDetails } } = props;
     return (
-        <div className="row">
-            <div className="col">
-                <h2 className="header px-0">Project AOI</h2>
-                <div id="project-aoi">
-                    <div id="project-map"></div>
-                    {msg}
+        <SectionBlock title="Project Info">
+            <div id="project-info">
+                <div className="form-group">
+                    <h3 htmlFor="project-name">Name</h3>
+                    <input className="form-control form-control-sm" type="text" id="project-name" name="name"
+                        autoComplete="off" defaultValue={templateDetails.name}
+                        onChange={props.handleChange}/>
+                </div>
+                <div className="form-group">
+                    <h3 htmlFor="project-description">Description</h3>
+                    <textarea className="form-control form-control-sm" id="project-description"
+                            name="description"
+                            value={templateDetails.description} onChange={props.handleChange}></textarea>
+                </div>
+            </div>
+        </SectionBlock>
+    );
+}
+
+function ProjectVisibility({ project : { templateDetails : { privacyLevel } } }) {
+    return (
+        <SectionBlock title= "Project Visibility">
+            <h3>Privacy Level</h3>
+            <div id="project-visibility" className="mb-3">
+                <div className="form-check form-check-inline">
+                    <input className="form-check-input" type="radio" id="privacy-public" name="privacy-level"
+                            value="public" checked={privacyLevel === 'public'}
+                            onChange={() => props.setPrivacyLevel('public')}/>
+                    <label className="form-check-label small" htmlFor="privacy-public">Public: <i>All Users</i></label>
+                </div>
+                <div className="form-check form-check-inline">
+                    <input className="form-check-input" type="radio" id="privacy-private" name="privacy-level"
+                            value="private" onChange={() => props.setPrivacyLevel('private')}
+                            checked={privacyLevel === 'private'}/>
+                    <label className="form-check-label small" htmlFor="privacy-private">Private: <i>Group
+                        Admins</i></label>
+                </div>
+                <div className="form-check form-check-inline">
+                    <input className="form-check-input" type="radio" id="privacy-institution"
+                            name="privacy-level"
+                            value="institution" onChange={() => props.setPrivacyLevel('institution')}
+                            checked={privacyLevel === 'institution'}/>
+                    <label className="form-check-label small" htmlFor="privacy-institution">Institution: <i>Group
+                        Members</i></label>
+                </div>
+                <div className="form-check form-check-inline">
+                    <input className="form-check-input" type="radio" id="privacy-invitation"
+                            name="privacy-level"
+                            value="invitation" onChange={() => props.setPrivacyLevel('invitation')} disabled
+                            checked={privacyLevel === 'invitation'}/>
+                    <label className="form-check-label small" htmlFor="privacy-invitation">Invitation: <i>Coming
+                        Soon</i></label>
+                </div>
+            </div>
+        </SectionBlock>
+    );
+}
+
+function ProjectAOI({ project: { latMax, lonMin, lonMax, latMin } }) {
+    return (
+        <SectionBlock title="Project AOI">
+            <div id="project-aoi">
+                <div id="project-map">
+                    <div className="col small text-center mb-2">Hold CTRL and click-and-drag a bounding box on the map</div>
                     <div className="form-group mx-4">
                         <div className="row">
                             <div className="col-md-6 offset-md-3">
                                 <input className="form-control form-control-sm" type="number" id="lat-max" name="lat-max"
-                                       defaultValue={project.latMax} placeholder="North" autoComplete="off" min="-90.0"
-                                       max="90.0" step="any"/>
+                                    defaultValue={latMax} placeholder="North" autoComplete="off" min="-90.0"
+                                    max="90.0" step="any"/>
                             </div>
                         </div>
                         <div className="row">
                             <div className="col-md-6">
                                 <input className="form-control form-control-sm" type="number" id="lon-min" name="lon-min"
-                                       defaultValue={project.lonMin} placeholder="West" autoComplete="off" min="-180.0"
-                                       max="180.0" step="any"/>
+                                    defaultValue={lonMin} placeholder="West" autoComplete="off" min="-180.0"
+                                    max="180.0" step="any"/>
                             </div>
                             <div className="col-md-6">
                                 <input className="form-control form-control-sm" type="number" id="lon-max" name="lon-max"
-                                       defaultValue={project.lonMax} placeholder="East" autoComplete="off" min="-180.0"
-                                       max="180.0" step="any"/>
+                                    defaultValue={lonMax} placeholder="East" autoComplete="off" min="-180.0"
+                                    max="180.0" step="any"/>
                             </div>
                         </div>
                         <div className="row">
                             <div className="col-md-6 offset-md-3">
                                 <input className="form-control form-control-sm" type="number" id="lat-min" name="lat-min"
-                                       defaultValue={project.latMin} placeholder="South" autoComplete="off" min="-90.0"
-                                       max="90.0" step="any"/>
+                                    defaultValue={latMin} placeholder="South" autoComplete="off" min="-90.0"
+                                    max="90.0" step="any"/>
                             </div>
                         </div>
                     </div>
                 </div>
             </div>
-        </div>
+        </SectionBlock>
     );
 }
 
-function ProjectImagery(props) {
-    var project = props.project;
-    if (project.imageryList != null) {
-        if(project.details && project.details.baseMapSource==null){
-            project.details.baseMapSource="";
-        }
-        return (
-            <div className="row mb-3">
-                <div className="col">
-                    <h2 className="header px-0">Project Imagery</h2>
-                    <div id="project-imagery">
-                        <div className="form-group mb-1">
-                            <h3 htmlFor="base-map-source">Basemap Source</h3>
-                            <select className="form-control form-control-sm" id="base-map-source" name="base-map-source"
-                                    size="1"
-                                    value={project.details?project.details.baseMapSource:""} onChange={props.setBaseMapSource}>
-                                {
-                                    project.imageryList.map((imagery,uid) =>
-                                        <option key={uid} value={imagery.title}>{imagery.title}</option>
-                                    )
-                                }
-                            </select>
-                        </div>
-                    </div>
+function ProjectImagery({ project, setBaseMapSource }) {
+    return (
+        <SectionBlock title="Project Imagery">
+            <div id="project-imagery">
+                <div className="form-group">
+                    <h3 htmlFor="base-map-source">Basemap Source</h3>
+                    <select className="form-control form-control-sm" id="base-map-source" name="base-map-source"
+                            size="1"
+                            value={project.templateDetails && project.templateDetails.baseMapSource != null 
+                                    ? project.templateDetails.baseMapSource 
+                                    : ""} 
+                            onChange={setBaseMapSource}>
+                        {
+                            project.imageryList.map((imagery,uid) =>
+                                <option key={uid} value={imagery.title}>{imagery.title}</option>
+                            )
+                        }
+                    </select>
                 </div>
             </div>
-        );
-    }
-    else {
-        return (<span></span>);
-    }
+        </SectionBlock>
+    );
 }
 
 class PlotDesign extends React.Component {
@@ -1068,128 +806,153 @@ class PlotDesign extends React.Component {
     }
 
     render() {
-        var project = this.props.project;
-        var plotshape = "";
-        var txt = "";
-        if (project.details != null) {
-            if (project.details.plotShape == 'circle') {
-                txt = 'Diameter (m)';
-            } else txt = 'Width (m)';
-            plotshape = <React.Fragment>
-                <p htmlFor="plot-size">{txt}</p>
-                <input className="form-control form-control-sm" type="number" id="plot-size"
-                       name="plot-size" autoComplete="off" min="0.0" step="any"
-                       defaultValue={project.details.plotSize}/>
-            </React.Fragment>
-            return (
-                <div className="row mb-3">
-                    <div className="col">
-                        <h2 className="header px-0">Plot Design</h2>
-                        <div id="plot-design">
-                            <div className="row">
-                                <div id="plot-design-col1" className="col">
-                                    <h3>Spatial Distribution</h3>
-                                    <div className="form-check form-check-inline">
-                                        <input className="form-check-input" type="radio" id="plot-distribution-random"
-                                               name="plot-distribution" defaultValue="random"
-                                               onChange={() => this.props.setPlotDistribution('random')}
-                                               defaultChecked={this.props.project.details.plotDistribution === 'random'}/>
-                                        <label className="form-check-label small"
-                                               htmlFor="plot-distribution-random">Random</label>
-                                    </div>
-                                    <div className="form-check form-check-inline">
-                                        <input className="form-check-input" type="radio" id="plot-distribution-gridded"
-                                               name="plot-distribution" defaultValue="gridded"
-                                               onChange={() => this.props.setPlotDistribution('gridded')}
-                                               defaultChecked={this.props.project.details.plotDistribution === 'gridded'}/>
-                                        <label className="form-check-label small"
-                                               htmlFor="plot-distribution-gridded">Gridded</label>
-                                    </div>
-                                    <div className="form-check form-check-inline">
-                                        <input className="form-check-input" type="radio" id="plot-distribution-csv"
-                                               name="plot-distribution" defaultValue="csv"
-                                               onChange={() => this.props.setPlotDistribution('csv')}
-                                               defaultChecked={this.props.project.details.plotDistribution === 'csv'}/>
-                                        <label
-                                            className="btn btn-sm btn-block btn-outline-lightgreen btn-file py-0 my-0"
-                                            id="custom-csv-upload">
-                                            <small>Upload CSV</small>
-                                            <input type="file" accept="text/csv" id="plot-distribution-csv-file"
-                                                   onChange={this.encodeImageFileAsURL}
-                                                   style={{display: "none"}} disabled/>
-                                        </label>
-                                    </div>
-                                    <div className="form-check form-check-inline">
-                                        <input className="form-check-input" type="radio" id="plot-distribution-shp"
-                                               name="plot-distribution" defaultValue="shp"
-                                               onChange={() => this.props.setPlotDistribution('shp')}
-                                               defaultChecked={this.props.project.details.plotDistribution === 'shp'}/>
-                                        <label
-                                            className="btn btn-sm btn-block btn-outline-lightgreen btn-file py-0 my-0"
-                                            id="custom-shp-upload">
-                                            <small>Upload SHP</small>
-                                            <input type="file" accept="application/zip" id="plot-distribution-shp-file"
-                                                   onChange={this.encodeImageFileAsURL}
-                                                   style={{display: "none"}} disabled/>
-                                        </label>
-                                    </div>
-                                    <p id="plot-design-text">Plot centers will be randomly distributed within the AOI.</p>
+        var { project: { useTemplatePlots, templateDetails, templateDetails : { plotDistribution, plotShape }}} = this.props;
+        return (
+            <SectionBlock title="Plot Design">
+                <div id="plot-design">
+                    <div className="row">
+                        <div id="plot-design-col1" className="col">
+                            <h3>Template Plots</h3>
+                            <div className="form-check form-check-inline">
+                                <input className="form-check-input" type="checkbox" id="use-template-plots"
+                                        name="use-template-plots" defaultValue={useTemplatePlots}
+                                        onChange={() => this.props.setTemplatePlots(!useTemplatePlots)}
+                                        checked={useTemplatePlots}/>
+                                <label className="form-check-label small"
+                                        htmlFor="use-template-plots">Use Template Plots and Samples</label>
+                            </div>
 
-                                    <div className="form-group mb-1">
-                                        <p htmlFor="num-plots">Number of plots</p>
-                                        <input className="form-control form-control-sm" type="number" id="num-plots"
-                                               name="num-plots" autoComplete="off" min="0" step="1"
-                                               defaultValue={project.details == null ? "" : project.details.numPlots}/>
-                                    </div>
-                                    <div className="form-group mb-1">
-                                        <p htmlFor="plot-spacing">Plot spacing (m)</p>
-                                        <input className="form-control form-control-sm" type="number" id="plot-spacing"
-                                               name="plot-spacing" autoComplete="off" min="0.0" step="any"
-                                               defaultValue={project.details == null ? "" : project.details.plotSpacing}
-                                               disabled/>
-                                    </div>
+                            {!useTemplatePlots &&
+                            <Fragment>
+                                <h3>Spatial Distribution</h3>
+                                <div className="form-check form-check-inline">
+                                    <input className="form-check-input" type="radio" id="plot-distribution-random"
+                                            name="plot-distribution" defaultValue="random"
+                                            onChange={() => this.props.setPlotDistribution('random')}
+                                            checked={plotDistribution === 'random'}/>
+                                    <label className="form-check-label small"
+                                            htmlFor="plot-distribution-random">Random</label>
                                 </div>
-                            </div>
-                            <hr/>
-                            <div className="row">
-                                <div id="plot-design-col2" className="col">
-                                    <h3>Plot Shape</h3>
-                                    <div className="form-check form-check-inline">
-                                        <input className="form-check-input" type="radio" id="plot-shape-circle"
-                                               name="plot-shape" defaultValue="circle"
-                                               onChange={() => this.props.setPlotShape('circle')}
-                                               defaultChecked={this.props.project.details.plotShape === 'circle'}/>
-                                        <label className="form-check-label small"
-                                               htmlFor="plot-shape-circle">Circle</label>
-                                    </div>
-                                    <div className="form-check form-check-inline">
-                                        <input className="form-check-input" type="radio" id="plot-shape-square"
-                                               name="plot-shape" defaultValue="square"
-                                               onChange={() => this.props.setPlotShape('square')}
-                                               defaultChecked={this.props.project.details.plotShape === 'square'}/>
-                                        <label className="form-check-label small"
-                                               htmlFor="plot-shape-square">Square</label>
-                                    </div>
-                                    {plotshape}
+                                <div className="form-check form-check-inline">
+                                    <input className="form-check-input" type="radio" id="plot-distribution-gridded"
+                                            name="plot-distribution" defaultValue="gridded"
+                                            onChange={() => this.props.setPlotDistribution('gridded')}
+                                            checked={plotDistribution === 'gridded'}/>
+                                    <label className="form-check-label small"
+                                            htmlFor="plot-distribution-gridded">Gridded</label>
                                 </div>
-                            </div>
+                                <div className="form-check form-check-inline">
+                                    <input className="form-check-input" type="radio" id="plot-distribution-csv"
+                                            name="plot-distribution" defaultValue="csv"
+                                            onChange={() => this.props.setPlotDistribution('csv')}
+                                            checked={plotDistribution === 'csv'}/>
+                                    <label
+                                        className="btn btn-sm btn-block btn-outline-lightgreen btn-file py-0 my-0"
+                                        id="custom-csv-upload">
+                                        <small>Upload CSV</small>
+                                        <input 
+                                            type="file" accept="text/csv" id="plot-distribution-csv-file"
+                                            defaultVale=""
+                                            name="plot-distribution-csv-file"
+                                            onChange={this.encodeImageFileAsURL}
+                                            style={{display: "none"}} 
+                                            disabled={plotDistribution != 'csv'}
+                                        />
+                                    </label>
+                                </div>
+                                <div className="form-check form-check-inline">
+                                    <input className="form-check-input" type="radio" id="plot-distribution-shp"
+                                            name="plot-distribution" defaultValue="shp"
+                                            onChange={() => this.props.setPlotDistribution('shp')}
+                                            checked={plotDistribution === 'shp'}/>
+                                    <label
+                                        className="btn btn-sm btn-block btn-outline-lightgreen btn-file py-0 my-0"
+                                        id="custom-shp-upload">
+                                        <small>Upload SHP</small>
+                                        <input 
+                                            type="file" accept="application/zip" id="plot-distribution-shp-file"
+                                            defaultVale=""
+                                            name="plot-distribution-shp-file"
+                                            onChange={this.encodeImageFileAsURL}
+                                            style={{display: "none"}} 
+                                            disabled = {plotDistribution != 'shp'}/>
+                                    </label>
+                                </div>
+                                <p id="plot-design-text">
+                                    {plotDistribution === 'random' && 
+                                        'Plot centers will be randomly distributed within the AOI.'}
+                                    {plotDistribution === 'gridded' && 
+                                        'Plot centers will be arranged on a grid within the AOI using the plot spacing selected below.'}
+                                    {plotDistribution === 'csv' && 
+                                        'Specify your own plot centers by uploading a CSV with these fields: LONGITUDE,LATITUDE,PLOTID.'}
+                                    {plotDistribution === 'shp' && 
+                                        'Specify your own plot boundaries by uploading a zipped Shapefile (containing SHP, SHX, DBF, and PRJ files) of polygon features. Each feature must have a unique PLOTID field.'}
+                                </p>
+
+                                <div className="form-group mb-1">
+                                    <p htmlFor="num-plots">Number of plots</p>
+                                    <input className="form-control form-control-sm" type="number" id="num-plots"
+                                            name="num-plots" autoComplete="off" min="0" step="1"
+                                            defaultValue={templateDetails.numPlots || ""}
+                                            disabled={plotDistribution != 'random'}
+                                        />
+                                </div>
+                                <div className="form-group mb-1">
+                                    <p htmlFor="plot-spacing">Plot spacing (m)</p>
+                                    <input className="form-control form-control-sm" type="number" id="plot-spacing"
+                                            name="plot-spacing" autoComplete="off" min="0.0" step="any"
+                                            defaultValue={templateDetails.plotSpacing || ""}
+                                            disabled={plotDistribution != 'gridded'}
+                                            />
+                                </div>
+                                <hr/>
+                                <h3>Plot Shape</h3>
+                                <div className="form-check form-check-inline">
+                                    <input className="form-check-input" type="radio" id="plot-shape-circle"
+                                            name="plot-shape" defaultValue="circle"
+                                            onChange={() => this.props.setPlotShape('circle')}
+                                            checked={plotShape === 'circle'}
+                                            disabled ={plotDistribution === 'shp'}
+                                            />
+                                    <label className="form-check-label small"
+                                            htmlFor="plot-shape-circle">Circle</label>
+                                </div>
+                                <div className="form-check form-check-inline">
+                                    <input className="form-check-input" type="radio" id="plot-shape-square"
+                                            name="plot-shape" defaultValue="square"
+                                            onChange={() => this.props.setPlotShape('square')}
+                                            checked={plotShape === 'square'}
+                                            disabled ={plotDistribution === 'shp'}
+                                            />
+                                    <label className="form-check-label small"
+                                            htmlFor="plot-shape-square">Square</label>
+                                </div>
+                                <p htmlFor="plot-size">
+                                    {plotShape == 'circle' ? 'Diameter (m)' : 'Width (m)'}
+                                </p>
+                                <input className="form-control form-control-sm" type="number" id="plot-size"
+                                    name="plot-size" autoComplete="off" min="0.0" step="any"
+                                    defaultValue={templateDetails.plotSize}
+                                    disabled ={plotDistribution === 'shp'}
+                                    />
+                            </Fragment>
+                        }
                         </div>
                     </div>
                 </div>
-            );
-        }
-        else {
-            return (<span></span>);
-        }
+            </SectionBlock>
+        );
     }
+
 }
+
 
 class SampleDesign extends React.Component{
     constructor(props) {
         super(props);
     };
     encodeImageFileAsURL(event) {
-        var file = event.target.files[0];
+        let file = event.target.files[0];
         let reader = new FileReader();
         reader.onloadend = function () {
             let base64Data = reader.result;
@@ -1199,248 +962,257 @@ class SampleDesign extends React.Component{
     }
     render()
     {
-        var project = this.props.project;
-        if (project.details != null) {
-            return (
-                <div className="row mb-3">
-                    <div className="col">
-                        <div id="sample-design">
-                            <h2 className="header px-0">Sample Design</h2>
-                            <h3>Spatial Distribution</h3>
-                            <div className="form-check form-check-inline">
-                                <input className="form-check-input" type="radio" id="sample-distribution-random"
-                                       name="sample-distribution" defaultValue="random"
-                                       onChange={() => this.props.setSampleDistribution('random')}
-                                       defaultChecked={this.props.project.details.sampleDistribution === 'random'}/>
-                                <label className="form-check-label small"
-                                       htmlFor="sample-distribution-random">Random</label>
-                            </div>
-                            <div className="form-check form-check-inline">
-                                <input className="form-check-input" type="radio" id="sample-distribution-gridded"
-                                       name="sample-distribution" defaultValue="gridded"
-                                       onChange={() => this.props.setSampleDistribution('gridded')}
-                                       defaultChecked={this.props.project.details.sampleDistribution === 'gridded'}/>
-                                <label className="form-check-label small"
-                                       htmlFor="sample-distribution-gridded">Gridded</label>
-                            </div>
-                            <div className="form-check form-check-inline">
-                                <input className="form-check-input" type="radio" id="sample-distribution-csv"
-                                       name="sample-distribution" defaultValue="csv"
-                                       onChange={() => this.props.setSampleDistribution('csv')}
-                                       defaultChecked={this.props.project.details.sampleDistribution === 'csv'}/>
-                                <label className="btn btn-sm btn-block btn-outline-lightgreen btn-file py-0 my-0"
-                                       id="sample-custom-csv-upload">
-                                    <small>Upload CSV</small>
-                                    <input type="file" accept="text/csv" id="sample-distribution-csv-file"
-                                           onChange={this.encodeImageFileAsURL}
-                                           style={{display: "none"}} disabled/>
-                                </label>
-                            </div>
-                            <div className="form-check form-check-inline">
-                                <input className="form-check-input" type="radio" id="sample-distribution-shp"
-                                       name="sample-distribution" defaultValue="shp"
-                                       onChange={() => this.props.setSampleDistribution('shp')}
-                                       defaultChecked={this.props.project.details.sampleDistribution === 'shp'}/>
-                                <label className="btn btn-sm btn-block btn-outline-lightgreen btn-file py-0 my-0"
-                                       id="sample-custom-shp-upload">
-                                    <small>Upload SHP</small>
-                                    <input type="file" accept="application/zip" id="sample-distribution-shp-file"
-                                           onChange={this.encodeImageFileAsURL}
-                                           style={{display: "none"}} disabled/>
-                                </label>
-                            </div>
-                            <p id="sample-design-text">Sample points will be randomly distributed within the plot boundary.</p>
-                            <div className="form-group mb-1">
-                                <p htmlFor="samples-per-plot">Samples per plot</p>
-                                <input className="form-control form-control-sm" type="number" id="samples-per-plot"
-                                       name="samples-per-plot" autoComplete="off" min="0" step="1"
-                                       defaultValue={project.details.samplesPerPlot}/>
-                            </div>
-                            <div className="form-group mb-1">
-                                <p htmlFor="sample-resolution">Sample resolution (m)</p>
-                                <input className="form-control form-control-sm" type="number" id="sample-resolution"
-                                       name="sample-resolution" autoComplete="off" min="0.0" step="any"
-                                       defaultValue={project.details.sampleResolution} disabled/>
-                            </div>
-                        </div>
+        const { project: { templateDetails : { plotDistribution, sampleDistribution, samplesPerPlot, sampleResolution }}} = this.props;
+        return (
+            <SectionBlock title="Sample Design">
+                <div id="sample-design">
+                    <h3>Spatial Distribution</h3>
+                    <div className="form-check form-check-inline">
+                        <input className="form-check-input" type="radio" id="sample-distribution-random"
+                                name="sample-distribution" defaultValue="random"
+                                onChange={() => this.props.setSampleDistribution('random')}
+                                checked={sampleDistribution === 'random'}
+                                disabled={plotDistribution === 'shp'}
+                                />
+                        <label className="form-check-label small"
+                                htmlFor="sample-distribution-random">Random</label>
+                    </div>
+                    <div className="form-check form-check-inline">
+                        <input className="form-check-input" type="radio" id="sample-distribution-gridded"
+                                name="sample-distribution" defaultValue="gridded"
+                                onChange={() => this.props.setSampleDistribution('gridded')}
+                                checked={sampleDistribution === 'gridded'}
+                                disabled={plotDistribution === 'shp'}
+                                />
+                        <label className="form-check-label small"
+                                htmlFor="sample-distribution-gridded">Gridded</label>
+                    </div>
+                    <div className="form-check form-check-inline">
+                        <input className="form-check-input" type="radio" id="sample-distribution-csv"
+                                name="sample-distribution" defaultValue="csv"
+                                onChange={() => this.props.setSampleDistribution('csv')}
+                                checked={sampleDistribution === 'csv'}
+                                disabled={plotDistribution === 'random' || plotDistribution === 'gridded'}
+                                />
+                        <label className="btn btn-sm btn-block btn-outline-lightgreen btn-file py-0 my-0"
+                                id="sample-custom-csv-upload">
+                            <small>Upload CSV</small>
+                            <input type="file" accept="text/csv" id="sample-distribution-csv-file"
+                                    name="sample-distribution-csv-file"
+                                    defaultVale=""
+                                    onChange={this.encodeImageFileAsURL}
+                                    style={{display: "none"}} 
+                                    disabled={sampleDistribution != 'csv'}
+                            />
+                        </label>
+                    </div>
+                    <div className="form-check form-check-inline">
+                        <input className="form-check-input" type="radio" id="sample-distribution-shp"
+                                name="sample-distribution" defaultValue="shp"
+                                onChange={() => this.props.setSampleDistribution('shp')}
+                                checked={sampleDistribution === 'shp'}
+                                disabled={plotDistribution === 'random' || plotDistribution === 'gridded'}
+                                />
+                        <label className="btn btn-sm btn-block btn-outline-lightgreen btn-file py-0 my-0"
+                                id="sample-custom-shp-upload">
+                            <small>Upload SHP</small>
+                            <input type="file" accept="application/zip" id="sample-distribution-shp-file"
+                                    name="sample-distribution-shp-file"
+                                    defaultVale=""
+                                    onChange={this.encodeImageFileAsURL}
+                                    style={{display: "none"}} 
+                                    disabled = {sampleDistribution != 'shp'}
+                                    />
+                        </label>
+                    </div>
+                    <p id="sample-design-text">Sample points will be randomly distributed within the plot boundary.</p>
+                    <div className="form-group mb-1">
+                        <p htmlFor="samples-per-plot">Samples per plot</p>
+                        <input className="form-control form-control-sm" type="number" id="samples-per-plot"
+                                name="samples-per-plot" autoComplete="off" min="0" step="1"
+                                defaultValue={samplesPerPlot || ""}
+                                disabled={sampleDistribution != 'random'}/>
+                    </div>
+                    <div className="form-group mb-1">
+                        <p htmlFor="sample-resolution">Sample resolution (m)</p>
+                        <input className="form-control form-control-sm" type="number" id="sample-resolution"
+                                name="sample-resolution" autoComplete="off" min="0.0" step="any"
+                                defaultValue={sampleResolution || ""} 
+                                disabled={sampleDistribution != 'gridded'}/>
                     </div>
                 </div>
-            );
-        }
-        else return (<span></span>);
+            </SectionBlock>
+        );
     }
 }
 
 function SurveyDesign(props){
-    if (props.project.details != null) {
-        var answer_select = "";
-        var dropdowns;
-        var answers = props.getParentSurveyQuestionAnswers(props.project.details.sampleValues);
-        if (answers.length > 0) {
-            answer_select = props.getParentSurveyQuestionAnswers(props.project.details.sampleValues).map((parentSurveyQuestionAnswer, uid) =>
-                <option key={uid}
-                        value={parentSurveyQuestionAnswer.id}>{parentSurveyQuestionAnswer.answer}</option>
-            )
-        }
-        if(props.projectId=="0") {
+    var answer_select = "";
+    var answers = props.getParentSurveyQuestionAnswers(props.project.templateDetails.sampleValues);
+    if (answers.length > 0) {
+        answer_select = props.getParentSurveyQuestionAnswers(props.project.templateDetails.sampleValues).map((parentSurveyQuestionAnswer, uid) =>
+            <option key={uid}
+                    value={parentSurveyQuestionAnswer.id}>{parentSurveyQuestionAnswer.answer}</option>
+        )
+    }
 
-            dropdowns = <React.Fragment>
-                <tr>
-                    <td>
-                        <label htmlFor="value-parent">Parent Question:</label>
-                    </td>
-                    <td>
-                        <select id="value-parent" className="form-control form-control-sm" size="1"
-                                onChange={(e) => props.handleInputParent(e)}>
-                            <option value="">None</option>
-                            {
-                                (props.project.details.sampleValues).map((parentSurveyQuestion, uid) =>
-                                    <option key={uid}
-                                            value={parentSurveyQuestion.id}>{parentSurveyQuestion.question}</option>
-                                )
-                            }
-                        </select>
-                    </td>
-                </tr>
-                <tr>
-                    <td>
-                        <label htmlFor="value-answer">Parent Answer:</label>
-                    </td>
-                    <td>
-                        <select id="value-answer" className="form-control form-control-sm" size="1"
-                                onChange={(e) => props.handleInputParent(e)}>
-                            <option value="">Any</option>
-                            {answer_select}
-                        </select>
-                    </td>
-                </tr>
-            </React.Fragment>;
-        }
-
-
-        return (
-            <div className="row mb-3">
-                <div className="col">
-                    <div id="survey-design">
-                        <h2 className="header px-0">Survey Design</h2>
-                        <SurveyQuestionTree project={props.project} projectId={props.projectId}
-                                            addSurveyQuestionRow={props.addSurveyQuestionRow} topoSort={props.topoSort}
-                                            getParentSurveyQuestions={props.getParentSurveyQuestions}
-                                            removeSurveyQuestion={props.removeSurveyQuestion}
-                                            removeSurveyQuestionRow={props.removeSurveyQuestionRow}
-                                            handleInputColor={props.handleInputColor}
-                                            handleInputName={props.handleInputName}
-                                            handleInputParent={props.handleInputParent}/>
-                        <table>
-                            <tbody>
-                            {dropdowns}
-                            {props.addSurveyQuestionButton}
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
+    return (
+        <SectionBlock title = "Survey Design">
+            <div id="survey-design">
+                <SurveyQuestionTree 
+                    project={props.project}
+                    addSurveyQuestionRow={props.addSurveyQuestionRow} topoSort={props.topoSort}
+                    getParentSurveyQuestions={props.getParentSurveyQuestions}
+                    removeSurveyQuestion={props.removeSurveyQuestion}
+                    removeSurveyQuestionRow={props.removeSurveyQuestionRow}
+                    handleInputColor={props.handleInputColor}
+                    handleInputName={props.handleInputName}
+                    handleInputParent={props.handleInputParent}
+                />
+                <table>
+                    <tbody>
+                        <tr>
+                            <td>
+                                <label htmlFor="value-parent">Parent Question:</label>
+                            </td>
+                            <td>
+                                <select id="value-parent" className="form-control form-control-sm" size="1"
+                                        onChange={(e) => props.handleInputParent(e)}>
+                                    <option value="">None</option>
+                                    {
+                                        (props.project.templateDetails.sampleValues).map((parentSurveyQuestion, uid) =>
+                                            <option key={uid}
+                                                    value={parentSurveyQuestion.id}>{parentSurveyQuestion.question}
+                                            </option>
+                                        )
+                                    }
+                                </select>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <label htmlFor="value-answer">Parent Answer:</label>
+                            </td>
+                            <td>
+                                <select id="value-answer" className="form-control form-control-sm" size="1"
+                                        onChange={(e) => props.handleInputParent(e)}>
+                                    <option value="">Any</option>
+                                    {answer_select}
+                                </select>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><label htmlFor="value-SQ">New Question:</label></td>
+                            <td>
+                                <div id="add-sample-value-group">
+                                    <input type="text" id="surveyQuestionText" autoComplete="off"
+                                        value={project.newSurveyQuestionName}/>
+                                </div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><input type="button" className="button" value="Add Survey Question"
+                                    onClick={props.addSurveyQuestion}/></td>
+                            <td></td>
+                        </tr>
+                    </tbody>
+                </table>
             </div>
-        );
-    }
-    else{
-        return(<span></span>);
-    }
+        </SectionBlock>
+    );
 }
 class SurveyQuestionTree extends React.Component {
     constructor(props) {
         super(props);
     };
-    getCurrent = (node) => this.props.project.details.sampleValues.filter(cNode => cNode.parent_question == node).map((cNode,uid) => (
-        <ul  key={`node_${uid}`} style={{listStyleType:"none"}}>
-            <li>
-                <SurveyQuestion prop={this.props} surveyQuestion={cNode}/>
-                {this.getCurrent(cNode.id)}
-            </li>
+    getCurrent = (node) => 
+        this.props.project.templateDetails.sampleValues.filter(cNode => 
+            cNode.parent_question == node).map((cNode,uid) => (
+                <ul  key={`node_${uid}`} style={{listStyleType:"none"}}>
+                    <li>
+                        <SurveyQuestion parentProps={this.props} surveyQuestion={cNode}/>
+                        {this.getCurrent(cNode.id)}
+                    </li>
 
-        </ul>
+                </ul>
     ))
     render() {
-        var project = this.props.project;
-        if (project.details != null) {
-            return (
-                <div>
-                    {this.getCurrent(-1)}
-                </div>
-            );
-        }
-        else {
-            return (<span></span>);
-        }
+        const { project } = this.props;
+        return (
+            <Fragment>
+                {project.templateDetails && this.getCurrent(-1)}
+            </Fragment>
+        );
     }
 }
 
-function SurveyQuestion(properties) {
-    var props=properties.prop;
-    var project = props.project;
-    if(properties.surveyQuestion.answers==null){
+function SurveyQuestion({ parentProps, parentProps: { project }, surveyQuestion}) {
+    if(surveyQuestion.answers==null){
         console.log("answers null");
     }
-    if (project.details != null) {
-        return (
-            <div className="sample-value-info">
-                <h3 className="header px-0">
-                    <RemoveSurveyQuestionButton projectId={props.projectId}
-                                                removeSurveyQuestion={props.removeSurveyQuestion}
-                                                surveyQuestion={properties.surveyQuestion}/>
-                    <label> Survey Question: {properties.surveyQuestion.question}</label>
-                </h3>
-                <table className="table table-sm">
-                    <thead>
-                    <tr>
-                        <th scope="col"></th>
-                        <th scope="col">Answer</th>
-                        <th scope="col">Color</th>
-                        <th scope="col">&nbsp;</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    {
+    return (
+        <div className="sample-value-info">
+            <h3 className="header px-0">
+                <RemoveSurveyQuestionButton
+                    removeSurveyQuestion={parentProps.removeSurveyQuestion}
+                    surveyQuestion={surveyQuestion}
+                />
+                <label> Survey Question: {surveyQuestion.question}</label>
+            </h3>
+            <table className="table table-sm">
+                <thead>
+                <tr>
+                    <th scope="col"></th>
+                    <th scope="col">Answer</th>
+                    <th scope="col">Color</th>
+                    <th scope="col">&nbsp;</th>
+                </tr>
+                </thead>
+                <tbody>
+                {
 
-                        (properties.surveyQuestion.answers).map((surveyAnswer, uid) => {
+                    (surveyQuestion.answers).map((surveyAnswer, uid) => {
 
-                                return <tr key={uid}>
-                                    <td>
-                                        <RemoveSurveyQuestionRowButton projectId={props.projectId}
-                                                                       removeSurveyQuestionRow={props.removeSurveyQuestionRow}
-                                                                       surveyQuestion={properties.surveyQuestion}
-                                                                       surveyAnswer={surveyAnswer}/>
-                                    </td>
+                            return <tr key={uid}>
+                                <td>
+                                    {surveyAnswer && 
+                                        <RemoveSurveyQuestionRowButton 
+                                            removeSurveyQuestionRow={parentProps.removeSurveyQuestionRow}
+                                            surveyQuestion={surveyQuestion}
+                                            surveyAnswer={surveyAnswer}
+                                        />
+                                    }
+                                </td>
 
-                                    <td>
-                                        {surveyAnswer.answer}
-                                    </td>
-                                    <td>
-                                        <div className="circle"
-                                             style={{backgroundColor: surveyAnswer.color, border: "solid 1px"}}></div>
-                                    </td>
-                                    <td>
-                                        &nbsp;
-                                    </td>
-                                </tr>
-                            }
-                        )
-                    }
-                    <SurveyQuestionTable project={project} projectId={props.projectId}
-                                         surveyQuestion={properties.surveyQuestion}
-                                         getParentSurveyQuestions={props.getParentSurveyQuestions}
-                                         addSurveyQuestionRow={props.addSurveyQuestionRow}
-                                         handleInputName={props.handleInputName}
-                                         handleInputColor={props.handleInputColor}
-                                         handleInputParent={props.handleInputParent}/>
-                    </tbody>
-                </table>
-            </div>
+                                <td>
+                                    {surveyAnswer.answer}
+                                </td>
+                                <td>
+                                    <div className="circle"
+                                            style={{backgroundColor: surveyAnswer.color, border: "solid 1px"}}></div>
+                                </td>
+                                <td>
+                                    &nbsp;
+                                </td>
+                            </tr>
+                        }
+                    )
+                }
+                <SurveyQuestionTable 
+                    project={project}
+                    surveyQuestion={surveyQuestion}
+                    getParentSurveyQuestions={parentProps.getParentSurveyQuestions}
+                    addSurveyQuestionRow={parentProps.addSurveyQuestionRow}
+                    handleInputName={parentProps.handleInputName}
+                    handleInputColor={parentProps.handleInputColor}
+                    handleInputParent={parentProps.handleInputParent}
+                />
+                </tbody>
+            </table>
+        </div>
 
-        );
-    }
-    else {
-        return (<span></span>);
-    }
+    );
+
 }
 
 function RemoveSurveyQuestionButton(props) {
@@ -1450,13 +1222,10 @@ function RemoveSurveyQuestionButton(props) {
 }
 
 function RemoveSurveyQuestionRowButton(props) {
-    if (props.surveyAnswer) {
-        return (
-            <input type="button" className="button" value="-"
-                   onClick={() => props.removeSurveyQuestionRow(props.surveyQuestion.question, props.surveyAnswer.answer)}/>
-        );
-    }
-    else return (<h1></h1>);
+    return (
+        <input type="button" className="button" value="-"
+                onClick={() => props.removeSurveyQuestionRow(props.surveyQuestion.question, props.surveyAnswer.answer)}/>
+    );
 }
 
 function SurveyQuestionTable(props) {
@@ -1486,23 +1255,26 @@ function SurveyQuestionTable(props) {
 
 function ProjectManagement(props) {
     return (
-        <div id="project-management" className="col mb-3">
-            <h2 className="header px-0">Project Management</h2>
-            <div className="row">
-                <input type="button" id="create-project" className="btn btn-outline-danger btn-sm btn-block"
-                       name="create-project" value="Create Project"
-                       onClick={props.createProject}/>
-                <div id="spinner"></div>
+        <SectionBlock title="Project Management">
+            <div id="project-management">
+                <div className="row">
+                    <input type="button" id="create-project" className="btn btn-outline-danger btn-sm btn-block"
+                        name="create-project" value="Create Project"
+                        onClick={props.createProject}/>
+                    <div id="spinner"></div>
+                </div>
             </div>
-        </div>
+        </SectionBlock>
     );
 }
 
 export function renderCreateProjectPage(args) {
     ReactDOM.render(
-        <Project documentRoot={args.documentRoot} userId={args.userId} projectId={args.projectId} institutionId={args.institutionId}
-                 project_stats_visibility={args.project_stats_visibility}
-                 project_template_visibility={args.project_template_visibility}/>,
+        <Project 
+            documentRoot={args.documentRoot} 
+            userId={args.userId} 
+            institutionId={args.institutionId}
+        />,
         document.getElementById("project")
     );
 }

--- a/src/main/resources/public/jsx/create-project.js
+++ b/src/main/resources/public/jsx/create-project.js
@@ -673,18 +673,18 @@ function ProjectVisibility({ project : { templateDetails : { privacyLevel } } })
     return (
         <SectionBlock title= "Project Visibility">
             <h3>Privacy Level</h3>
-            <div id="project-visibility" className="mb-3">
+            <div id="project-visibility" className="mb-3" style={{'font-size': '.9rem'}}>
                 <div className="form-check form-check-inline">
                     <input className="form-check-input" type="radio" id="privacy-public" name="privacy-level"
                             value="public" checked={privacyLevel === 'public'}
                             onChange={() => props.setPrivacyLevel('public')}/>
-                    <label className="form-check-label small" htmlFor="privacy-public">Public: <i>All Users</i></label>
+                    <label className="form-check-label" htmlFor="privacy-public">Public: <i>All Users</i></label>
                 </div>
                 <div className="form-check form-check-inline">
                     <input className="form-check-input" type="radio" id="privacy-private" name="privacy-level"
                             value="private" onChange={() => props.setPrivacyLevel('private')}
                             checked={privacyLevel === 'private'}/>
-                    <label className="form-check-label small" htmlFor="privacy-private">Private: <i>Group
+                    <label className="form-check-label" htmlFor="privacy-private">Private: <i>Group
                         Admins</i></label>
                 </div>
                 <div className="form-check form-check-inline">
@@ -692,7 +692,7 @@ function ProjectVisibility({ project : { templateDetails : { privacyLevel } } })
                             name="privacy-level"
                             value="institution" onChange={() => props.setPrivacyLevel('institution')}
                             checked={privacyLevel === 'institution'}/>
-                    <label className="form-check-label small" htmlFor="privacy-institution">Institution: <i>Group
+                    <label className="form-check-label" htmlFor="privacy-institution">Institution: <i>Group
                         Members</i></label>
                 </div>
                 <div className="form-check form-check-inline">
@@ -700,7 +700,7 @@ function ProjectVisibility({ project : { templateDetails : { privacyLevel } } })
                             name="privacy-level"
                             value="invitation" onChange={() => props.setPrivacyLevel('invitation')} disabled
                             checked={privacyLevel === 'invitation'}/>
-                    <label className="form-check-label small" htmlFor="privacy-invitation">Invitation: <i>Coming
+                    <label className="form-check-label" htmlFor="privacy-invitation">Invitation: <i>Coming
                         Soon</i></label>
                 </div>
             </div>
@@ -809,7 +809,7 @@ class PlotDesign extends React.Component {
           <div className="row">
             <div id="plot-design-col1" className="col">
               <h3>Template Plots</h3>
-              <div className="form-check form-check-inline">
+              <div className="form-check form-check-inline mb-3">
                 <input
                   className="form-check-input"
                   type="checkbox"
@@ -822,7 +822,7 @@ class PlotDesign extends React.Component {
                   checked={useTemplatePlots}
                 />
                 <label
-                  className="form-check-label small"
+                  className="form-check-label medium"
                   htmlFor="use-template-plots"
                 >
                   Use Template Plots and Samples
@@ -843,7 +843,7 @@ class PlotDesign extends React.Component {
                       checked={plotDistribution === "random"}
                     />
                     <label
-                      className="form-check-label small"
+                      className="form-check-label medium"
                       htmlFor="plot-distribution-random"
                     >
                       Random
@@ -860,7 +860,7 @@ class PlotDesign extends React.Component {
                       checked={plotDistribution === "gridded"}
                     />
                     <label
-                      className="form-check-label small"
+                      className="form-check-label medium"
                       htmlFor="plot-distribution-gridded"
                     >
                       Gridded
@@ -880,7 +880,7 @@ class PlotDesign extends React.Component {
                       className="btn btn-sm btn-block btn-outline-lightgreen btn-file py-0 my-0"
                       id="custom-csv-upload"
                     >
-                      <small>Upload CSV</small>
+                      <medium>Upload CSV</medium>
                       <input
                         type="file"
                         accept="text/csv"
@@ -907,7 +907,7 @@ class PlotDesign extends React.Component {
                       className="btn btn-sm btn-block btn-outline-lightgreen btn-file py-0 my-0"
                       id="custom-shp-upload"
                     >
-                      <small>Upload SHP</small>
+                      <medium>Upload SHP</medium>
                       <input
                         type="file"
                         accept="application/zip"
@@ -920,7 +920,7 @@ class PlotDesign extends React.Component {
                       />
                     </label>
                   </div>
-                  <p id="plot-design-text">
+                  <p id="plot-design-text" className="font-italic ml-2">-
                     {plotDistribution === "random" &&
                       "Plot centers will be randomly distributed within the AOI."}
                     {plotDistribution === "gridded" &&
@@ -973,7 +973,7 @@ class PlotDesign extends React.Component {
                       disabled={plotDistribution === "shp"}
                     />
                     <label
-                      className="form-check-label small"
+                      className="form-check-label medium"
                       htmlFor="plot-shape-circle"
                     >
                       Circle
@@ -991,7 +991,7 @@ class PlotDesign extends React.Component {
                       disabled={plotDistribution === "shp"}
                     />
                     <label
-                      className="form-check-label small"
+                      className="form-check-label medium"
                       htmlFor="plot-shape-square"
                     >
                       Square
@@ -1049,7 +1049,7 @@ class SampleDesign extends React.Component {
                             checked={sampleDistribution === 'random'}
                             disabled={plotDistribution === 'shp'}
                         />
-                        <label className="form-check-label small"
+                        <label className="form-check-label medium"
                             htmlFor="sample-distribution-random">
                             Random
                         </label>
@@ -1062,7 +1062,7 @@ class SampleDesign extends React.Component {
                             checked={sampleDistribution === 'gridded'}
                             disabled={plotDistribution === 'shp'}
                         />
-                        <label className="form-check-label small"
+                        <label className="form-check-label medium"
                             htmlFor="sample-distribution-gridded">
                             Gridded
                         </label>
@@ -1077,7 +1077,7 @@ class SampleDesign extends React.Component {
                         />
                         <label className="btn btn-sm btn-block btn-outline-lightgreen btn-file py-0 my-0"
                             id="sample-custom-csv-upload">
-                            <small>Upload CSV</small>
+                            <medium>Upload CSV</medium>
                             <input 
                                 type="file" accept="text/csv" id="sample-distribution-csv-file"
                                 name="sample-distribution-csv-file"
@@ -1098,7 +1098,7 @@ class SampleDesign extends React.Component {
                         />
                         <label className="btn btn-sm btn-block btn-outline-lightgreen btn-file py-0 my-0"
                             id="sample-custom-shp-upload">
-                            <small>Upload SHP</small>
+                            <medium>Upload SHP</medium>
                             <input
                                 type="file" accept="application/zip" id="sample-distribution-shp-file"
                                 name="sample-distribution-shp-file"
@@ -1109,7 +1109,7 @@ class SampleDesign extends React.Component {
                             />
                         </label>
                     </div>
-                    <p id="sample-design-text">
+                    <p id="sample-design-text" className="font-italic ml-2">-
                         {sampleDistribution === 'random' &&
                             'Sample points will be randomly distributed within the plot boundary.'}
                         {sampleDistribution === 'gridded' &&

--- a/src/main/resources/public/jsx/institution.js
+++ b/src/main/resources/public/jsx/institution.js
@@ -250,7 +250,7 @@ class Institution extends React.Component {
         } else if (this.state.details.id == -1) {
             alert("Projects cannot be created without first selecting an institution.");
         } else {
-            window.location = this.props.documentRoot + "/create-project/0?institution=" + this.state.details.id;
+            window.location = this.props.documentRoot + "/create-project?institution=" + this.state.details.id;
         }
     }
 

--- a/src/main/resources/public/jsx/review-institution.js
+++ b/src/main/resources/public/jsx/review-institution.js
@@ -252,7 +252,7 @@ class Institution extends React.Component {
         } else if (this.state.details.id == -1) {
             alert("Projects cannot be created without first selecting an institution.");
         } else {
-            window.location = this.props.documentRoot + "/create-project/0?institution=" + this.state.details.id;
+            window.location = this.props.documentRoot + "/create-project?institution=" + this.state.details.id;
         }
     }
 

--- a/src/main/resources/public/jsx/review-project.js
+++ b/src/main/resources/public/jsx/review-project.js
@@ -351,7 +351,7 @@ class Project extends React.Component {
         mercator.removeLayerByTitle(this.state.mapConfig, "flaggedPlots");
         mercator.removeLayerByTitle(this.state.mapConfig, "analyzedPlots");
         mercator.removeLayerByTitle(this.state.mapConfig, "unanalyzedPlots");
-        this.showPlotCenters(projectId, 100);
+        this.showPlotCenters(projectId, 300);
     }
 
     updateUnmanagedComponents(projectId) {

--- a/src/main/resources/public/jsx/review-project.js
+++ b/src/main/resources/public/jsx/review-project.js
@@ -48,6 +48,8 @@ class Project extends React.Component {
     };
 
     componentDidMount() {
+        // FIXME use promises to load map only once after correct data is loaded
+        // FIXME Use promises to load imagery after project data is loaded so we can use the projects institutionId
         this.getProjectStats();
         this.getImageryList();
         this.getProjectById();

--- a/src/main/resources/public/jsx/review-project.js
+++ b/src/main/resources/public/jsx/review-project.js
@@ -1,10 +1,10 @@
 import React, { Fragment }  from 'react';
 import ReactDOM from 'react-dom';
-import { mercator, ceoMapStyles } from "../js/mercator-openlayers.js";
-import { utils } from "../js/utils.js";
 
 import FormLayout from "./components/FormLayout"
 import SectionBlock from "./components/SectionBlock"
+import { mercator, ceoMapStyles } from "../js/mercator-openlayers.js";
+import { utils } from "../js/utils.js";
 
 class Project extends React.Component {
     constructor(props) {
@@ -468,7 +468,7 @@ function ProjectStats({ project }) {
 
 function ProjectDesignReview(props) {
     return (
-        <form id="project-design-form" className="px-2 pb-2">
+        <div id="project-design-form" className="px-2 pb-2">
             <ProjectInfoReview project={props.project}/>
             <ProjectVisibility project={props.project}/>
             <ProjectAOI projectId={props.projectId} project={props.project}/>
@@ -484,7 +484,7 @@ function ProjectDesignReview(props) {
                 getParentSurveyQuestionAnswers={props.getParentSurveyQuestionAnswers}
             />
 
-        </form>
+        </div>
     );
 }
 

--- a/src/main/resources/public/jsx/review-project.js
+++ b/src/main/resources/public/jsx/review-project.js
@@ -1,13 +1,16 @@
-import React from 'react';
+import React, { Fragment }  from 'react';
 import ReactDOM from 'react-dom';
 import { mercator, ceoMapStyles } from "../js/mercator-openlayers.js";
 import { utils } from "../js/utils.js";
+
+import FormLayout from "./components/FormLayout"
+import SectionBlock from "./components/SectionBlock"
 
 class Project extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            details: null,
+            projectDetails: null,
             stats: null,
             imageryList: null,
             mapConfig: null,
@@ -55,7 +58,7 @@ class Project extends React.Component {
             utils.show_element("spinner");
             var ref = this;
             $.ajax({
-                url: this.props.documentRoot + "/publish-project/" + this.state.details.id,
+                url: this.props.documentRoot + "/publish-project/" + this.state.projectDetails.id,
                 type: "POST",
                 async: true,
                 crossDomain: true,
@@ -65,9 +68,9 @@ class Project extends React.Component {
                 console.log(response);
                 alert("Error publishing project. See console for details.");
             }).done(function (data) {
-                var detailsNew = ref.state.details;
+                var detailsNew = ref.state.projectDetails;
                 detailsNew.availability = "published";
-                ref.setState({details: detailsNew});
+                ref.setState({projectDetails: detailsNew});
                 utils.hide_element("spinner");
             });
         }
@@ -78,7 +81,7 @@ class Project extends React.Component {
             utils.show_element("spinner");
             var ref = this;
             $.ajax({
-                url: this.props.documentRoot + "/close-project/" + this.state.details.id,
+                url: this.props.documentRoot + "/close-project/" + this.state.projectDetails.id,
                 type: "POST",
                 async: true,
                 crossDomain: true,
@@ -88,9 +91,9 @@ class Project extends React.Component {
                 console.log(response);
                 alert("Error closing project. See console for details.");
             }).done(function (data) {
-                var detailsNew = ref.state.details;
+                var detailsNew = ref.state.projectDetails;
                 detailsNew.availability = "closed";
-                ref.setState({details: detailsNew});
+                ref.setState({projectDetails: detailsNew});
                 utils.hide_element("spinner");
             });
         }
@@ -101,7 +104,7 @@ class Project extends React.Component {
             utils.show_element("spinner");
             var ref = this;
             $.ajax({
-                url: this.props.documentRoot + "/archive-project/" + this.state.details.id,
+                url: this.props.documentRoot + "/archive-project/" + this.state.projectDetails.id,
                 type: "POST",
                 async: true,
                 crossDomain: true,
@@ -111,44 +114,44 @@ class Project extends React.Component {
                 console.log(response);
                 alert("Error archiving project. See console for details.");
             }).done(function (data) {
-                var detailsNew = ref.state.details;
+                var detailsNew = ref.state.projectDetails;
                 detailsNew.availability = "archived";
-                ref.setState({details: detailsNew});
+                ref.setState({projectDetails: detailsNew});
                 utils.hide_element("spinner");
-                alert("Project " + ref.state.details.id + " has been archived.");
+                alert("Project " + ref.state.projectDetails.id + " has been archived.");
                 window.location = ref.props.documentRoot + "/home";
             });
         }
     }
 
     changeAvailability() {
-        if (this.state.details.availability == "nonexistent") {
+        if (this.state.projectDetails.availability == "nonexistent") {
             this.createProject();
-        } else if (this.state.details.availability == "unpublished") {
+        } else if (this.state.projectDetails.availability == "unpublished") {
             this.publishProject();
-        } else if (this.state.details.availability == "published") {
+        } else if (this.state.projectDetails.availability == "published") {
             this.closeProject();
-        } else if (this.state.details.availability == "closed") {
+        } else if (this.state.projectDetails.availability == "closed") {
             this.archiveProject();
         }
     }
 
     configureGeoDash() {
 
-        if (this.state.plotList != null && this.state.details != null) {
+        if (this.state.plotList != null && this.state.projectDetails != null) {
             window.open(this.props.documentRoot + "/widget-layout-editor?editable=true&"
-                + encodeURIComponent("institutionId=" + this.state.details.institution
-                    + "&pid=" + this.state.details.id),
+                + encodeURIComponent("institutionId=" + this.state.projectDetails.institution
+                    + "&pid=" + this.state.projectDetails.id),
                 "_geo-dash");
         }
     }
 
     downloadPlotData() {
-        window.open(this.props.documentRoot + "/dump-project-aggregate-data/" + this.state.details.id, "_blank");
+        window.open(this.props.documentRoot + "/dump-project-aggregate-data/" + this.state.projectDetails.id, "_blank");
     }
 
     downloadSampleData() {
-        window.open(this.props.documentRoot + "/dump-project-raw-data/" + this.state.details.id, "_blank");
+        window.open(this.props.documentRoot + "/dump-project-raw-data/" + this.state.projectDetails.id, "_blank");
     }
 
     getParentSurveyQuestions(sampleSurvey) {
@@ -211,7 +214,7 @@ class Project extends React.Component {
     }
 
     getSurveyQuestionByName(surveyQuestionName) {
-        return this.state.details.sampleValues.find(
+        return this.state.projectDetails.sampleValues.find(
             function (surveyQuestion) {
                 return surveyQuestion.question == surveyQuestionName;
             }
@@ -265,7 +268,7 @@ class Project extends React.Component {
                         );
                     }
                     detailsNew.sampleValues=newSV;
-                    this.setState({details: detailsNew});
+                    this.setState({projectDetails: detailsNew});
                     this.updateUnmanagedComponents(projectId);
 
                 }
@@ -316,7 +319,7 @@ class Project extends React.Component {
             })
             .then(data => {
                 this.setState({plotList: data});
-                mercator.addPlotOverviewLayers(this.state.mapConfig, this.state.plotList, this.state.details.plotShape);
+                mercator.addPlotOverviewLayers(this.state.mapConfig, this.state.plotList, this.state.projectDetails.plotShape);
             })
             .catch(e => this.setState({plotList: null}));
     }
@@ -327,10 +330,10 @@ class Project extends React.Component {
             this.setState({mapConfig: mercator.createMap("project-map", [0.0, 0.0], 1, this.state.imageryList)});
         }
 
-        mercator.setVisibleLayer(this.state.mapConfig, this.state.details.baseMapSource);
+        mercator.setVisibleLayer(this.state.mapConfig, this.state.projectDetails.baseMapSource);
         
         // Extract bounding box coordinates from the project boundary and show on the map
-        var boundaryExtent = mercator.parseGeoJson(this.state.details.boundary, false).getExtent();
+        var boundaryExtent = mercator.parseGeoJson(this.state.projectDetails.boundary, false).getExtent();
         this.setState({lonMin: boundaryExtent[0]});
         this.setState({latMin: boundaryExtent[1]});
         this.setState({lonMax: boundaryExtent[2]});
@@ -340,11 +343,11 @@ class Project extends React.Component {
         mercator.removeLayerByTitle(this.state.mapConfig, "currentAOI");
         mercator.addVectorLayer(this.state.mapConfig,
             "currentAOI",
-            mercator.geometryToVectorSource(mercator.parseGeoJson(this.state.details.boundary, true)),
+            mercator.geometryToVectorSource(mercator.parseGeoJson(this.state.projectDetails.boundary, true)),
             ceoMapStyles.yellowPolygon);
         mercator.zoomMapToLayer(this.state.mapConfig, "currentAOI");
 
-        // Update plots
+        // Show plots
         mercator.removeLayerByTitle(this.state.mapConfig, "flaggedPlots");
         mercator.removeLayerByTitle(this.state.mapConfig, "analyzedPlots");
         mercator.removeLayerByTitle(this.state.mapConfig, "unanalyzedPlots");
@@ -352,503 +355,360 @@ class Project extends React.Component {
     }
 
     updateUnmanagedComponents(projectId) {
-        if (this.state.details != null) {
-            // Enable the input fields that are connected to the radio buttons if their values are not null
-            if (this.state.details.plotDistribution == "gridded") {
-                utils.enable_element("plot-spacing");
-            }
-            if (this.state.details.sampleDistribution == "gridded") {
-                utils.enable_element("sample-resolution");
-            }
-
+        if (this.state.projectDetails != null) {
             if (this.state.imageryList && this.state.imageryList.length > 0) {
-                var detailsNew = this.state.details;
-                detailsNew.baseMapSource = this.state.details.baseMapSource || this.state.imageryList[0].title;
+                var detailsNew = this.state.projectDetails;
+                detailsNew.baseMapSource = this.state.projectDetails.baseMapSource || this.state.imageryList[0].title;
                 // If baseMapSource isn't provided by the project, just use the first entry in the imageryList
-                this.setState({details: detailsNew});
+                this.setState({projectDetails: detailsNew});
                 this.showProjectMap(projectId)
                 // Draw a map with the project AOI and a sampling of its plots
             }
         }
     }
     gotoProjectDashboard(){
-        if (this.state.plotList != null && this.state.details != null) {
-            window.open(this.props.documentRoot + "/project-dashboard/"+this.state.details.id);
+        if (this.state.plotList != null && this.state.projectDetails != null) {
+            window.open(this.props.documentRoot + "/project-dashboard/"+this.state.projectDetails.id);
         }
     }
 
     render() {
         return (
-            <div id="project-design" className="col-xl-6 col-lg-8 border bg-lightgray mb-5">
-                <div className="bg-darkgreen mb-3 no-container-margin">
-                    <h1>Review Project</h1>
-                </div>
-                <ProjectStats project={this.state} project_stats_visibility={true}/>
-                <ProjectDesignForm projectId={this.props.projectId} project={this.state}
-                                   project_template_visibility={false}
-                                   setBaseMapSource={this.setBaseMapSource}
-                                   topoSort={this.topoSort} getParentSurveyQuestions={this.getParentSurveyQuestions} getParentSurveyQuestionAnswers={this.getParentSurveyQuestionAnswers}/>
-                <ProjectManagement project={this.state} projectId={this.props.projectId}
-                                   configureGeoDash={this.configureGeoDash} downloadPlotData={this.downloadPlotData}
-                                   downloadSampleData={this.downloadSampleData}
-                                   changeAvailability={this.changeAvailability} gotoProjectDashboard={this.gotoProjectDashboard}/>
-            </div>
+            <FormLayout id="project-design"  title="Review Project">
+                {this.state.projectDetails && parseInt(this.state.projectDetails.id) > 0
+                ?
+                    <Fragment>
+                        {this.state.stats && 
+                            <ProjectStats project={this.state}/>
+                        }
+                        <ProjectDesignReview 
+                            projectId={this.props.projectId} 
+                            project={this.state}
+                            project_template_visibility={false}
+                            setBaseMapSource={this.setBaseMapSource}
+                            topoSort={this.topoSort} 
+                            getParentSurveyQuestions={this.getParentSurveyQuestions} 
+                            getParentSurveyQuestionAnswers={this.getParentSurveyQuestionAnswers}
+                        />
+                        <ProjectManagement 
+                            project={this.state} 
+                            projectId={this.props.projectId}
+                            configureGeoDash={this.configureGeoDash} downloadPlotData={this.downloadPlotData}
+                            downloadSampleData={this.downloadSampleData}
+                            changeAvailability={this.changeAvailability} 
+                            gotoProjectDashboard={this.gotoProjectDashboard}
+                        />
+                    </Fragment>
+                :
+                    <ProjectNotFount projectId={this.props.projectId} />
+                }
+            </FormLayout>
         );
     }
 }
 
-function ProjectStats(props) {
-    var project = props.project;
-    if (project.stats != null) {
-        return (<div className="row mb-3">
-                <div id="project-stats" className={"col " + props.project_stats_visibility}>
-                    <button className="btn btn-outline-lightgreen btn-sm btn-block mb-1" data-toggle="collapse"
-                            href="#project-stats-collapse" role="button" aria-expanded="false"
-                            aria-controls="project-stats-collapse">
-                        Project Stats
-                    </button>
-                    <div className="collapse col-xl-12" id="project-stats-collapse">
-                        <table className="table table-sm">
-                            <tbody>
-                            <tr>
-                                <td>Members</td>
-                                <td>{project.stats.members}</td>
-                                <td>Contributors</td>
-                                <td>{project.stats.contributors}</td>
-                            </tr>
-                            <tr>
-                                <td>Total Plots</td>
-                                <td>{project.details?project.details.numPlots : 0}</td>
-                                <td>Date Created</td>
-                                <td>{project.dateCreated}</td>
-                            </tr>
-                            <tr>
-                                <td>Flagged Plots</td>
-                                <td>{project.stats.flaggedPlots}</td>
-                                <td>Date Published</td>
-                                <td>{project.datePublished}</td>
-                            </tr>
-                            <tr>
-                                <td>Analyzed Plots</td>
-                                <td>{project.stats.analyzedPlots}</td>
-                                <td>Date Closed</td>
-                                <td>{project.dateClosed}</td>
-                            </tr>
-                            <tr>
-                                <td>Unanalyzed Plots</td>
-                                <td>{project.stats.unanalyzedPlots}</td>
-                                <td>Date Archived</td>
-                                <td>{project.dateArchived}</td>
-                            </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-            </div>
-
-        );
-    }
-    else {
-        return (<span></span>);
-    }
+function ProjectNotFount({ projectId }){
+    return (
+        <SectionBlock title="Project Information">
+            <h3>Project {projectId} not found.</h3>
+        </SectionBlock>
+    )
 }
 
-function ProjectDesignForm(props) {
+function ProjectStats({ project }) {
+    return (
+        <div className="row mb-3">
+            <div id="project-stats" className={"col "}>
+                <button className="btn btn-outline-lightgreen btn-sm btn-block mb-1" data-toggle="collapse"
+                        href="#project-stats-collapse" role="button" aria-expanded="false"
+                        aria-controls="project-stats-collapse">
+                    Project Stats
+                </button>
+                <div className="collapse col-xl-12" id="project-stats-collapse">
+                    <table className="table table-sm">
+                        <tbody>
+                        <tr>
+                            <td>Members</td>
+                            <td><span className="badge badge-pill bg-lightgreen">{project.stats.members}</span></td>
+                            <td>Contributors</td>
+                            <td>{project.stats.contributors}</td>
+                        </tr>
+                        <tr>
+                            <td>Total Plots</td>
+                            <td><span className="badge badge-pill bg-lightgreen">{project.projectDetails ? project.projectDetails.numPlots : 0}</span></td>
+                            <td>Date Created</td>
+                            <td>{project.dateCreated}</td>
+                        </tr>
+                        <tr>
+                            <td>Flagged Plots</td>
+                            <td><span className="badge badge-pill bg-lightgreen">{project.stats.flaggedPlots}</span></td>
+                            <td>Date Published</td>
+                            <td><span className="badge badge-pill bg-lightgreen">{project.datePublished}</span></td>
+                        </tr>
+                        <tr>
+                            <td>Analyzed Plots</td>
+                            <td><span className="badge badge-pill bg-lightgreen">{project.stats.analyzedPlots}</span></td>
+                            <td>Date Closed</td>
+                            <td><span className="badge badge-pill bg-lightgreen">{project.dateClosed}</span></td>
+                        </tr>
+                        <tr>
+                            <td>Unanalyzed Plots</td>
+                            <td><span className="badge badge-pill bg-lightgreen">{project.stats.unanalyzedPlots}</span></td>
+                            <td>Date Archived</td>
+                            <td><span className="badge badge-pill bg-lightgreen">{project.dateArchived}</span></td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+
+    );
+}
+
+function ProjectDesignReview(props) {
     return (
         <form id="project-design-form" className="px-2 pb-2">
-            <ProjectInfo project={props.project}/>
+            <ProjectInfoReview project={props.project}/>
             <ProjectVisibility project={props.project}/>
             <ProjectAOI projectId={props.projectId} project={props.project}/>
-            <ProjectImagery project={props.project} setBaseMapSource={props.setBaseMapSource}/>
-            <PlotDesign project={props.project}/>
-            <SampleDesign project={props.project}/>
-            <SurveyDesign project={props.project} projectId={props.projectId}
-                          topoSort={props.topoSort}
-                          getParentSurveyQuestions={props.getParentSurveyQuestions} getParentSurveyQuestionAnswers={props.getParentSurveyQuestionAnswers}/>
+            {props.project.imageryList &&
+                <ProjectImageryReview project={props.project} setBaseMapSource={props.setBaseMapSource}/>
+            }
+            <PlotReview project={props.project}/>
+            <SampleReview project={props.project}/>
+            <SurveyReview 
+                project={props.project} projectId={props.projectId}
+                topoSort={props.topoSort}
+                getParentSurveyQuestions={props.getParentSurveyQuestions} 
+                getParentSurveyQuestionAnswers={props.getParentSurveyQuestionAnswers}
+            />
 
         </form>
     );
 }
 
-function ProjectInfo(props) {
-    var project = props.project;
-    if (project.details != null) {
-        return (
-            <div className="row">
-                <div className="col">
-                    <h2 className="header px-0">Project Info</h2>
-                    <div id="project-info">
-                        <div className="form-group">
-                            <h3 htmlFor="project-name">Name</h3>
-                            <input className="form-control form-control-sm" type="text" id="project-name" name="name"
-                                   autoComplete="off" defaultValue={project.details.name}
-                                   />
-                        </div>
-                        <div className="form-group">
-                            <h3 htmlFor="project-description">Description</h3>
-                            <textarea className="form-control form-control-sm" id="project-description"
-                                      name="description"
-                                      defaultValue={project.details.description}></textarea>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        );
-    }
-    else {
-        return (<span></span>);
-    }
+function ProjectInfoReview({ project }) {
+    return (
+        <SectionBlock id="project-info" title="Project Info">
+            <h3>Name</h3>
+            <p className="ml-2">{project.projectDetails.name}</p>
+            <h3>Description</h3>
+            <p className="ml-2">{project.projectDetails.description}</p>
+        </SectionBlock>
+    );
 }
 
+// FIXME potential to let the user change the visibility
 function ProjectVisibility(props) {
-    if (props.project.details != null) {
-        return (
-            <div className="row">
-                <div className="col">
-                    <h2 className="header px-0">Project Visibility</h2>
-                    <h3>Privacy Level</h3>
-                    <div id="project-visibility" className="mb-3">
-                        <div className="form-check form-check-inline">
-                            <input className="form-check-input" type="radio" id="privacy-public" name="privacy-level"
-                                   value="public" defaultChecked={props.project.details.privacyLevel === 'public'}
-                                   />
-                            <label className="form-check-label small" htmlFor="privacy-public">Public: <i>All Users</i></label>
-                        </div>
-                        <div className="form-check form-check-inline">
-                            <input className="form-check-input" type="radio" id="privacy-private" name="privacy-level"
-                                   value="private"
-                                   defaultChecked={props.project.details.privacyLevel === 'private'}/>
-                            <label className="form-check-label small" htmlFor="privacy-private">Private: <i>Group
-                                Admins</i></label>
-                        </div>
-                        <div className="form-check form-check-inline">
-                            <input className="form-check-input" type="radio" id="privacy-institution"
-                                   name="privacy-level"
-                                   value="institution"
-                                   defaultChecked={props.project.details.privacyLevel === 'institution'}/>
-                            <label className="form-check-label small" htmlFor="privacy-institution">Institution: <i>Group
-                                Members</i></label>
-                        </div>
-                        <div className="form-check form-check-inline">
-                            <input className="form-check-input" type="radio" id="privacy-invitation"
-                                   name="privacy-level"
-                                   value="invitation" disabled
-                                   defaultChecked={props.project.details.privacyLevel === 'invitation'}/>
-                            <label className="form-check-label small" htmlFor="privacy-invitation">Invitation: <i>Coming
-                                Soon</i></label>
-                        </div>
-                    </div>
+    return (
+        <SectionBlock title="Project Visibility">
+            <h3>Privacy Level</h3>
+            <div id="project-visibility" className="mb-3">
+                <div className="form-check form-check-inline">
+                    <input className="form-check-input" type="radio" id="privacy-public" name="privacy-level"
+                            value="public" defaultChecked={props.project.projectDetails.privacyLevel === 'public'}
+                            disabled
+                            />
+                    <label className="form-check-label small" htmlFor="privacy-public">Public: <i>All Users</i></label>
+                </div>
+                <div className="form-check form-check-inline">
+                    <input className="form-check-input" type="radio" id="privacy-private" name="privacy-level"
+                            value="private"
+                            defaultChecked={props.project.projectDetails.privacyLevel === 'private'}
+                            disabled
+                            />
+                    <label className="form-check-label small" htmlFor="privacy-private">Private: <i>Group
+                        Admins</i></label>
+                </div>
+                <div className="form-check form-check-inline">
+                    <input className="form-check-input" type="radio" id="privacy-institution"
+                            name="privacy-level"
+                            value="institution"
+                            defaultChecked={props.project.projectDetails.privacyLevel === 'institution'}
+                            disabled
+                            />
+                    <label className="form-check-label small" htmlFor="privacy-institution">Institution: <i>Group
+                        Members</i></label>
+                </div>
+                <div className="form-check form-check-inline">
+                    <input className="form-check-input" type="radio" id="privacy-invitation"
+                            name="privacy-level"
+                            value="invitation"
+                            defaultChecked={props.project.projectDetails.privacyLevel === 'invitation'}
+                            disabled
+                            />
+                    <label className="form-check-label small" htmlFor="privacy-invitation">Invitation: <i>Coming
+                        Soon</i></label>
                 </div>
             </div>
-        );
-    }
-    return (<span></span>);
+        </SectionBlock>
+    );
 }
 
 function ProjectAOI({ project: { latMax, lonMin, lonMax, latMin } }) {
     return (
-        <div className="row">
-            <div className="col">
-                <h2 className="header px-0">Project AOI</h2>
-                <div id="project-aoi">
-                    <div id="project-map"></div>
-                    <div className="form-group mx-4">
-                        <div className="row">
-                            <div className="col-md-6 offset-md-3">
-                                <input className="form-control form-control-sm" type="number" id="lat-max" name="lat-max"
-                                       defaultValue={latMax} placeholder="North" autoComplete="off" min="-90.0"
-                                       max="90.0" step="any"/>
-                            </div>
+        <SectionBlock title="Project AOI">
+            <div id="project-aoi">
+                <div id="project-map"></div>
+                <div className="form-group mx-4">
+                    <div className="row">
+                        <div className="col-md-6 offset-md-3">
+                            <input 
+                                className="form-control form-control-sm" type="number" id="lat-max" name="lat-max"
+                                defaultValue={latMax} placeholder="North" autoComplete="off" min="-90.0"
+                                max="90.0" step="any"
+                                disabled
+                            />
                         </div>
-                        <div className="row">
-                            <div className="col-md-6">
-                                <input className="form-control form-control-sm" type="number" id="lon-min" name="lon-min"
-                                       defaultValue={lonMin} placeholder="West" autoComplete="off" min="-180.0"
-                                       max="180.0" step="any"/>
-                            </div>
-                            <div className="col-md-6">
-                                <input className="form-control form-control-sm" type="number" id="lon-max" name="lon-max"
-                                       defaultValue={lonMax} placeholder="East" autoComplete="off" min="-180.0"
-                                       max="180.0" step="any"/>
-                            </div>
+                    </div>
+                    <div className="row">
+                        <div className="col-md-6">
+                            <input 
+                                className="form-control form-control-sm" type="number" id="lon-min" name="lon-min"
+                                defaultValue={lonMin} placeholder="West" autoComplete="off" min="-180.0"
+                                max="180.0" step="any"
+                                disabled
+                            />
                         </div>
-                        <div className="row">
-                            <div className="col-md-6 offset-md-3">
-                                <input className="form-control form-control-sm" type="number" id="lat-min" name="lat-min"
-                                       defaultValue={latMin} placeholder="South" autoComplete="off" min="-90.0"
-                                       max="90.0" step="any"/>
-                            </div>
+                        <div className="col-md-6">
+                            <input 
+                                className="form-control form-control-sm" type="number" id="lon-max" name="lon-max"
+                                defaultValue={lonMax} placeholder="East" autoComplete="off" min="-180.0"
+                                max="180.0" step="any"
+                                disabled
+                            />
+                        </div>
+                    </div>
+                    <div className="row">
+                        <div className="col-md-6 offset-md-3">
+                            <input 
+                                className="form-control form-control-sm" type="number" id="lat-min" name="lat-min"
+                                defaultValue={latMin} placeholder="South" autoComplete="off" min="-90.0"
+                                max="90.0" step="any"
+                                disabled
+                            />
                         </div>
                     </div>
                 </div>
             </div>
-        </div>
+        </SectionBlock>
     );
 }
 
-function ProjectImagery(props) {
-    var project = props.project;
-    if (project.imageryList != null) {
-        if(project.details && project.details.baseMapSource==null){
-            project.details.baseMapSource="";
-        }
-        return (
-            <div className="row mb-3">
-                <div className="col">
-                    <h2 className="header px-0">Project Imagery</h2>
-                    <div id="project-imagery">
-                        <div className="form-group mb-1">
-                            <h3 htmlFor="base-map-source">Basemap Source</h3>
-                            <select className="form-control form-control-sm" id="base-map-source" name="base-map-source"
-                                    size="1"
-                                    defaultValue={project.details?project.details.baseMapSource:""} 
-                                    onChange={props.setBaseMapSource}>
-                                {
-                                    project.imageryList.map((imagery,uid) =>
-                                        <option key={uid} value={imagery.title}>{imagery.title}</option>
-                                    )
-                                }
-                            </select>
-                        </div>
+function ProjectImageryReview({ project, setBaseMapSource}) {
+    return (
+        <SectionBlock id="project-imagery-review" title="Project Imagery">
+            <h3>Basemap Source</h3>
+            <p className="ml-2">{project.projectDetails.baseMapSource}</p>
+        </SectionBlock>
+    );
+}
+
+function PlotReview({ project: { projectDetails: { plotDistribution, numPlots, plotSpacing, plotShape, plotSize }} }) {
+    return (
+        <SectionBlock title="Plot Review">
+            <div id="plot-design">
+                <div className="row">
+                    <div id="plot-design-col1" className="col">
+                        <table id="plot-review-table" className="table table-sm">
+                        <tbody>
+                            <tr>
+                                <td className="w-80">Spatial Distribution</td>
+                                <td className="w-20 text-center">
+                                    <span className="badge badge-pill bg-lightgreen">{plotDistribution} distribution</span>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td className="w-80">Number of plots</td>
+                                <td className="w-20 text-center">
+                                    <span className="badge badge-pill bg-lightgreen">{numPlots} plots</span>
+                                </td>
+                            </tr>
+                            {plotDistribution === 'gridded' &&
+                                <tr>
+                                    <td className="w-80">Plot spacing</td>
+                                    <td className="w-20 text-center">
+                                        <span className="badge badge-pill bg-lightgreen">{plotSpacing} m</span>
+                                    </td>
+                                </tr>
+                            }
+                            {plotDistribution != 'shp' &&
+                                <Fragment>
+                                    <tr>
+                                        <td className="w-80">Plot shape</td>
+                                        <td className="w-20 text-center">
+                                            <span className="badge badge-pill bg-lightgreen">{plotShape}</span>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td className="w-80">Plot size</td>
+                                        <td className="w-20 text-center">
+                                            <span className="badge badge-pill bg-lightgreen">{plotSize} m</span>
+                                        </td>
+                                    </tr>
+                                </Fragment>
+                            }
+                        </tbody>
+                        </table>
                     </div>
                 </div>
             </div>
-        );
-    }
-    else {
-        return (<span></span>);
-    }
+        </SectionBlock>
+    );
 }
 
-class PlotDesign extends React.Component {
-    constructor(props) {
-        super(props);
-    };
+function SampleReview({ project: { projectDetails: { plotDistribution, sampleDistribution, samplesPerPlot, sampleResolution }} }){
 
-    encodeImageFileAsURL(event) {
-        var file = event.target.files[0];
-        let reader = new FileReader();
-        reader.onloadend = function () {
-            let base64Data = reader.result;
-            console.log('RESULT', base64Data);
-        };
-        reader.readAsDataURL(file);
-    }
-
-    render() {
-        var project = this.props.project;
-        var plotshape = "";
-        var txt = "";
-        if (project.details != null) {
-            if (project.details.plotShape == 'circle') {
-                txt = 'Diameter (m)';
-            } else txt = 'Width (m)';
-            plotshape = <React.Fragment>
-                <p htmlFor="plot-size">{txt}</p>
-                <input className="form-control form-control-sm" type="number" id="plot-size"
-                       name="plot-size" autoComplete="off" min="0.0" step="any"
-                       defaultValue={project.details.plotSize}/>
-            </React.Fragment>
-            return (
-                <div className="row mb-3">
-                    <div className="col">
-                        <h2 className="header px-0">Plot Design</h2>
-                        <div id="plot-design">
-                            <div className="row">
-                                <div id="plot-design-col1" className="col">
-                                    <h3>Spatial Distribution</h3>
-                                    <div className="form-check form-check-inline">
-                                        <input className="form-check-input" type="radio" id="plot-distribution-random"
-                                               name="plot-distribution" value="random"
-                                               defaultChecked={this.props.project.details.plotDistribution === 'random'}/>
-                                        <label className="form-check-label small"
-                                               htmlFor="plot-distribution-random">Random</label>
-                                    </div>
-                                    <div className="form-check form-check-inline">
-                                        <input className="form-check-input" type="radio" id="plot-distribution-gridded"
-                                               name="plot-distribution" defaultValue="gridded"
-                                               defaultChecked={this.props.project.details.plotDistribution === 'gridded'}/>
-                                        <label className="form-check-label small"
-                                               htmlFor="plot-distribution-gridded">Gridded</label>
-                                    </div>
-                                    <div className="form-check form-check-inline">
-                                        <input className="form-check-input" type="radio" id="plot-distribution-csv"
-                                               name="plot-distribution" defaultValue="csv"
-                                               defaultChecked={this.props.project.details.plotDistribution === 'csv'}/>
-                                        <label
-                                            className="btn btn-sm btn-block btn-outline-lightgreen btn-file py-0 my-0"
-                                            id="custom-csv-upload">
-                                            <small>Upload CSV</small>
-                                            <input type="file" accept="text/csv" id="plot-distribution-csv-file"
-                                                   style={{display: "none"}} disabled/>
-                                        </label>
-                                    </div>
-                                    <div className="form-check form-check-inline">
-                                        <input className="form-check-input" type="radio" id="plot-distribution-shp"
-                                               name="plot-distribution" defaultValue="shp"
-                                               defaultChecked={this.props.project.details.plotDistribution === 'shp'}/>
-                                        <label
-                                            className="btn btn-sm btn-block btn-outline-lightgreen btn-file py-0 my-0"
-                                            id="custom-shp-upload">
-                                            <small>Upload SHP</small>
-                                            <input type="file" accept="application/zip" id="plot-distribution-shp-file"
-                                                   style={{display: "none"}} disabled/>
-                                        </label>
-                                    </div>
-                                    <p id="plot-design-text">Plot centers will be randomly distributed within the AOI.</p>
-
-                                    <div className="form-group mb-1">
-                                        <p htmlFor="num-plots">Number of plots</p>
-                                        <input className="form-control form-control-sm" type="number" id="num-plots"
-                                               name="num-plots" autoComplete="off" min="0" step="1"
-                                               defaultValue={project.details == null ? "" : project.details.numPlots}/>
-                                    </div>
-                                    <div className="form-group mb-1">
-                                        <p htmlFor="plot-spacing">Plot spacing (m)</p>
-                                        <input className="form-control form-control-sm" type="number" id="plot-spacing"
-                                               name="plot-spacing" autoComplete="off" min="0.0" step="any"
-                                               defaultValue={project.details == null ? "" : project.details.plotSpacing}
-                                               disabled/>
-                                    </div>
-                                </div>
-                            </div>
-                            <hr/>
-                            <div className="row">
-                                <div id="plot-design-col2" className="col">
-                                    <h3>Plot Shape</h3>
-                                    <div className="form-check form-check-inline">
-                                        <input className="form-check-input" type="radio" id="plot-shape-circle"
-                                               name="plot-shape" defaultValue="circle"
-                                               defaultChecked={this.props.project.details.plotShape === 'circle'}/>
-                                        <label className="form-check-label small"
-                                               htmlFor="plot-shape-circle">Circle</label>
-                                    </div>
-                                    <div className="form-check form-check-inline">
-                                        <input className="form-check-input" type="radio" id="plot-shape-square"
-                                               name="plot-shape" defaultValue="square"
-                                               defaultChecked={this.props.project.details.plotShape === 'square'}/>
-                                        <label className="form-check-label small"
-                                               htmlFor="plot-shape-square">Square</label>
-                                    </div>
-                                    {plotshape}
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+    return (
+        <SectionBlock title="Sample Design">
+                <div id="sample-design">
+                    <table id="plot-review-table" className="table table-sm">
+                    <tbody>
+                        <tr>
+                            <td className="w-80">Spatial Distribution</td>
+                            <td className="w-20 text-center">
+                                <span className="badge badge-pill bg-lightgreen">{sampleDistribution} distribution</span>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td className="w-80">Samples Per Plot</td>
+                            <td className="w-20 text-center">
+                                <span className="badge badge-pill bg-lightgreen">{samplesPerPlot} /plot</span>
+                            </td>
+                        </tr>
+                        {sampleDistribution === 'gridded' &&
+                            <tr>
+                                <td className="w-80">Sample Resolution</td>
+                                <td className="w-20 text-center">
+                                    <span className="badge badge-pill bg-lightgreen">{sampleResolution} m</span>
+                                </td>
+                            </tr>
+                        }
+                        
+                    </tbody>
+                    </table>
                 </div>
-            );
-        }
-        else {
-            return (<span></span>);
-        }
-    }
+        </SectionBlock>
+    );
 }
 
-class SampleDesign extends React.Component{
-    constructor(props) {
-        super(props);
-    };
-    encodeImageFileAsURL(event) {
-        var file = event.target.files[0];
-        let reader = new FileReader();
-        reader.onloadend = function () {
-            let base64Data = reader.result;
-            console.log('RESULT', base64Data);
-        };
-        reader.readAsDataURL(file);
-    }
-    render()
-    {
-        var project = this.props.project;
-        if (project.details != null) {
-            return (
-                <div className="row mb-3">
-                    <div className="col">
-                        <div id="sample-design">
-                            <h2 className="header px-0">Sample Design</h2>
-                            <h3>Spatial Distribution</h3>
-                            <div className="form-check form-check-inline">
-                                <input className="form-check-input" type="radio" id="sample-distribution-random"
-                                       name="sample-distribution" defaultValue="random"
-                                       defaultChecked={this.props.project.details.sampleDistribution === 'random'}/>
-                                <label className="form-check-label small"
-                                       htmlFor="sample-distribution-random">Random</label>
-                            </div>
-                            <div className="form-check form-check-inline">
-                                <input className="form-check-input" type="radio" id="sample-distribution-gridded"
-                                       name="sample-distribution" defaultValue="gridded"
-                                       defaultChecked={this.props.project.details.sampleDistribution === 'gridded'}/>
-                                <label className="form-check-label small"
-                                       htmlFor="sample-distribution-gridded">Gridded</label>
-                            </div>
-                            <div className="form-check form-check-inline">
-                                <input className="form-check-input" type="radio" id="sample-distribution-csv"
-                                       name="sample-distribution" defaultValue="csv"
-                                       defaultChecked={this.props.project.details.sampleDistribution === 'csv'}/>
-                                <label className="btn btn-sm btn-block btn-outline-lightgreen btn-file py-0 my-0"
-                                       id="sample-custom-csv-upload">
-                                    <small>Upload CSV</small>
-                                    <input type="file" accept="text/csv" id="sample-distribution-csv-file"
-                                           style={{display: "none"}} disabled/>
-                                </label>
-                            </div>
-                            <div className="form-check form-check-inline">
-                                <input className="form-check-input" type="radio" id="sample-distribution-shp"
-                                       name="sample-distribution" defaultValue="shp"
-                                       defaultChecked={this.props.project.details.sampleDistribution === 'shp'}/>
-                                <label className="btn btn-sm btn-block btn-outline-lightgreen btn-file py-0 my-0"
-                                       id="sample-custom-shp-upload">
-                                    <small>Upload SHP</small>
-                                    <input type="file" accept="application/zip" id="sample-distribution-shp-file"
-                                           style={{display: "none"}} disabled/>
-                                </label>
-                            </div>
-                            <p id="sample-design-text">Sample points will be randomly distributed within the plot boundary.</p>
-                            <div className="form-group mb-1">
-                                <p htmlFor="samples-per-plot">Samples per plot</p>
-                                <input className="form-control form-control-sm" type="number" id="samples-per-plot"
-                                       name="samples-per-plot" autoComplete="off" min="0" step="1"
-                                       defaultValue={project.details.samplesPerPlot}/>
-                            </div>
-                            <div className="form-group mb-1">
-                                <p htmlFor="sample-resolution">Sample resolution (m)</p>
-                                <input className="form-control form-control-sm" type="number" id="sample-resolution"
-                                       name="sample-resolution" autoComplete="off" min="0.0" step="any"
-                                       defaultValue={project.details.sampleResolution} disabled/>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            );
-        }
-        else return (<span></span>);
-    }
-}
-
-function SurveyDesign(props){
-    if (props.project.details != null) {
-        return (
-            <div className="row mb-3">
-                <div className="col">
-                    <div id="survey-design">
-                        <h2 className="header px-0">Survey Design</h2>
-                        <SurveyQuestionTree project={props.project} projectId={props.projectId}
-                                            topoSort={props.topoSort}
-                                            getParentSurveyQuestions={props.getParentSurveyQuestions}/>
-                    </div>
-                </div>
+function SurveyReview(props){
+    return (
+        <SectionBlock title="Survey Design">
+            <div id="survey-design">
+                <SurveyQuestionTree project={props.project} projectId={props.projectId}
+                                    topoSort={props.topoSort}
+                                    getParentSurveyQuestions={props.getParentSurveyQuestions}/>
             </div>
-        );
-    }
-    else{
-        return(<span></span>);
-    }
+        </SectionBlock>
+    );
 }
 class SurveyQuestionTree extends React.Component {
     constructor(props) {
         super(props);
     };
-    getCurrent = (node) => this.props.project.details.sampleValues.filter(cNode => cNode.parent_question == node).map((cNode,uid) => (
+    getCurrent = (node) => this.props.project.projectDetails.sampleValues.filter(cNode => cNode.parent_question == node).map((cNode,uid) => (
         <ul  key={`node_${uid}`} style={{listStyleType:"none"}}>
             <li>
                 <SurveyQuestion prop={this.props} surveyQuestion={cNode}/>
@@ -859,7 +719,7 @@ class SurveyQuestionTree extends React.Component {
     ))
     render() {
         var project = this.props.project;
-        if (project.details != null) {
+        if (project.projectDetails != null) {
             return (
                 <div>
                     {this.getCurrent(-1)}
@@ -878,7 +738,7 @@ function SurveyQuestion(properties) {
     if (properties.surveyQuestion.answers == null) {
         console.log("answers null");
     }
-    if (project.details != null) {
+    if (project.projectDetails != null) {
         return (
             <div className="sample-value-info">
                 <h3 className="header px-0">
@@ -924,7 +784,7 @@ function SurveyQuestion(properties) {
 function ProjectManagement(props) {
     var project = props.project;
     var buttons = "";
-    if (project.details != null) {
+    if (project.projectDetails != null) {
         buttons = <React.Fragment>
             <input type="button" id="project-dashboard" className="btn btn-outline-lightgreen btn-sm btn-block"
                    name="project-dashboard" value="Project Dashboard"
@@ -933,21 +793,21 @@ function ProjectManagement(props) {
             <input type="button" id="configure-geo-dash" className="btn btn-outline-lightgreen btn-sm btn-block"
                    name="configure-geo-dash" value="Configure Geo-Dash"
                    onClick={props.configureGeoDash}
-                   style={{display: project.details.availability == 'unpublished' || project.details.availability == 'published' ? 'block' : 'none'}}/>
+                   style={{display: project.projectDetails.availability == 'unpublished' || project.projectDetails.availability == 'published' ? 'block' : 'none'}}/>
             <input type="button" id="download-plot-data"
                    className="btn btn-outline-lightgreen btn-sm btn-block"
                    name="download-plot-data" value="Download Plot Data"
                    onClick={props.downloadPlotData}
-                   style={{display: project.details.availability == 'published' || project.details.availability == 'closed' ? 'block' : 'none'}}/>
+                   style={{display: project.projectDetails.availability == 'published' || project.projectDetails.availability == 'closed' ? 'block' : 'none'}}/>
             <input type="button" id="download-sample-data"
                    className="btn btn-outline-lightgreen btn-sm btn-block"
                    name="download-sample-data" value="Download Sample Data"
                    onClick={props.downloadSampleData}
-                   style={{display: project.details.availability == 'published' || project.details.availability == 'closed' ? 'block' : 'none'}}/>
+                   style={{display: project.projectDetails.availability == 'published' || project.projectDetails.availability == 'closed' ? 'block' : 'none'}}/>
             <input type="button" id="change-availability"
                    className="btn btn-outline-danger btn-sm btn-block"
                    name="change-availability"
-                   value={project.stateTransitions[project.details.availability] + "Project"}
+                   value={project.stateTransitions[project.projectDetails.availability] + "Project"}
                    onClick={props.changeAvailability}/>
         </React.Fragment>
     }

--- a/src/main/resources/scripts/data_migration.py
+++ b/src/main/resources/scripts/data_migration.py
@@ -3,6 +3,7 @@ import json
 import psycopg2
 import os
 import csv
+import re
 import subprocess
 from config import config
 params = config()
@@ -11,7 +12,6 @@ jsonpath = r'../../../../target/classes/json'
 csvpath = r'../../../../target/classes/csv'
 shppath = r'../../../../target/classes/shp'
 
-#jsonpath = r'../json'
 def insert_users():
     conn = None
     user_id=-1
@@ -38,7 +38,6 @@ def insert_users():
 
 def insert_institutions():
     conn = None
-    institution_id=-1
     try:
         conn = psycopg2.connect(**params)
         cur = conn.cursor()
@@ -72,8 +71,6 @@ def insert_institutions():
                     user_id=pending
                     role_id=3
                     cur1.execute("select * from add_institution_user(%s,%s,%s)", (institution['id'],user_id,role_id))
-            conn.commit()
-            institution_id = cur.fetchone()[0]
             conn.commit()
         cur.close()
     except (Exception, psycopg2.DatabaseError) as error:
@@ -137,7 +134,7 @@ def insert_projects():
         print(len(projectArr))
         for project in projectArr:
             try:
-                if project['id']>0:
+                if project['id'] > 0:
                     print("inserting project with project id"+str(project['id']))
                     if project['numPlots'] is None: project['numPlots']=0
                     if project['plotSpacing'] is None: project['plotSpacing']=0
@@ -162,11 +159,17 @@ def insert_projects():
                         if dash_id.isnumeric() and int(dash['projectID']) == int(project_id):
                             insert_project_widgets(project_id,dash_id,conn)
                             break
-
+                    ## insert data the entire json file at a time, much faster but requires permissions
                     insert_plots_samples_by_file(project_id, conn)
+                    
+                    ## insert data by row with loops
+                    # insert_plots(project_id, conn)
+                    
+                    ## merge in external files
                     merge_files(project, project_id, conn)
                     conn.commit()
             except(Exception, psycopg2.DatabaseError) as error:
+                conn.commit()
                 print("project for loop: "+ str(error))
         cur.close()
     except (Exception, psycopg2.DatabaseError) as error:
@@ -211,28 +214,32 @@ def insert_plots(project_id,conn):
                     plot['flagged']=0
                 else:
                     plot['flagged']=1
+                
+                if not ('collectionStart' in plot): plot['collectionStart']=None
+                if not ('collectionTime' in plot) or re.search('^\d+$', plot['collectionTime']) is None : plot['collectionTime']=None
 
                 cur_plot.execute("select * from create_project_plot(%s,ST_SetSRID(ST_GeomFromGeoJSON(%s), 4326))",
                 (project_id,plot['center']))
 
                 plot_id = cur_plot.fetchone()[0]
                 if plot['user'] is not None:
-                    user_plot_id=insert_user_plots(plot_id,plot['user'],boolean_Flagged,conn)
+                    user_plot_id=insert_user_plots(plot_id,plot,boolean_Flagged,conn)
                 insert_samples(plot_id,plot['samples'],user_plot_id,conn)
                 conn.commit()
             except (Exception, psycopg2.DatabaseError) as error:
                 print("plots error: "+ str(error))
     cur_plot.close()
 
-def insert_user_plots(plot_id,user,flagged,conn):
+def insert_user_plots(plot_id,plot,flagged,conn):
     user_plot_id=-1
     cur_up = conn.cursor()
     cur_user = conn.cursor()
-    cur_user.execute("select id from users where email=%s;",(user,))
+    cur_user.execute("select id from users where email=%s;",[plot['user']])
     rows = cur_user.fetchall()
     if len(rows)>0:
         try:
-            cur_up.execute("select * from add_user_plots_migration(%s,%s::text,%s)",(plot_id,user,flagged))
+            cur_up.execute("select * from add_user_plots_migration(%s,%s::text,to_timestamp(%s/1000.0)::timestamp,to_timestamp(%s/1000.0)::timestamp,%s)",
+                (plot_id,plot['user'],plot['collectionStart'],plot['collectionTime'],flagged))
             user_plot_id = cur_up.fetchone()[0]
             conn.commit()
         except (Exception, psycopg2.DatabaseError) as error:
@@ -250,16 +257,23 @@ def insert_samples(plot_id,samples,user_plot_id,conn):
 
             sample_id = cur_sample.fetchone()[0]
             if user_plot_id != -1 and 'value' in sample:
-                insert_sample_values(user_plot_id,sample_id,sample['value'],conn)
+                if not ('userImage' in sample):
+                    sample['image_id'] = None
+                    sample['image_attributes'] = None
+                else:
+                    sample['image_id'] = sample['userImage']['id']
+                    sample['image_attributes'] = sample['userImage']['attributes']
+                insert_sample_values(user_plot_id,sample_id,sample['value'],sample['image_id'],sample['image_attributes'],conn)
             conn.commit()
         except (Exception, psycopg2.DatabaseError) as error:
                 print("samples error: "+ str(error))
     cur_sample.close()
 
-def insert_sample_values(user_plot_id,sample_id,sample_value,conn):
+def insert_sample_values(user_plot_id,sample_id,sample_value,image_id,image_value,conn):
     cur_sv = conn.cursor()
     try:
-        cur_sv.execute("select * from add_sample_values_migration(%s,%s,%s::jsonb)",(user_plot_id,sample_id,json.dumps(sample_value)))
+        cur_sv.execute("select * from add_sample_values_migration(%s,%s,%s::jsonb,%s,%s::jsonb)",
+            (user_plot_id,sample_id,json.dumps(sample_value),image_id,json.dumps(image_value)))
     except (Exception, psycopg2.DatabaseError) as error:
                 print("sample values error: "+ str(error))
     conn.commit()
@@ -268,18 +282,22 @@ def insert_sample_values(user_plot_id,sample_id,sample_value,conn):
 # builds list of old name to become lon, lat
 def csvColRenameList(csvCols):
     renameCol = []
-    renameCol.append([csvCols[0], 'lon'])
-    renameCol.append([csvCols[1], 'lat'])
+    renameCol.append([csvCols[0].replace(" ", ""), 'lon'])
+    renameCol.append([csvCols[1].replace(" ", ""), 'lat'])
     return renameCol
 
 # files should have lat lon in the first 2 columns, returns string
 def csvHeaderToCol(csvCols):
     colsStr = ''
     for i, h in enumerate(csvCols):
-        if i <=1:
-            colsStr += h + ' float,'
-        else:
-            colsStr += h + ' text,'
+        h = h.replace(" ", "")
+        if len(h) > 0:
+            if i <=1:
+                colsStr += h + ' float,'
+            elif (i == 2 and h.upper() == "PLOTID") or (i == 3 and h.upper() == "SAMPLEID"):
+                colsStr += h + ' integer,'
+            else:
+                colsStr += h + ' text,'
     return colsStr[:-1]
 
 def checkRequiredCols(actualCols, reqCols):
@@ -474,19 +492,22 @@ def merge_files(project, project_id, conn):
         cur.execute("SELECT * FROM update_project_tables(%s,%s,%s)" , [project_id, plots_table, samples_table])
         conn.commit()
 
-        if need_to_update >= 2:
-            # clean up project tables
-            cur.execute("SELECT * FROM cleanup_project_tables(%s,%s)" , [project_id, project['plotSize']])
-            conn.commit()
+        try:
+            if need_to_update >= 2:
+                # clean up project tables
+                cur.execute("SELECT * FROM cleanup_project_tables(%s,%s)" , [project_id, project['plotSize']])
+                conn.commit()
 
-        if need_to_update == 3:
-            # merge files into plots and samples
-            cur.execute("SELECT * FROM merge_plot_and_file(%s)" , [project_id])
-            conn.commit()
-        else:
-            # merge files into plots
-            cur.execute("SELECT * FROM merge_plots_only(%s)" , [project_id])
-            conn.commit()
+            if need_to_update == 3:
+                # merge files into plots and samples
+                cur.execute("SELECT * FROM merge_plot_and_file(%s)" , [project_id])
+                conn.commit()
+            else:
+                # merge files into plots
+                cur.execute("SELECT * FROM merge_plots_only(%s)" , [project_id])
+                conn.commit()
+        finally:
+            pass
 
     except (Exception, psycopg2.DatabaseError) as error:
         print("merge file error: "+ str(error))

--- a/src/main/resources/sql/load_ceo_functions.sql
+++ b/src/main/resources/sql/load_ceo_functions.sql
@@ -214,11 +214,11 @@ CREATE OR REPLACE FUNCTION get_user_stats(_user_email text)
 	),
 	proj_agg as (
 		SELECT
-			format('{%s}', string_agg(format('"%s":"%s"', proj_id, plot_cnt), ',')) as count_json,
+			format('{%s}', string_agg(format('"%s":%s', proj_id, plot_cnt), ',')) as count_json,
 			format('{%s}', string_agg((CASE WHEN sec_avg IS NULL THEN
-					format('"%s":"%s"',proj_id, 0)  			 
+					format('"%s":%s',proj_id, 0)  			 
 				ELSE
-					format('"%s":"%s"', proj_id, sec_avg)
+					format('"%s":%s', proj_id, sec_avg)
 				END) , ',')) as avg_json
 		FROM proj_groups
 	)

--- a/src/main/resources/template/freemarker/account.ftl
+++ b/src/main/resources/template/freemarker/account.ftl
@@ -1,7 +1,7 @@
 <#include "header.ftl">
 <#include "navbar.ftl">
 <#include "start-content.ftl">
-<div id="account" class="row justify-content-center"></div>
+<div id="account"></div>
 <script type="text/javascript" src="${root}/js/vendors~account~collection~create_institution~create_project~geodashreact~home~project_dashboard~rev~1b583733.bundle.js"></script>
 <script type="text/javascript" src="${root}/js/account.bundle.js"></script>
 <script type="text/javascript">

--- a/src/main/resources/template/freemarker/account.ftl
+++ b/src/main/resources/template/freemarker/account.ftl
@@ -1,9 +1,7 @@
 <#include "header.ftl">
 <#include "navbar.ftl">
 <#include "start-content.ftl">
-<div class="row justify-content-center">
-	<div id="account" class="col-xl-6 col-lg-8 border bg-lightgray mb-5"></div>
-</div>
+<div id="account" class="row justify-content-center"></div>
 <script type="text/javascript" src="${root}/js/vendors~account~collection~create_institution~create_project~geodashreact~home~project_dashboard~rev~1b583733.bundle.js"></script>
 <script type="text/javascript" src="${root}/js/account.bundle.js"></script>
 <script type="text/javascript">

--- a/src/main/resources/template/freemarker/create-project.ftl
+++ b/src/main/resources/template/freemarker/create-project.ftl
@@ -1,18 +1,8 @@
 <#include "header.ftl">
 <#include "navbar.ftl">
 <#include "start-content.ftl">
-<#if project_id == "">
-    <#assign project_id = "0">
-</#if>
 <#if institution_id == "">
     <#assign institution_id = "0">
-</#if>
-<#if project_id == "0">
-    <#assign project_stats_visibility = "d-none">
-    <#assign project_template_visibility = "visible">
-<#else>
-    <#assign project_stats_visibility = "visible">
-    <#assign project_template_visibility = "d-none">
 </#if>
 <div id="project" class="row justify-content-center"></div>
 <script type="text/javascript" src="${root}/js/vendors~account~collection~create_institution~create_project~geodashreact~home~project_dashboard~rev~1b583733.bundle.js"></script>
@@ -23,10 +13,7 @@
      create_project.renderCreateProjectPage({
          documentRoot:                "${root}",
          userId:                      "${userid}",
-         projectId:                   "${project_id}",
          institutionId:               "${institution_id}",
-         project_stats_visibility:    "${project_stats_visibility}",
-         project_template_visibility: "${project_template_visibility}"
      });
  };
 </script>

--- a/src/main/resources/template/freemarker/create-project.ftl
+++ b/src/main/resources/template/freemarker/create-project.ftl
@@ -4,7 +4,7 @@
 <#if institution_id == "">
     <#assign institution_id = "0">
 </#if>
-<div id="project" class="row justify-content-center"></div>
+<div id="project"></div>
 <script type="text/javascript" src="${root}/js/vendors~account~collection~create_institution~create_project~geodashreact~home~project_dashboard~rev~1b583733.bundle.js"></script>
 <script type="text/javascript" src="${root}/js/collection~create_project~geodashreact~home~project_dashboard~review_project.bundle.js"></script>
 <script type="text/javascript" src="${root}/js/create_project.bundle.js"></script>

--- a/src/main/resources/template/freemarker/review-project.ftl
+++ b/src/main/resources/template/freemarker/review-project.ftl
@@ -7,13 +7,6 @@
 <#if institution_id == "">
     <#assign institution_id = "0">
 </#if>
-<#if project_id == "0">
-    <#assign project_stats_visibility = "d-none">
-    <#assign project_template_visibility = "visible">
-<#else>
-    <#assign project_stats_visibility = "visible">
-    <#assign project_template_visibility = "d-none">
-</#if>
 <div id="project" class="row justify-content-center"></div>
 <script type="text/javascript" src="${root}/js/vendors~account~collection~create_institution~create_project~geodashreact~home~project_dashboard~rev~1b583733.bundle.js"></script>
 <script type="text/javascript" src="${root}/js/collection~create_project~geodashreact~home~project_dashboard~review_project.bundle.js"></script>
@@ -24,9 +17,7 @@
          documentRoot:                "${root}",
          userId:                      "${userid}",
          projectId:                   "${project_id}",
-         institutionId:               "${institution_id}",
-         project_stats_visibility:    "${project_stats_visibility}",
-         project_template_visibility: "${project_template_visibility}"
+         institutionId:               "${institution_id}"
      });
  };
 </script>

--- a/src/main/resources/template/freemarker/review-project.ftl
+++ b/src/main/resources/template/freemarker/review-project.ftl
@@ -7,7 +7,7 @@
 <#if institution_id == "">
     <#assign institution_id = "0">
 </#if>
-<div id="project" class="row justify-content-center"></div>
+<div id="project"></div>
 <script type="text/javascript" src="${root}/js/vendors~account~collection~create_institution~create_project~geodashreact~home~project_dashboard~rev~1b583733.bundle.js"></script>
 <script type="text/javascript" src="${root}/js/collection~create_project~geodashreact~home~project_dashboard~review_project.bundle.js"></script>
 <script type="text/javascript" src="${root}/js/review_project.bundle.js"></script>


### PR DESCRIPTION
- Update the projects UI to add checkbox option to use template plots and sample.  
- Update styling for some of the selectors on create project
- During this process clean up the create-project and review-project files.  
-- Remove circular logic
-- Do not store props in state if not mutating
-- More specific variable names
-- Remove more unused functions due to splitting the page into review and create
-- Update styling on review page to display information in a non-selectable state (ie no radio buttons)
-- Create external components for re-used code
-- Remove direct mutation of dom elements.  Use inline ternary instead.
-- Use ternary instead of if blocks for conditional rendering.

- Update routing for create-project, no ID is needed
- Update JSON projects to create a project using plots from the template project.
