### PR TITLE
Various UI fixes

### DIFF
--- a/src/main/java/org/openforis/ceo/utils/ProjectUtils.java
+++ b/src/main/java/org/openforis/ceo/utils/ProjectUtils.java
@@ -381,7 +381,7 @@ public class ProjectUtils {
 
     public static void runBashScriptForProject(int projectId, String plotsOrSamples, String script, String rpath) {
         try {
-            System.out.println("Runnin " + script);
+            System.out.println("Running " + script);
             var pb = new ProcessBuilder("/bin/sh", script, "project-" + projectId + "-" + plotsOrSamples);
             pb.directory(new File(expandResourcePath(rpath)));
             pb.redirectOutput(new File("out.txt"));
@@ -395,7 +395,7 @@ public class ProjectUtils {
         } catch (Exception e) {
             // for windows
             try {
-                System.out.println("Runnin " + script + " with git bash.");
+                System.out.println("Running " + script + " with git bash.");
                 var pb = new ProcessBuilder("C:\\Program Files\\Git\\bin\\bash.exe", script, "project-" + projectId + "-" + plotsOrSamples);
                 pb.directory(new File(expandResourcePath(rpath)));
                 // For some reason shp2pgsql needs this to work

--- a/src/main/resources/public/jsx/collection.js
+++ b/src/main/resources/public/jsx/collection.js
@@ -3,12 +3,13 @@ import ReactDOM from "react-dom";
 import { mercator, ceoMapStyles } from "../js/mercator-openlayers.js";
 
 import { SurveyQuestions } from "./components/SurveyQuestions"
+import { convertSampleValuesToSurveyQuestions } from "./utils/SurveyUtils"
 
 class Collection extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            currentProject: {sampleValues: [], institution: ""},
+            currentProject: {surveyQuestions: [], institution: ""},
             plotList: [],
             imageryList: [],
             mapConfig: null,
@@ -27,7 +28,7 @@ class Collection extends React.Component {
             userImages: {},
             collectionStart: 0,
             reviewPlots: false,
-            selectedQuestionText: "",
+            selectedQuestion: -1,
             sampleOutlineBlack: true
         };
     }
@@ -77,7 +78,7 @@ class Collection extends React.Component {
         // Selective sample updates when not a new plot
         if (this.state.currentPlot && this.state.currentPlot === prevState.currentPlot) {
             // Changing questions shows different set of samples
-            if (this.state.selectedQuestionText !== prevState.selectedQuestionText 
+            if (this.state.selectedQuestion.id !== prevState.selectedQuestion.id
                         || this.state.sampleOutlineBlack !== prevState.sampleOutlineBlack
                         || this.state.userSamples !== prevState.userSamples) {
                 this.showPlotSamples();
@@ -85,7 +86,7 @@ class Collection extends React.Component {
             }
         }
 
-        if (this.state.currentProject.sampleValues.length > 0 && this.state.userSamples !== prevState.userSamples) {
+        if (this.state.currentProject.surveyQuestions.length > 0 && this.state.userSamples !== prevState.userSamples) {
             this.updateQuestionStatus();
         }
 
@@ -119,8 +120,8 @@ class Collection extends React.Component {
                 if (project == null || project.id == 0) {
                     alert("No project found with ID " + this.props.projectId + ".");
                 } else {
-                    const surveyQuestions = this.convertSampleValuesToSurveyQuestions(project.sampleValues || {});
-                    this.setState({currentProject: { ...project, sampleValues: surveyQuestions }});
+                    const surveyQuestions = convertSampleValuesToSurveyQuestions(project.sampleValues);
+                    this.setState({currentProject: { ...project, surveyQuestions: surveyQuestions }});
                 }
             });
     }
@@ -393,38 +394,13 @@ class Collection extends React.Component {
                     return obj;
                     }, {}) 
                 : {},
-            selectedQuestionText: this.state.currentProject.sampleValues.sort((a, b) => b.id - a.id).find(surveyNode => surveyNode.parent_question == -1).question || "",
+            // fixi 
+            selectedQuestion: this.state.currentProject.surveyQuestions
+                                .sort((a, b) => a.id - b.id)
+                                .find(surveyNode => surveyNode.parentQuestion == -1),                    
             collectionStart: Date.now(),
             sampleOutlineBlack: true
         };
-    }
-
-    // FIXME, used in project review, move to common functions file
-    convertSampleValuesToSurveyQuestions(sampleValues) {
-        return sampleValues.map(sampleValue => {
-            if (sampleValue.name && sampleValue.values) {
-                const surveyQuestionAnswers = sampleValue.values.map(value => {
-                    if (value.name) {
-                        return {
-                            id: value.id,
-                            answer: value.name,
-                            color: value.color
-                        };
-                    } else {
-                        return value;
-                    }
-                });
-                return {
-                    id: sampleValue.id,
-                    question: sampleValue.name,
-                    answers: surveyQuestionAnswers,
-                    parent_question: -1,
-                    parent_answer: -1
-                };
-            } else {
-                return sampleValue;
-            }
-        });
     }
 
     showProjectPlot() {
@@ -450,8 +426,8 @@ class Collection extends React.Component {
     }
 
     showPlotSamples() {
-        const { mapConfig, selectedQuestionText, currentProject : { sampleValues} } = this.state;
-        const shownSamples = this.getVisibleSamples(sampleValues.find(sv => sv.question === selectedQuestionText).id);
+        const { mapConfig, selectedQuestion } = this.state;
+        const shownSamples = this.getVisibleSamples(selectedQuestion.id);
         mercator.disableSelection(mapConfig);
         mercator.removeLayerByTitle(mapConfig, "currentSamples");
         mercator.addVectorLayer(mapConfig,
@@ -568,20 +544,17 @@ class Collection extends React.Component {
         }
     }
 
-    validateCurrentSelection(selectedFeatures, questionText) {
-        const visibleSamples = this.getVisibleSamples(
-                                    this.state.currentProject.sampleValues
-                                    .find(sv => sv.question === questionText).id);
+    validateCurrentSelection = (selectedFeatures, questionId) => selectedFeatures.getArray()
+                                                                    .map(sf => sf.get("sampleId"))
+                                                                    .every(sid => 
+                                                                        this.getVisibleSamples(questionId)
+                                                                        .some(vs => vs.id === sid));
 
-        return selectedFeatures.getArray()
-            .map(sf => sf.get("sampleId"))
-            .every(sid => visibleSamples.some(vs => vs.id === sid));
-    }
 
     getChildQuestions(currentQuestionText) {
-        const { sampleValues } = this.state.currentProject;
-        const { question, id } = sampleValues.find(sv => sv.question === currentQuestionText);
-        const childQuestions = sampleValues.filter(sv => sv.parent_question === id);
+        const { surveyQuestions } = this.state.currentProject;
+        const { question, id } = surveyQuestions.find(sv => sv.question === currentQuestionText);
+        const childQuestions = surveyQuestions.filter(sv => sv.parentQuestion === id);
 
         if (childQuestions.length === 0) {
             return [question];
@@ -592,31 +565,34 @@ class Collection extends React.Component {
         }
     }
 
-    setCurrentValue = (questionText, answerId, answerText, answerColor) => {
+    setCurrentValue = (setQuestion, answerId, answerText) => {
         const selectedFeatures = mercator.getSelectedSamples(this.state.mapConfig);
         
         if (Object.keys(this.state.userSamples).length === 1 
             || (selectedFeatures && selectedFeatures.getLength() 
-                    && this.validateCurrentSelection(selectedFeatures, questionText))) {
+                    && this.validateCurrentSelection(selectedFeatures, setQuestion.id))) {
                 
             const sampleIds = Object.keys(this.state.userSamples).length === 1  
                                 ? [Object.keys(this.state.userSamples)[0]]
                                 : selectedFeatures.getArray().map(sf => sf.get("sampleId"))
 
-            const newSamples = sampleIds.reduce((prev, sampleId) => {
-                const newQuestion = { answer: answerText, color: answerColor};
-                const clearedSubQuestions = this.getChildQuestions(questionText)
-                                            .reduce((prev, question) => {
-                                                const { [question]: value, ...rest} = prev
+            const newSamples = sampleIds.reduce((acc, sampleId) => {
+                const newQuestion = { questionText: setQuestion.id, 
+                                      questionId: setQuestion.question, 
+                                      answer: answerText, 
+                                      answerId: answerId};
+                const clearedSubQuestions = this.getChildQuestions(setQuestion.text)
+                                            .reduce((acc, question) => {
+                                                const { [question]: value, ...rest} = acc
                                                 return {...rest};
                                             }, {...this.state.userSamples[sampleId]});
                                             
-                return {...prev, [sampleId]: {...clearedSubQuestions,
-                                        [questionText]: newQuestion}};
+                return {...acc, [sampleId]: {...clearedSubQuestions,
+                                        [setQuestion.text]: newQuestion}};
             }, {}); 
             
-            const newUserImages = sampleIds.reduce((prev, sampleId) => {
-                return {...prev, [sampleId]: 
+            const newUserImages = sampleIds.reduce((acc, sampleId) => {
+                return {...acc, [sampleId]: 
                                     { id: this.state.currentImagery.id,
                                     attributes: this.getImageryAttributes() }
                         }
@@ -625,7 +601,7 @@ class Collection extends React.Component {
             this.setState({
                         userSamples: {...this.state.userSamples, ...newSamples},
                         userImages: {...this.state.userImages, ...newUserImages},
-                        selectedQuestionText: questionText
+                        selectedQuestion: setQuestion
                     });
             return true;
         } else if(selectedFeatures && selectedFeatures.getLength() == 0 ) {
@@ -637,7 +613,7 @@ class Collection extends React.Component {
         }
     }
 
-    setSelectedQuestionText = (newselectedQuestionText) => this.setState({selectedQuestionText: newselectedQuestionText});
+    setSelectedQuestion = (newselectedQuestion) => this.setState({selectedQuestion: newselectedQuestion});
 
     invertColor(hex) {
         const dehashed = hex.indexOf("#") === 0 ? hex.slice(1) : hex;
@@ -650,25 +626,24 @@ class Collection extends React.Component {
         const g = (255 - parseInt(hexFormatted.slice(2, 4), 16)).toString(16);
         const b = (255 - parseInt(hexFormatted.slice(4, 6), 16)).toString(16);
         // pad each with zeros and return
-        return "#" + this.padZero(r) + this.padZero(g) + this.padZero(b);
-    }
-
-    padZero(str) {
-        const zeros = new Array(2).join("0");
-        return (zeros + str).slice(-2);
+        const padZero = (str) => (new Array(2).join("0") + str).slice(-2)
+        return "#" + padZero(r) + padZero(g) + padZero(b);
     }
 
     highlightSamplesByQuestion() {
         const allFeatures = mercator.getAllFeatures(this.state.mapConfig, "currentSamples") || [];
-        allFeatures.filter(feature => {
+        
+        // FIXME use map to convert to sampleId once
+        allFeatures
+        .filter(feature => {
             const sampleId = feature.get("sampleId");
-            return this.state.userSamples[sampleId] && this.state.userSamples[sampleId][this.state.selectedQuestionText];
+            return this.state.userSamples[sampleId] && this.state.userSamples[sampleId][this.state.selectedQuestion.question];
         } ).forEach(feature => {
             const sampleId = feature.get("sampleId");
 
-            const answeredQuestion = this.state.currentProject.sampleValues
-                             .find(sv => sv.question === this.state.selectedQuestionText);
-            const userAnswer = this.state.userSamples[sampleId][this.state.selectedQuestionText].answer;
+            const answeredQuestion = this.state.currentProject.surveyQuestions
+                             .find(sv => sv.id === this.state.selectedQuestion.id);
+            const userAnswer = this.state.userSamples[sampleId][this.state.selectedQuestion.question].answer;
             const matchingAnswer = answeredQuestion.answers.find(ans => ans.answer === userAnswer);
             
             const color = answeredQuestion.componentType === "input"
@@ -686,61 +661,61 @@ class Collection extends React.Component {
     toggleSampleBW = () => this.setState({ sampleOutlineBlack: !this.state.sampleOutlineBlack });
     
     getVisibleSamples(currentQuestionId) {
-        const { currentProject : { sampleValues}, userSamples } = this.state;
-        const {parent_question, parent_answer} = sampleValues.find(sv => sv.id === currentQuestionId);
-        const parentQuestionText = parent_question === -1 
+        const { currentProject : { surveyQuestions }, userSamples } = this.state;
+        const {parentQuestion, parentAnswer} = surveyQuestions.find(sv => sv.id === currentQuestionId);
+        const parentQuestionText = parentQuestion === -1 
                 ? "" 
-                : sampleValues.find(sv => sv.id === parent_question).question;
+                : surveyQuestions.find(sv => sv.id === parentQuestion).question;
         
-        if (parent_question === -1) {
+        if (parentQuestion === -1) {
             return this.state.currentPlot.samples;
         }
         else {
-            const correctAnswerText = sampleValues
-                                    .find(sv => sv.id === parent_question).answers
-                                    .find(ans => parent_answer === -1 || ans.id === parent_answer).answer;
+            const correctAnswerText = surveyQuestions
+                                    .find(sv => sv.id === parentQuestion).answers
+                                    .find(ans => parentAnswer === -1 || ans.id === parentAnswer).answer;
 
-            return this.getVisibleSamples(parent_question)
+            return this.getVisibleSamples(parentQuestion)
                     .filter(sample => {
                         const sampleAnswer = userSamples[sample.id][parentQuestionText] 
                                              && userSamples[sample.id][parentQuestionText].answer;
-                        return (parent_answer === -1 && sampleAnswer) || correctAnswerText === sampleAnswer;
+                        return (parentAnswer === -1 && sampleAnswer) || correctAnswerText === sampleAnswer;
                     });
         }
     }
 
     getAnsweredSamples(currentQuestionId) {
-        const { currentProject : { sampleValues}, userSamples } = this.state;
-        const { parent_question, parent_answer, question } = sampleValues.find(sv => sv.id === currentQuestionId);
-        const parentQuestionText = parent_question === -1 ? "" : sampleValues.find(sv => sv.id === parent_question).question;
+        const { currentProject : { surveyQuestions}, userSamples } = this.state;
+        const { parentQuestion, parentAnswer, question } = surveyQuestions.find(sv => sv.id === currentQuestionId);
+        const parentQuestionText = parentQuestion === -1 ? "" : surveyQuestions.find(sv => sv.id === parentQuestion).question;
         
-        if (parent_question === -1) {
+        if (parentQuestion === -1) {
             return this.state.currentPlot.samples.filter(s => userSamples[s.id][question]);
         } else {
-            const correctAnswerText = sampleValues
-                                    .find(sv => sv.id === parent_question).answers
-                                    .find(ans => parent_answer === -1 || ans.id === parent_answer).answer;
+            const correctAnswerText = surveyQuestions
+                                    .find(sv => sv.id === parentQuestion).answers
+                                    .find(ans => parentAnswer === -1 || ans.id === parentAnswer).answer;
 
-            return this.getVisibleSamples(parent_question)
+            return this.getVisibleSamples(parentQuestion)
                     .filter(sample => {
                         const sampleAnswer = userSamples[sample.id][parentQuestionText] 
                                                 && userSamples[sample.id][parentQuestionText].answer;
-                        return (parent_answer === -1 && sampleAnswer) || correctAnswerText === sampleAnswer;
+                        return (parentAnswer === -1 && sampleAnswer) || correctAnswerText === sampleAnswer;
                     })
                     .filter(s => userSamples[s.id][question]);
         }
     }
 
     updateQuestionStatus() {
-        const { currentProject: { sampleValues }} = this.state;
+        const { currentProject: { surveyQuestions }} = this.state;
 
-        const newSampleValues = sampleValues.map(value => ({
+        const newSampleValues = surveyQuestions.map(value => ({
                                     ...value,
                                     visible: this.getVisibleSamples(value.id).length,
                                     answered: this.getAnsweredSamples(value.id).length
                                 }));
 
-        this.setState({currentProject: {...this.state.currentProject, sampleValues: newSampleValues}});
+        this.setState({currentProject: {...this.state.currentProject, surveyQuestions: newSampleValues}});
     }
 
     render() {
@@ -755,7 +730,7 @@ class Collection extends React.Component {
                     documentRoot={this.props.documentRoot}
                     userName={this.props.userName}
                     postValuesToDB={this.postValuesToDB}
-                    surveyQuestions={this.state.currentProject.sampleValues}
+                    surveyQuestions={this.state.currentProject.surveyQuestions}
                     projectName={this.state.currentProject.name}
                 >
                     {this.state.plotList.length > 0
@@ -801,10 +776,10 @@ class Collection extends React.Component {
                     {this.state.currentPlot 
                     ? 
                         <SurveyQuestions 
-                            selectedQuestionText={this.state.selectedQuestionText}
-                            surveyQuestions={this.state.currentProject.sampleValues}
+                            selectedQuestion={this.state.selectedQuestion}
+                            surveyQuestions={this.state.currentProject.surveyQuestions}
                             setCurrentValue={this.setCurrentValue}
-                            setSelectedQuestionText={this.setSelectedQuestionText}
+                            setSelectedQuestion={this.setSelectedQuestion}
                         />
                     :
                         <fieldset className="mb-3 justify-content-center text-center">

--- a/src/main/resources/public/jsx/collection.js
+++ b/src/main/resources/public/jsx/collection.js
@@ -576,8 +576,8 @@ class Collection extends React.Component {
                                 : selectedFeatures.getArray().map(sf => sf.get("sampleId"))
 
             const newSamples = sampleIds.reduce((acc, sampleId) => {
-                const newQuestion = { questionText: questionToSet.id, 
-                                      questionId: questionToSet.question, 
+                const newQuestion = { questionText: questionToSet.question, 
+                                      questionId: questionToSet.id, 
                                       answer: answerText, 
                                       answerId: answerId};
                 const clearedSubQuestions = this.getChildQuestions(questionToSet.id)

--- a/src/main/resources/public/jsx/collection.js
+++ b/src/main/resources/public/jsx/collection.js
@@ -551,7 +551,6 @@ class Collection extends React.Component {
                                                                         .some(vs => vs.id === sid));
 
     getChildQuestions(currentQuestionId) {
-        console.log(currentQuestionId)
         const { surveyQuestions } = this.state.currentProject;
         const { question, id } = surveyQuestions.find(sv => sv.id === currentQuestionId);
         const childQuestions = surveyQuestions.filter(sv => sv.parentQuestion === id);
@@ -561,7 +560,7 @@ class Collection extends React.Component {
         } else {
             return childQuestions.reduce((prev, cur) => {
                 return [...prev, ...this.getChildQuestions(cur.id)];
-            }, [question])
+            }, [question]);
         }
     }
 

--- a/src/main/resources/public/jsx/collection.js
+++ b/src/main/resources/public/jsx/collection.js
@@ -2,7 +2,7 @@ import React, { Fragment } from "react";
 import ReactDOM from "react-dom";
 import { mercator, ceoMapStyles } from "../js/mercator-openlayers.js";
 
-import { SurveyQuestions } from "./components/SurveyQuestions"
+import { SurveyQuestions } from "./components/SurveyCollection"
 import { convertSampleValuesToSurveyQuestions } from "./utils/SurveyUtils"
 
 class Collection extends React.Component {
@@ -28,7 +28,7 @@ class Collection extends React.Component {
             userImages: {},
             collectionStart: 0,
             reviewPlots: false,
-            selectedQuestion: -1,
+            selectedQuestion: { id: 0, question: ""},
             sampleOutlineBlack: true
         };
     }
@@ -581,8 +581,8 @@ class Collection extends React.Component {
                                       answer: answerText, 
                                       answerId: answerId};
                 const clearedSubQuestions = this.getChildQuestions(questionToSet.id)
-                                            .reduce((acc, question) => {
-                                                const { [question]: value, ...rest} = acc
+                                            .reduce((acc, questionText) => {
+                                                const { [questionText]: value, ...rest} = acc
                                                 return {...rest};
                                             }, {...this.state.userSamples[sampleId]});
                                             

--- a/src/main/resources/public/jsx/collection.js
+++ b/src/main/resources/public/jsx/collection.js
@@ -28,7 +28,7 @@ class Collection extends React.Component {
             userImages: {},
             collectionStart: 0,
             reviewPlots: false,
-            selectedQuestion: { id: 0, question: ""},
+            selectedQuestion: { id: 0, question: "", answers: []},
             sampleOutlineBlack: true
         };
     }

--- a/src/main/resources/public/jsx/collection.js
+++ b/src/main/resources/public/jsx/collection.js
@@ -551,6 +551,7 @@ class Collection extends React.Component {
                                                                         .some(vs => vs.id === sid));
 
     getChildQuestions(currentQuestionId) {
+        console.log(currentQuestionId)
         const { surveyQuestions } = this.state.currentProject;
         const { question, id } = surveyQuestions.find(sv => sv.id === currentQuestionId);
         const childQuestions = surveyQuestions.filter(sv => sv.parentQuestion === id);
@@ -559,7 +560,7 @@ class Collection extends React.Component {
             return [question];
         } else {
             return childQuestions.reduce((prev, cur) => {
-                return [...prev, ...this.getChildQuestions(cur.question)];
+                return [...prev, ...this.getChildQuestions(cur.id)];
             }, [question])
         }
     }
@@ -634,10 +635,12 @@ class Collection extends React.Component {
         
         const { question } = this.state.selectedQuestion
         allFeatures
-            .map(f => f.get("sampleId"))
-            .filter(sampleId => this.state.userSamples[sampleId] 
-                                && this.state.userSamples[sampleId][question])
-            .forEach(sampleId => {
+            .filter(feature => {
+                const sampleId = feature.get("sampleId")
+                return this.state.userSamples[sampleId] 
+                                && this.state.userSamples[sampleId][question]})
+            .forEach(feature => {
+                const sampleId = feature.get("sampleId")
                 const userAnswer = this.state.userSamples[sampleId][question].answer;
                 const matchingAnswer = this.state.selectedQuestion.answers
                                         .find(ans => ans.answer === userAnswer);

--- a/src/main/resources/public/jsx/components/SurveyCardList.js
+++ b/src/main/resources/public/jsx/components/SurveyCardList.js
@@ -34,11 +34,7 @@ class SurveyCard extends React.Component {
 
     swapQuestionIds = (upOrDown) => {
         const myId = this.props.surveyQuestion.id
-
-        // FIXME can I rely on key for index?
         const myIndex = this.props.topLevelNodeIds.indexOf(this.props.surveyQuestion.id)
-        console.log("props", props.key)
-        console.log(myIndex)
         const swapId = this.props.topLevelNodeIds[myIndex + upOrDown]
 
         const newSurveyQuestions = this.props.surveyQuestions

--- a/src/main/resources/public/jsx/components/SurveyCardList.js
+++ b/src/main/resources/public/jsx/components/SurveyCardList.js
@@ -1,5 +1,7 @@
 import React, { Fragment }  from "react";
 
+import { removeEnumerator } from "../utils/SurveyUtils"
+
 export default function SurveyCardList(props) {
     const topLevelNodes = props.surveyQuestions
                             .filter(sq => sq.parentQuestion == -1)
@@ -63,7 +65,11 @@ class SurveyCard extends React.Component {
                                 <span className="font-weight-bold">{this.state.showQuestions ? "-" : "+"}</span>
                             </button>
                             <h2 className="font-weight-bold mt-2 pt-1 ml-2">Survey Card Number {cardNumber}</h2>
-                            <h3 className="m-3">{this.state.showQuestions ? "" : `-- ${surveyQuestion.question}`}</h3>
+                            <h3 className="m-3">
+                                {!this.state.showQuestions && `-- ${inDesignMode ? surveyQuestion.question
+                                                                                : removeEnumerator(surveyQuestion.question)}`
+                                }
+                            </h3>
                         </div>
                         {inDesignMode && 
                             <div className="col-2 d-flex pr-1 justify-content-end">
@@ -144,7 +150,9 @@ function SurveyQuestionTree({
                                 <span className="font-weight-bold">X</span>
                             </button>
                         }
-                            <h3 className="font-weight-bold">{surveyQuestion.question}</h3>
+                            <h3 className="font-weight-bold">
+                                {inDesignMode ? surveyQuestion.question : removeEnumerator(surveyQuestion.question)}
+                            </h3>
                         </div>
                         <div className="SurveyQuestionTree__question-information pb-1">
                             <ul className="mb-1">
@@ -157,7 +165,8 @@ function SurveyQuestionTree({
                                 {surveyQuestion.parentQuestion > -1 &&
                                     <Fragment>
                                         <li>
-                                            <span className="font-weight-bold">Parent Question:  </span> {parentQuestion.question}
+                                            <span className="font-weight-bold">Parent Question:  </span> 
+                                            {inDesignMode ? parentQuestion.question : removeEnumerator(parentQuestion.question)}
                                         </li>
                                         <li>
                                             <span className="font-weight-bold">Parent Answer:  </span>{surveyQuestion.parentAnswer === -1 

--- a/src/main/resources/public/jsx/components/SurveyCardList.js
+++ b/src/main/resources/public/jsx/components/SurveyCardList.js
@@ -2,7 +2,7 @@ import React, { Fragment }  from "react";
 
 export default function SurveyCardList(props) {
     const topLevelNodes = props.surveyQuestions
-                            .filter(sq => sq.parent_question == -1)
+                            .filter(sq => sq.parentQuestion == -1)
                             .sort((a, b) => a.id - b.id);
 
     return topLevelNodes.map((sq, index) =>
@@ -32,7 +32,11 @@ class SurveyCard extends React.Component {
 
     swapQuestionIds = (upOrDown) => {
         const myId = this.props.surveyQuestion.id
+
+        // FIXME can I rely on key for index?
         const myIndex = this.props.topLevelNodeIds.indexOf(this.props.surveyQuestion.id)
+        console.log("props", props.key)
+        console.log(myIndex)
         const swapId = this.props.topLevelNodeIds[myIndex + upOrDown]
 
         const newSurveyQuestions = this.props.surveyQuestions
@@ -118,8 +122,8 @@ function SurveyQuestionTree({
     surveyQuestions,
     setSurveyQuestions }) {
 
-    const childNodes = surveyQuestions.filter(sq => sq.parent_question == surveyQuestion.id);
-    const parentQuestion = surveyQuestions.find(sq => sq.id === surveyQuestion.parent_question);
+    const childNodes = surveyQuestions.filter(sq => sq.parentQuestion == surveyQuestion.id);
+    const parentQuestion = surveyQuestions.find(sq => sq.id === surveyQuestion.parentQuestion);
     return (
         <Fragment>
             <div className="SurveyQuestionTree__question d-flex border-top pt-3 pb-1">
@@ -150,13 +154,13 @@ function SurveyQuestionTree({
                                         {surveyQuestion.componentType + " - " + surveyQuestion.dataType}
                                     </li>
                                 }
-                                {surveyQuestion.parent_question > -1 &&
+                                {surveyQuestion.parentQuestion > -1 &&
                                     <Fragment>
                                         <li>
                                             <span className="font-weight-bold">Parent Question:  </span> {parentQuestion.question}
                                         </li>
                                         <li>
-                                            <span className="font-weight-bold">Parent Answer:  </span>{surveyQuestion.parent_answer === -1 
+                                            <span className="font-weight-bold">Parent Answer:  </span>{surveyQuestion.parentAnswer === -1 
                                                 ? "Any" 
                                                 : parentQuestion.answers
                                                     .find(ans => ans.id === surveyQuestion.parent_answer).answer}

--- a/src/main/resources/public/jsx/components/SurveyCollection.js
+++ b/src/main/resources/public/jsx/components/SurveyCollection.js
@@ -66,11 +66,10 @@ export class SurveyQuestions extends React.Component {
     getNodeById = (id) => this.props.surveyQuestions.find(sq => sq.id === id);
 
     render() {
-    
         return (
             <fieldset className="mb-3 justify-content-center text-center">
                 <h3>Survey Questions</h3>
-                {this.props.surveyQuestions.length
+                {this.props.surveyQuestions.length > 0
                 ?
                     <div className="SurveyQuestions__questions">
                         <div className="SurveyQuestions__top-questions">
@@ -172,7 +171,7 @@ class SurveyQuestionTree extends React.Component  {
                     <SurveyAnswers
                         componentType={this.props.surveyNode.componentType}
                         dataType={this.props.surveyNode.dataType}
-                        setQuestion={this.props.surveyNode}
+                        surveyNode={this.props.surveyNode}
                         answers={this.props.surveyNode.answers}
                         setCurrentValue={this.props.setCurrentValue}
                     />
@@ -213,7 +212,7 @@ function AnswerButton(props){
                             //         ? "0px 0px 4px 4px black inset, 0px 0px 4px 4px white inset"
                             //         : "initial"
                             // }}
-                            onClick={() => props.setCurrentValue(props.setQuestion, ans.id, ans.answer)}
+                            onClick={() => props.setCurrentValue(props.surveyNode, ans.id, ans.answer)}
                         >
                             <div className="circle"
                                 style={{
@@ -239,7 +238,7 @@ function AnswerRadioButton(props) {
                             className="btn-outline-darkgray btn-sm btn-block pl-1"
                             id={ans.answer + "_" + ans.id}
                             name={ans.answer + "_" + ans.id}
-                            onClick={() => props.setCurrentValue(props.setQuestion, ans.id, ans.answer)}
+                            onClick={() => props.setCurrentValue(props.surveyNode, ans.id, ans.answer)}
                         >
                             <div className="circle"
                                 style={{
@@ -265,7 +264,7 @@ class AnswerInput extends React.Component{
     }
 
     componentDidUpdate(prevProps) {
-        if (this.props.setQuestion.id !== prevProps.setQuestion.id) {
+        if (this.props.surveyNode.id !== prevProps.surveyNode.id) {
             this.setState({ newInput: "" })
         }
     }
@@ -301,7 +300,7 @@ class AnswerInput extends React.Component{
                         name="save-input"
                         value="Save"
                         onClick={() => {
-                            props.setCurrentValue(props.setQuestion, ans.id, this.state.newInput)
+                            props.setCurrentValue(props.surveyNode, ans.id, this.state.newInput)
                             this.setState({ newInput: ""})
                         }}
                     />
@@ -319,7 +318,7 @@ class AnswerDropDown extends React.Component {
     }  
 
     componentDidUpdate (prevProps) {
-        if (this.props.setQuestion !== prevProps.setQuestion) {
+        if (this.props.surveyNode !== prevProps.surveyNode) {
             this.setState({showDropdown: false})
         }
     }
@@ -331,7 +330,7 @@ class AnswerDropDown extends React.Component {
             <div 
                 key={uid} 
                 onClick={() => {
-                        this.props.setCurrentValue(this.props.setQuestion, ans.id, ans.answer);
+                        this.props.setCurrentValue(this.props.surveyNode, ans.id, ans.answer);
                         this.setState({ showDropdown: false });
                     }
                 }
@@ -401,28 +400,28 @@ function SurveyAnswers(props) {
   if (props.componentType && props.componentType.toLowerCase() == "radiobutton") {
         return (<AnswerRadioButton 
                     answers={props.answers} 
-                    setQuestion={props.setQuestion}
+                    surveyNode={props.surveyNode}
                     dataType={props.dataType}
                     setCurrentValue={props.setCurrentValue}
                 />);
     } else if (props.componentType && props.componentType.toLowerCase() == "input") {
         return (<AnswerInput
                     answers={props.answers} 
-                    setQuestion={props.setQuestion}
+                    surveyNode={props.surveyNode}
                     dataType={props.dataType}
                     setCurrentValue={props.setCurrentValue}
                 />);
     } else if (props.componentType && props.componentType.toLowerCase() == "dropdown") {
         return (<AnswerDropDown 
                     answers={props.answers} 
-                    setQuestion={props.setQuestion} 
+                    surveyNode={props.surveyNode} 
                     childNodes={props.childNodes}  
                     setCurrentValue={props.setCurrentValue}
                 />);
     } else {
         return (<AnswerButton 
                     answers={props.answers} 
-                    setQuestion={props.setQuestion}
+                    surveyNode={props.surveyNode}
                     dataType={props.dataType}
                     setCurrentValue={props.setCurrentValue}
                 />);

--- a/src/main/resources/public/jsx/components/SurveyDesign.js
+++ b/src/main/resources/public/jsx/components/SurveyDesign.js
@@ -2,6 +2,7 @@ import React, {Fragment} from "react";
 
 import { SectionBlock } from "./FormComponents"
 import SurveyCardList from "./SurveyCardList"
+import { removeEnumerator } from "../utils/SurveyUtils"
 
 const componentTypes = [
     {componentType: "button", dataType: "text"},
@@ -189,9 +190,13 @@ class NewQuestionDesigner extends React.Component {
         if (this.state.newQuestionText != "") {
             const { surveyQuestions } = this.props;
             const { dataType, componentType } = componentTypes[this.props.inSimpleMode ? 0 : this.state.selectedType];
+            const repeatedQuestions = surveyQuestions.filter(sq => removeEnumerator(sq.question) === this.state.newQuestionText).length;
+
             const newQuestion = {
                                     id: surveyQuestions.reduce((p,c) => Math.max(p,c.id), 0) + 1,
-                                    question: this.state.newQuestionText,
+                                    question: repeatedQuestion > 0 
+                                                    ? this.state.newQuestionText + ` (${repeatedQuestions})` 
+                                                    : this.state.newQuestionText,
                                     answers: [],
                                     parentQuestion: this.state.selectedParent,
                                     parentAnswer: this.state.selectedAnswer,

--- a/src/main/resources/public/jsx/components/SurveyDesign.js
+++ b/src/main/resources/public/jsx/components/SurveyDesign.js
@@ -49,7 +49,7 @@ export class SurveyDesign extends React.Component {
     }
 
     getChildQuestionIds = (questionId) => {
-        const childQuestions = this.props.surveyQuestions.filter(sv => sv.parent_question === questionId);
+        const childQuestions = this.props.surveyQuestions.filter(sv => sv.parentQuestion === questionId);
         if (childQuestions.length === 0) {
             return [questionId];
         } else {
@@ -193,8 +193,8 @@ class NewQuestionDesigner extends React.Component {
                                     id: surveyQuestions.reduce((p,c) => Math.max(p,c.id), 0) + 1,
                                     question: this.state.newQuestionText,
                                     answers: [],
-                                    parent_question: this.state.selectedParent,
-                                    parent_answer: this.state.selectedAnswer,
+                                    parentQuestion: this.state.selectedParent,
+                                    parentAnswer: this.state.selectedAnswer,
                                     dataType: dataType,
                                     componentType: componentType,
                                 }; 

--- a/src/main/resources/public/jsx/components/SurveyDesign.js
+++ b/src/main/resources/public/jsx/components/SurveyDesign.js
@@ -187,24 +187,30 @@ class NewQuestionDesigner extends React.Component {
     }
 
     addSurveyQuestion = () => {
-        if (this.state.newQuestionText != "") {
+
+        if (this.state.newQuestionText !== "") {
             const { surveyQuestions } = this.props;
             const { dataType, componentType } = componentTypes[this.props.inSimpleMode ? 0 : this.state.selectedType];
             const repeatedQuestions = surveyQuestions.filter(sq => removeEnumerator(sq.question) === this.state.newQuestionText).length;
+            
+            if (repeatedQuestions === 0 
+                || confirm("Warning: this is a duplicate name.  This will save as " 
+                            + this.state.newQuestionText + ` (${repeatedQuestions})` + " in design mode")) {
 
-            const newQuestion = {
-                                    id: surveyQuestions.reduce((p,c) => Math.max(p,c.id), 0) + 1,
-                                    question: repeatedQuestion > 0 
-                                                    ? this.state.newQuestionText + ` (${repeatedQuestions})` 
-                                                    : this.state.newQuestionText,
-                                    answers: [],
-                                    parentQuestion: this.state.selectedParent,
-                                    parentAnswer: this.state.selectedAnswer,
-                                    dataType: dataType,
-                                    componentType: componentType,
-                                }; 
-            this.props.setSurveyQuestions([...surveyQuestions, newQuestion]);
-            this.setState({ selectedAnswer: -1, newQuestionText: "" });
+                const newQuestion = {
+                                        id: surveyQuestions.reduce((p,c) => Math.max(p,c.id), 0) + 1,
+                                        question: repeatedQuestions > 0 
+                                                        ? this.state.newQuestionText + ` (${repeatedQuestions})` 
+                                                        : this.state.newQuestionText,
+                                        answers: [],
+                                        parentQuestion: this.state.selectedParent,
+                                        parentAnswer: this.state.selectedAnswer,
+                                        dataType: dataType,
+                                        componentType: componentType,
+                                    }; 
+                this.props.setSurveyQuestions([...surveyQuestions, newQuestion]);
+                this.setState({ selectedAnswer: -1, newQuestionText: "" });
+            }
         } else {
             alert("Please enter a survey question first.");
         }

--- a/src/main/resources/public/jsx/components/SurveyQuestions.js
+++ b/src/main/resources/public/jsx/components/SurveyQuestions.js
@@ -1,5 +1,7 @@
 import React, { Fragment } from "react";
 
+import { removeEnumerator } from "../utils/SurveyUtils"
+
 export class SurveyQuestions extends React.Component {
     constructor(props) {
         super(props);
@@ -162,7 +164,7 @@ class SurveyQuestionTree extends React.Component  {
                                 `}}
                         onClick={() => this.props.setSelectedQuestion(this.props.surveyNode)}
                     >
-                    {this.props.higharcyLabel + this.props.surveyNode.question}
+                    {this.props.higharcyLabel + removeEnumerator(this.props.surveyNode.question)}
                     </button>
                 </div>
 

--- a/src/main/resources/public/jsx/create-project.js
+++ b/src/main/resources/public/jsx/create-project.js
@@ -19,25 +19,26 @@ class Project extends React.Component {
                 description: "",
                 id: 0,
                 name: "",
-                numPlots: null,
+                numPlots: "",
                 plotDistribution: "random",
                 plotShape: "circle",
-                plotSize: null,
-                plotSpacing: null,
+                plotSize: "",
+                plotSpacing: "",
                 privacyLevel: "public",
                 sampleDistribution: "random",
-                sampleResolution: null,
-                samplesPerPlot: null,
+                sampleResolution: "",
+                samplesPerPlot: "",
                 surveyQuestions: []
             },
             useTemplatePlots: false,
             imageryList: [],
             mapConfig: null,
             plotList: [],
-            lonMin: "",
-            latMin: "",
-            lonMax: "",
-            latMax: "",
+            coordinates: {
+                lonMin: "",
+                latMin: "",
+                lonMax: "",
+                latMax: "" },
             projectList: [],
         };
     };
@@ -53,7 +54,7 @@ class Project extends React.Component {
             this.initProjectMap();
         }
 
-        if (this.state.mapConfig && this.state.projectDetails.id
+        if (this.state.mapConfig
                 && (this.state.mapConfig !== prevState.mapConfig 
                 || this.state.projectDetails.id !== prevState.projectDetails.id))  {
             this.updateProjectMap();
@@ -68,7 +69,7 @@ class Project extends React.Component {
         // Set sample distribution to a valid choice based on plot selection
         if (this.state.projectDetails.plotDistribution !== prevState.projectDetails.plotDistribution) {
             const { plotDistribution, sampleDistribution } = this.state.projectDetails;
-            this.setSampleDistribution(["random", "gridded"].includes(plotDistribution) 
+            this.setProjectDetail("sampleDistribution", ["random", "gridded"].includes(plotDistribution) 
                                       && ["csv", "shp"].includes(sampleDistribution) ? "random"
                                             : plotDistribution === "shp" 
                                               && ["random", "gridded"].includes(sampleDistribution) ? "shp"
@@ -77,7 +78,7 @@ class Project extends React.Component {
     }
 
     createProject = () => {
-        if (this.validateSurvey() && confirm("Do you REALLY want to create this project?")) {
+        if (this.validateProject() && confirm("Do you REALLY want to create this project?")) {
             utils.show_element("spinner");
             let formData = new FormData(document.getElementById("project-design-form"));
             formData.append("institution", this.props.institutionId);
@@ -104,17 +105,51 @@ class Project extends React.Component {
         }
     }
 
-    validateSurvey = () => {
-        if (this.state.projectDetails.surveyQuestions.length === 0) {
-            alert("A survey must include at least one quesiont");
+    validateProject = () => {
+        const { projectDetails, coordinates } = this.state;
+        if (projectDetails.name === "" || projectDetails.description === "") {
+            alert("A project must contain a name and description");
             return false;
+
+        } else if (coordinates.latMax === "") {
+            alert("Please select a boundary");
+            return false;
+
+        } else if (projectDetails.plotDistribution === "random" 
+                    && (!projectDetails.numPlots || projectDetails.numPlots === 0)) {
+            alert("A number of plots is required for random plot distribution");
+            return false;
+
+        } else if (projectDetails.plotDistribution === "gridded" 
+                    && (!projectDetails.plotSpacing || projectDetails.plotSpacing === 0)) {
+            alert("A plot spacing is required for gridded plot distribution");
+            return false;
+
+        } else if (projectDetails.plotDistribution !== "shp" 
+                    && (!projectDetails.plotSize || projectDetails.plotSize === 0)) {
+            alert("A plot size is required");
+            return false;
+
+        } else if (projectDetails.sampleDistribution === "random" 
+                    && (!projectDetails.samplesPerPlot || projectDetails.samplesPerPlot === 0)) {
+            alert("A number of samples per plot is required for random sample distribution");
+            return false;
+
+        } else if (projectDetails.sampleDistribution === "gridded" 
+                && (!projectDetails.sampleResolution || projectDetails.sampleResolution === 0)) {
+            alert("A sample resolution is required for gridded sample distribution");
+            return false;
+
+        } else if (projectDetails.surveyQuestions.length === 0) {
+            alert("A survey must include at least one question");
+            return false;
+
+        } else if (projectDetails.surveyQuestions.some(sq => sq.answers.length === 0)) {
+            alert("All survey questions must contain at least one answer")
+            return false;
+
         } else {
-            if (this.state.projectDetails.surveyQuestions.some(sq => sq.answers.length === 0)) {
-                alert("All survey questions must contain at least one answer")
-                return false;
-            } else {
-                return true;
-            }
+            return true;
         }
     }
 
@@ -125,31 +160,15 @@ class Project extends React.Component {
         this.setState({projectDetails: { ...templateProject, surveyQuestions: newSurveyQuestions }});
     }
 
-    setPrivacyLevel = (privacyLevel) => 
-            this.setState({projectDetails: { ...this.state.projectDetails, privacyLevel: privacyLevel}});
-
-    setBaseMapSource = (newBaseMapSource) => 
-            this.setState({ projectDetails: { ...this.state.projectDetails, baseMapSource: newBaseMapSource }});
-
     toggleTemplatePlots = () => this.setState({useTemplatePlots: !this.state.useTemplatePlots});
 
-    setPlotDistribution = (newPlotDistribution) => 
-            this.setState({ projectDetails: { ...this.state.projectDetails, plotDistribution: newPlotDistribution }});
-
-    setPlotShape = (newPlotShape) => 
-            this.setState({projectDetails: { ...this.state.projectDetails, plotShape: newPlotShape }});
-    
-    setSampleDistribution = (newSampleDistribution) => 
-            this.setState({ projectDetails: { ...this.state.projectDetails, sampleDistribution: newSampleDistribution }});
-    
-    setProjectName = (newProjectName) => 
-            this.setState({ projectDetails: { ...this.state.projectDetails, name: newProjectName }});
-                    
-    setDescription = (newDescription) => 
-            this.setState({ projectDetails: { ...this.state.projectDetails, description: newDescription }});
-                                                                                                
+    setProjectDetail = (key, newValue) => 
+            this.setState({projectDetails: { ...this.state.projectDetails, [key]: newValue}});
+  
+                                                                                          
     setSurveyQuestions = (newSurveyQuestions) => 
             this.setState({ projectDetails: { ...this.state.projectDetails, surveyQuestions: newSurveyQuestions }})
+
 
     getProjectList = () => {
         const { userId } = this.props
@@ -213,16 +232,16 @@ class Project extends React.Component {
         mercator.removeLayerByTitle(this.state.mapConfig, "flaggedPlots");
         mercator.removeLayerByTitle(this.state.mapConfig, "analyzedPlots");
         mercator.removeLayerByTitle(this.state.mapConfig, "unanalyzedPlots");
-
-        if (this.state.projectDetails.id == 0) {
+        if (this.state.projectDetails.id === 0) {
             // Enable dragbox interaction if we are creating a new project
-            let displayDragBoxBounds = function (dragBox) {
+            let displayDragBoxBounds = (dragBox) => {
                 let extent = dragBox.getGeometry().clone().transform("EPSG:3857", "EPSG:4326").getExtent();
                 // FIXME: Can we just set this.lonMin/lonMax/latMin/latMax instead?
-                document.getElementById("lon-min").value = extent[0];
-                document.getElementById("lat-min").value = extent[1];
-                document.getElementById("lon-max").value = extent[2];
-                document.getElementById("lat-max").value = extent[3];
+                this.setState({coordinates: { lonMin: extent[0],
+                                                latMin: extent[1],
+                                                lonMax: extent[2],
+                                                latMax: extent[3] }
+                                    });
             };
             
             mercator.disableDragBoxDraw(this.state.mapConfig);
@@ -231,10 +250,11 @@ class Project extends React.Component {
             // Extract bounding box coordinates from the project boundary and show on the map
             let boundaryExtent = mercator.parseGeoJson(this.state.projectDetails.boundary, false).getExtent();
             // FIXME like above, these values are stored in the state but never used.
-            this.setState({lonMin: boundaryExtent[0]});
-            this.setState({latMin: boundaryExtent[1]});
-            this.setState({lonMax: boundaryExtent[2]});
-            this.setState({latMax: boundaryExtent[3]});
+            this.setState({coordinates: { lonMin: boundaryExtent[0],
+                                        latMin: boundaryExtent[1],
+                                        lonMax: boundaryExtent[2],
+                                        latMax: boundaryExtent[3] }
+                            });
 
             // Display a bounding box with the project's AOI on the map and zoom to it
             mercator.removeLayerByTitle(this.state.mapConfig, "currentAOI");
@@ -255,19 +275,17 @@ class Project extends React.Component {
                 {this.state.projectDetails && 
                     <Fragment>
                         <ProjectDesignForm 
-                            project={this.state}
+                            coordinates={this.state.coordinates}
+                            imageryList={this.state.imageryList}
+                            projectDetails={this.state.projectDetails}
+                            projectList={this.state.projectList}
+                            setProjectDetail={this.setProjectDetail}
                             setProjectTemplate={this.setProjectTemplate} 
-                            setPrivacyLevel={this.setPrivacyLevel}
-                            setSampleDistribution={this.setSampleDistribution}
-                            setBaseMapSource={this.setBaseMapSource}
-                            setPlotDistribution={this.setPlotDistribution} 
-                            setPlotShape={this.setPlotShape}
-                            toggleTemplatePlots={this.toggleTemplatePlots}
-                            setProjectName={this.setProjectName}
-                            setDescription={this.setDescription}
                             setSurveyQuestions={this.setSurveyQuestions}
+                            toggleTemplatePlots={this.toggleTemplatePlots}
+                            useTemplatePlots={this.useTemplatePlots}
                         />
-                        <ProjectManagement project={this.state} createProject={this.createProject} />
+                        <ProjectManagement createProject={this.createProject} />
                     </Fragment>
                 }
             </FormLayout>
@@ -281,34 +299,41 @@ function ProjectDesignForm(props) {
               action={props.documentRoot + "/create-project"}
               encType="multipart/form-data">
         
-                {props.project.projectList && 
+                {props.projectList && 
                     <ProjectTemplateVisibility 
-                        project={props.project} 
+                        projectId={props.projectDetails.id} 
+                        projectList={props.projectList}
                         setProjectTemplate={props.setProjectTemplate} 
                     />
                 }
                 <ProjectInfo 
-                    project={props.project} 
-                    setProjectName={props.setProjectName}
-                    setDescription={props.setDescription}
+                    name={props.projectDetails.name}
+                    description={props.projectDetails.description}
+                    setProjectDetail={props.setProjectDetail}
                 />
-                <ProjectVisibility project={props.project} setPrivacyLevel={props.setPrivacyLevel}/>
-                <ProjectAOI project={props.project}/>
-                {props.project.imageryList && 
-                    <ProjectImagery project={props.project} setBaseMapSource={props.setBaseMapSource}/>
+                <ProjectVisibility 
+                    privacyLevel={props.projectDetails.privacyLevel}
+                    setProjectDetail={props.setProjectDetail}
+                />
+                <ProjectAOI coordinates={props.coordinates}/>
+                {props.imageryList && 
+                    <ProjectImagery
+                        imageryList={props.imageryList}
+                        baseMapSource={props.projectDetails.baseMapSource}
+                        setProjectDetail={props.setProjectDetail}
+                    />
                 }
                 <PlotDesign 
-                    project={props.project} 
+                    projectDetails={props.projectDetails}
                     useTemplatePlots={props.useTemplatePlots}
-                    setPlotDistribution={props.setPlotDistribution}
-                    setPlotShape={props.setPlotShape}
+                    setProjectDetail={props.setProjectDetail}
                     toggleTemplatePlots={props.toggleTemplatePlots}
                 />
-                {!props.project.useTemplatePlots && 
-                    <SampleDesign project={props.project} setSampleDistribution={props.setSampleDistribution}/>
+                {!props.useTemplatePlots && 
+                    <SampleDesign projectDetails={props.projectDetails} setProjectDetail={props.setProjectDetail}/>
                 }
                 <SurveyDesign 
-                    surveyQuestions={props.project.projectDetails.surveyQuestions} 
+                    surveyQuestions={props.projectDetails.surveyQuestions} 
                     setSurveyQuestions={props.setSurveyQuestions} 
                 />
 
@@ -316,7 +341,7 @@ function ProjectDesignForm(props) {
     );
 }
 
-function ProjectTemplateVisibility({ project, setProjectTemplate }) {
+function ProjectTemplateVisibility({ projectId, projectList, setProjectTemplate }) {
     return (
         <SectionBlock title = "Use Project Template (Optional)">
             <div id="project-template-selector">
@@ -326,10 +351,10 @@ function ProjectTemplateVisibility({ project, setProjectTemplate }) {
                         className="form-control form-control-sm" id="project-template"
                         name="project-template"
                         size="1"
-                        value={project.projectDetails.id} onChange={e => setProjectTemplate(e.target.value)}
+                        value={projectId} onChange={e => setProjectTemplate(e.target.value)}
                     >
                         {
-                            project.projectList
+                            projectList
                                 .filter(proj => proj != null)
                                 .map((proj,uid) =>
                                     <option key={uid} value={proj.id}>{proj.name}</option>
@@ -342,17 +367,21 @@ function ProjectTemplateVisibility({ project, setProjectTemplate }) {
     );
 }
 
-
-function ProjectInfo(props) {
-    const { project: { projectDetails } } = props;
+function ProjectInfo({ name, description, setProjectDetail }) {
     return (
         <SectionBlock title="Project Info">
             <div id="project-info">
                 <div className="form-group">
                     <h3 htmlFor="project-name">Name</h3>
-                    <input className="form-control form-control-sm" type="text" id="project-name" name="name"
-                        autoComplete="off" defaultValue={projectDetails.name}
-                        onChange={e => props.setProjectName(e.target.value)}/>
+                    <input
+                        className="form-control form-control-sm"
+                        type="text"
+                        id="project-name"
+                        name="name"
+                        autoComplete="off"
+                        value={name}
+                        onChange={e => setProjectDetail("name", e.target.value)}
+                    />
                 </div>
                 <div className="form-group">
                     <h3 htmlFor="project-description">Description</h3>
@@ -360,8 +389,8 @@ function ProjectInfo(props) {
                         className="form-control form-control-sm" 
                         id="project-description"
                         name="description"
-                        value={projectDetails.description} 
-                        onChange={e => props.setDescription(e.target.value)}
+                        value={description} 
+                        onChange={e => setProjectDetail("description", e.target.value)}
                     />
                 </div>
             </div>
@@ -369,46 +398,73 @@ function ProjectInfo(props) {
     );
 }
 
-function ProjectVisibility({ project : { projectDetails : { privacyLevel } } }) {
+function ProjectVisibility({ privacyLevel, setProjectDetail }) {
     return (
         <SectionBlock title= "Project Visibility">
             <h3>Privacy Level</h3>
             <div id="project-visibility" className="mb-3 small">
                 <div className="form-check form-check-inline">
-                    <input className="form-check-input" type="radio" id="privacy-public" name="privacy-level"
-                            value="public" checked={privacyLevel === "public"}
-                            onChange={() => props.setPrivacyLevel("public")}/>
-                    <label className="form-check-label" htmlFor="privacy-public">Public: <i>All Users</i></label>
+                    <input 
+                        className="form-check-input"
+                        type="radio" 
+                        id="privacy-public" 
+                        name="privacy-level"
+                        value="public" 
+                        checked={privacyLevel === "public"}
+                        onChange={() => setProjectDetail("privacyLevel", "public")}
+                    />
+                    <label className="form-check-label" htmlFor="privacy-public">
+                        Public: <i>All Users</i>
+                    </label>
                 </div>
                 <div className="form-check form-check-inline">
-                    <input className="form-check-input" type="radio" id="privacy-private" name="privacy-level"
-                            value="private" onChange={() => props.setPrivacyLevel("private")}
-                            checked={privacyLevel === "private"}/>
-                    <label className="form-check-label" htmlFor="privacy-private">Private: <i>Group
-                        Admins</i></label>
+                    <input
+                        className="form-check-input"
+                        type="radio"
+                        id="privacy-private"
+                        name="privacy-level"
+                        value="private"
+                        onChange={() => setProjectDetail("privacyLevel", "private")}
+                        checked={privacyLevel === "private"}
+                    />
+                    <label className="form-check-label" htmlFor="privacy-private">
+                        Private: <i>Group Admins</i>
+                    </label>
                 </div>
                 <div className="form-check form-check-inline">
-                    <input className="form-check-input" type="radio" id="privacy-institution"
-                            name="privacy-level"
-                            value="institution" onChange={() => props.setPrivacyLevel("institution")}
-                            checked={privacyLevel === "institution"}/>
-                    <label className="form-check-label" htmlFor="privacy-institution">Institution: <i>Group
-                        Members</i></label>
+                    <input
+                        className="form-check-input"
+                        type="radio" id="privacy-institution"
+                        name="privacy-level"
+                        value="institution"
+                        onChange={() => setProjectDetail("privacyLevel", "institution")}
+                        checked={privacyLevel === "institution"}
+                    />
+                    <label className="form-check-label" htmlFor="privacy-institution">
+                        Institution: <i>Group Members</i>
+                    </label>
                 </div>
                 <div className="form-check form-check-inline">
-                    <input className="form-check-input" type="radio" id="privacy-invitation"
-                            name="privacy-level"
-                            value="invitation" onChange={() => props.setPrivacyLevel("invitation")} disabled
-                            checked={privacyLevel === "invitation"}/>
-                    <label className="form-check-label" htmlFor="privacy-invitation">Invitation: <i>Coming
-                        Soon</i></label>
+                    <input
+                        className="form-check-input"
+                        type="radio"
+                        id="privacy-invitation"
+                        name="privacy-level"
+                        value="invitation"
+                        onChange={() => setProjectDetail("privacyLevel", "invitation")} 
+                        disabled
+                        checked={privacyLevel === "invitation"}
+                    />
+                    <label className="form-check-label" htmlFor="privacy-invitation">
+                        Invitation: <i>Coming Soon</i>
+                    </label>
                 </div>
             </div>
         </SectionBlock>
     );
 }
 
-function ProjectAOI({ project: { latMax, lonMin, lonMax, latMin } }) {
+function ProjectAOI({ coordinates: { latMax, lonMin, lonMax, latMin } }) {
     return (
         <SectionBlock title="Project AOI">
             <div id="project-aoi">
@@ -418,34 +474,62 @@ function ProjectAOI({ project: { latMax, lonMin, lonMax, latMin } }) {
                         <div className="row">
                             <div className="col-md-6 offset-md-3">
                                 <input 
-                                    className="form-control form-control-sm" type="number" id="lat-max" name="lat-max"
-                                    defaultValue={latMax} placeholder="North" autoComplete="off" min="-90.0"
-                                    max="90.0" step="any"
+                                    className="form-control form-control-sm"
+                                    type="number"
+                                    id="lat-max"
+                                    name="lat-max"
+                                    value={latMax}
+                                    placeholder="North"
+                                    autoComplete="off"
+                                    min="-90.0"
+                                    max="90.0"
+                                    step="any"
                                 />
                             </div>
                         </div>
                         <div className="row">
                             <div className="col-md-6">
                                 <input 
-                                    className="form-control form-control-sm" type="number" id="lon-min" name="lon-min"
-                                    defaultValue={lonMin} placeholder="West" autoComplete="off" min="-180.0"
-                                    max="180.0" step="any"
+                                    className="form-control form-control-sm"
+                                    type="number"
+                                    id="lon-min"
+                                    name="lon-min"
+                                    value={lonMin}
+                                    placeholder="West"
+                                    autoComplete="off"
+                                    min="-180.0"
+                                    max="180.0"
+                                    step="any"
                                 />
                             </div>
                             <div className="col-md-6">
                                 <input 
-                                    className="form-control form-control-sm" type="number" id="lon-max" name="lon-max"
-                                    defaultValue={lonMax} placeholder="East" autoComplete="off" min="-180.0"
-                                    max="180.0" step="any"
+                                    className="form-control form-control-sm"
+                                    type="number"
+                                    id="lon-max"
+                                    name="lon-max"
+                                    value={lonMax}
+                                    placeholder="East"
+                                    autoComplete="off"
+                                    min="-180.0"
+                                    max="180.0"
+                                    step="any"
                                 />
                             </div>
                         </div>
                         <div className="row">
                             <div className="col-md-6 offset-md-3">
                                 <input 
-                                    className="form-control form-control-sm" type="number" id="lat-min" name="lat-min"
-                                    defaultValue={latMin} placeholder="South" autoComplete="off" min="-90.0"
-                                    max="90.0" step="any"
+                                    className="form-control form-control-sm"
+                                    type="number"
+                                    id="lat-min"
+                                    name="lat-min"
+                                    value={latMin}
+                                    placeholder="South"
+                                    autoComplete="off"
+                                    min="-90.0"
+                                    max="90.0"
+                                    step="any"
                                 />
                             </div>
                         </div>
@@ -456,7 +540,7 @@ function ProjectAOI({ project: { latMax, lonMin, lonMax, latMin } }) {
     );
 }
 
-function ProjectImagery({ project, setBaseMapSource }) {
+function ProjectImagery({ baseMapSource, imageryList, setProjectDetail }) {
     return (
         <SectionBlock title="Project Imagery">
             <div id="project-imagery">
@@ -464,12 +548,10 @@ function ProjectImagery({ project, setBaseMapSource }) {
                     <h3 htmlFor="base-map-source">Basemap Source</h3>
                     <select className="form-control form-control-sm" id="base-map-source" name="base-map-source"
                         size="1"
-                        value={project.projectDetails && project.projectDetails.baseMapSource != null
-                            ? project.projectDetails.baseMapSource
-                            : ""}
-                        onChange={e => setBaseMapSource(e.target.value)}>
+                        value={baseMapSource || ""}
+                        onChange={e => setProjectDetail("baseMapSource", e.target.value)}>
                         {
-                            project.imageryList.map((imagery, uid) =>
+                            imageryList.map((imagery, uid) =>
                                 <option key={uid} value={imagery.title}>{imagery.title}</option>
                             )
                         }
@@ -480,14 +562,9 @@ function ProjectImagery({ project, setBaseMapSource }) {
     );
 }
 
-class PlotDesign extends React.Component {
-  constructor(props) {
-    super(props);
-  }
-
-  encodeImageFileAsURL(event) {
+function encodeImageFileAsURL(event) {
       console.log(event)
-    let file = event.target.files[0];
+    const file = event.target.files[0];
     let reader = new FileReader();
     reader.onloadend = function() {
       let base64Data = reader.result;
@@ -496,395 +573,391 @@ class PlotDesign extends React.Component {
     reader.readAsDataURL(file);
   }
 
-  render() {
-    let {
-      project: {
-        useTemplatePlots,
-        projectDetails,
-        projectDetails: { plotDistribution, plotShape }
-      }
-    } = this.props;
+function PlotDesign ({
+    projectDetails: { id, plotDistribution, plotShape, numPlots, plotSpacing, plotSize },
+    setProjectDetail,
+    toggleTemplatePlots,
+    useTemplatePlots,
+    }) {
+
     return (
       <SectionBlock title="Plot Design">
         <div id="plot-design">
           <div className="row">
             <div id="plot-design-col1" className="col">
               <h3>Template Plots</h3>
-              <div className="form-check form-check-inline">
-                <input
-                  className="form-check-input"
-                  type="checkbox"
-                  id="use-template-plots"
-                  name="use-template-plots"
-                  defaultValue={useTemplatePlots}
-                  onChange={this.props.toggleTemplatePlots}
-                  checked={useTemplatePlots}
-                />
-                <label
-                  className="form-check-label"
-                  htmlFor="use-template-plots"
-                >
-                  Use Template Plots and Samples
-                </label>
-              </div>
+                {id > 0 &&
+                  <div className="form-check form-check-inline">
+                    <input
+                        className="form-check-input"
+                        type="checkbox"
+                        id="use-template-plots"
+                        name="use-template-plots"
+                        defaultValue={useTemplatePlots}
+                        onChange={toggleTemplatePlots}
+                        checked={useTemplatePlots}
+                    />
+                    <label
+                        className="form-check-label"
+                        htmlFor="use-template-plots"
+                    >
+                        Use Template Plots and Samples
+                    </label>
+                </div>
+                }
+                {!useTemplatePlots && (
+                    <Fragment>
+                    <hr />
+                    <h3 className="mb-3">Spatial Distribution</h3>
+                    <div className="form-check form-check-inline">
+                        <input
+                        className="form-check-input"
+                        type="radio"
+                        id="plot-distribution-random"
+                        name="plot-distribution"
+                        defaultValue="random"
+                        onChange={() => setProjectDetail("plotDistribution", "random")}
+                        checked={plotDistribution === "random"}
+                        />
+                        <label
+                        className="form-check-label"
+                        htmlFor="plot-distribution-random"
+                        >
+                        Random
+                        </label>
+                    </div>
+                    <div className="form-check form-check-inline">
+                        <input
+                        className="form-check-input"
+                        type="radio"
+                        id="plot-distribution-gridded"
+                        name="plot-distribution"
+                        defaultValue="gridded"
+                        onChange={() => setProjectDetail("plotDistribution", "gridded")}
+                        checked={plotDistribution === "gridded"}
+                        />
+                        <label
+                        className="form-check-label"
+                        htmlFor="plot-distribution-gridded"
+                        >
+                        Gridded
+                        </label>
+                    </div>
+                    <div className="form-check form-check-inline">
+                        <input
+                        className="form-check-input"
+                        type="radio"
+                        id="plot-distribution-csv"
+                        name="plot-distribution"
+                        defaultValue="csv"
+                        onChange={() => setProjectDetail("plotDistribution", "csv")}
+                        checked={plotDistribution === "csv"}
+                        />
+                        <label
+                        className="btn btn-sm btn-block btn-outline-lightgreen btn-file py-0 my-0"
+                        id="custom-csv-upload"
+                        htmlFor="plot-distribution-csv-file"
+                        >
+                        Upload CSV
+                        <input
+                            type="file"
+                            accept="text/csv"
+                            id="plot-distribution-csv-file"
+                            defaultValue=""
+                            name="plot-distribution-csv-file"
+                            onChange={encodeImageFileAsURL}
+                            style={{ display: "none" }}
+                            disabled={plotDistribution != "csv"}
+                        />
+                        </label>
+                    </div>
+                    <div className="form-check form-check-inline">
+                        <input
+                        className="form-check-input"
+                        type="radio"
+                        id="plot-distribution-shp"
+                        name="plot-distribution"
+                        defaultValue="shp"
+                        onChange={() => setProjectDetail("plotDistribution", "shp")}
+                        checked={plotDistribution === "shp"}
+                        />
+                        <label
+                        className="btn btn-sm btn-block btn-outline-lightgreen btn-file py-0 my-0"
+                        id="custom-shp-upload"
+                        htmlFor="plot-distribution-shp-file"
+                        >
+                        Upload SHP
+                        <input
+                            type="file"
+                            accept="application/zip"
+                            id="plot-distribution-shp-file"
+                            defaultValue=""
+                            name="plot-distribution-shp-file"
+                            onChange={encodeImageFileAsURL}
+                            style={{ display: "none" }}
+                            disabled={plotDistribution != "shp"}
+                        />
+                        </label>
+                    </div>
+                    <p id="plot-design-text" className="font-italic ml-2 small">-
+                        {plotDistribution === "random" &&
+                        "Plot centers will be randomly distributed within the AOI."}
+                        {plotDistribution === "gridded" &&
+                        "Plot centers will be arranged on a grid within the AOI using the plot spacing selected below."}
+                        {plotDistribution === "csv" &&
+                        "Specify your own plot centers by uploading a CSV with these fields: LONGITUDE,LATITUDE,PLOTID."}
+                        {plotDistribution === "shp" &&
+                        "Specify your own plot boundaries by uploading a zipped Shapefile (containing SHP, SHX, DBF, and PRJ files) of polygon features. Each feature must have a unique PLOTID field."}
+                    </p>
 
-              {!useTemplatePlots && (
-                <Fragment>
-                  <hr />
-                  <h3 className="mb-3">Spatial Distribution</h3>
-                  <div className="form-check form-check-inline">
-                    <input
-                      className="form-check-input"
-                      type="radio"
-                      id="plot-distribution-random"
-                      name="plot-distribution"
-                      defaultValue="random"
-                      onChange={() => this.props.setPlotDistribution("random")}
-                      checked={plotDistribution === "random"}
-                    />
-                    <label
-                      className="form-check-label"
-                      htmlFor="plot-distribution-random"
-                    >
-                      Random
+                    <div className="form-group mb-3">
+                        <label htmlFor="num-plots">Number of plots</label>
+                        <input
+                        className="form-control form-control-sm"
+                        type="number"
+                        id="num-plots"
+                        name="num-plots"
+                        autoComplete="off"
+                        min="0"
+                        step="1"
+                        value={numPlots || ""}
+                        disabled={plotDistribution != "random"}
+                        onChange={e => setProjectDetail("numPlots", e.target.value)}
+                        />
+                    </div>
+                    <div className="form-group mb-1">
+                        <label htmlFor="plot-spacing">Plot spacing (m)</label>
+                        <input
+                        className="form-control form-control-sm"
+                        type="number"
+                        id="plot-spacing"
+                        name="plot-spacing"
+                        autoComplete="off"
+                        min="0.0"
+                        step="any"
+                        value={plotSpacing || ""}
+                        disabled={plotDistribution != "gridded"}
+                        onChange={e => setProjectDetail("plotSpacing", e.target.value)}
+                        />
+                    </div>
+                    <hr />
+                    <h3>Plot Shape</h3>
+                    <div className="form-check form-check-inline">
+                        <input
+                        className="form-check-input"
+                        type="radio"
+                        id="plot-shape-circle"
+                        name="plot-shape"
+                        defaultValue="circle"
+                        onChange={() => setProjectDetail("plotShape", "circle")}
+                        checked={plotShape === "circle"}
+                        disabled={plotDistribution === "shp"}
+                        />
+                        <label
+                        className="form-check-label"
+                        htmlFor="plot-shape-circle"
+                        >
+                        Circle
+                        </label>
+                    </div>
+                    <div className="form-check form-check-inline">
+                        <input
+                        className="form-check-input"
+                        type="radio"
+                        id="plot-shape-square"
+                        name="plot-shape"
+                        defaultValue="square"
+                        onChange={() => setProjectDetail("plotShape", "square")}
+                        checked={plotShape === "square"}
+                        disabled={plotDistribution === "shp"}
+                        />
+                        <label
+                        className="form-check-label"
+                        htmlFor="plot-shape-square"
+                        >
+                        Square
+                        </label>
+                    </div>
+                    <br/>
+                    <label htmlFor="plot-size" className="mt-3">
+                        {plotShape == "circle" ? "Diameter (m)" : "Width (m)"}
                     </label>
-                  </div>
-                  <div className="form-check form-check-inline">
                     <input
-                      className="form-check-input"
-                      type="radio"
-                      id="plot-distribution-gridded"
-                      name="plot-distribution"
-                      defaultValue="gridded"
-                      onChange={() => this.props.setPlotDistribution("gridded")}
-                      checked={plotDistribution === "gridded"}
+                        className="form-control form-control-sm"
+                        type="number"
+                        id="plot-size"
+                        name="plot-size"
+                        autoComplete="off"
+                        min="0.0"
+                        step="any"
+                        value={plotSize}
+                        disabled={plotDistribution === "shp"}
+                        onChange={e => setProjectDetail("plotSize", e.target.value)}
                     />
-                    <label
-                      className="form-check-label"
-                      htmlFor="plot-distribution-gridded"
-                    >
-                      Gridded
-                    </label>
-                  </div>
-                  <div className="form-check form-check-inline">
-                    <input
-                      className="form-check-input"
-                      type="radio"
-                      id="plot-distribution-csv"
-                      name="plot-distribution"
-                      defaultValue="csv"
-                      onChange={() => this.props.setPlotDistribution("csv")}
-                      checked={plotDistribution === "csv"}
-                    />
-                    <label
-                      className="btn btn-sm btn-block btn-outline-lightgreen btn-file py-0 my-0"
-                      id="custom-csv-upload"
-                      htmlFor="plot-distribution-csv-file"
-                    >
-                      Upload CSV
-                      <input
-                        type="file"
-                        accept="text/csv"
-                        id="plot-distribution-csv-file"
-                        defaultValue=""
-                        name="plot-distribution-csv-file"
-                        onChange={this.encodeImageFileAsURL}
-                        style={{ display: "none" }}
-                        disabled={plotDistribution != "csv"}
-                      />
-                    </label>
-                  </div>
-                  <div className="form-check form-check-inline">
-                    <input
-                      className="form-check-input"
-                      type="radio"
-                      id="plot-distribution-shp"
-                      name="plot-distribution"
-                      defaultValue="shp"
-                      onChange={() => this.props.setPlotDistribution("shp")}
-                      checked={plotDistribution === "shp"}
-                    />
-                    <label
-                      className="btn btn-sm btn-block btn-outline-lightgreen btn-file py-0 my-0"
-                      id="custom-shp-upload"
-                      htmlFor="plot-distribution-shp-file"
-                    >
-                      Upload SHP
-                      <input
-                        type="file"
-                        accept="application/zip"
-                        id="plot-distribution-shp-file"
-                        defaultValue=""
-                        name="plot-distribution-shp-file"
-                        onChange={this.encodeImageFileAsURL}
-                        style={{ display: "none" }}
-                        disabled={plotDistribution != "shp"}
-                      />
-                    </label>
-                  </div>
-                  <p id="plot-design-text" className="font-italic ml-2 small">-
-                    {plotDistribution === "random" &&
-                      "Plot centers will be randomly distributed within the AOI."}
-                    {plotDistribution === "gridded" &&
-                      "Plot centers will be arranged on a grid within the AOI using the plot spacing selected below."}
-                    {plotDistribution === "csv" &&
-                      "Specify your own plot centers by uploading a CSV with these fields: LONGITUDE,LATITUDE,PLOTID."}
-                    {plotDistribution === "shp" &&
-                      "Specify your own plot boundaries by uploading a zipped Shapefile (containing SHP, SHX, DBF, and PRJ files) of polygon features. Each feature must have a unique PLOTID field."}
-                  </p>
-
-                  <div className="form-group mb-3">
-                    <label htmlFor="num-plots">Number of plots</label>
-                    <input
-                      className="form-control form-control-sm"
-                      type="number"
-                      id="num-plots"
-                      name="num-plots"
-                      autoComplete="off"
-                      min="0"
-                      step="1"
-                      defaultValue={projectDetails.numPlots || ""}
-                      disabled={plotDistribution != "random"}
-                    />
-                  </div>
-                  <div className="form-group mb-1">
-                    <label htmlFor="plot-spacing">Plot spacing (m)</label>
-                    <input
-                      className="form-control form-control-sm"
-                      type="number"
-                      id="plot-spacing"
-                      name="plot-spacing"
-                      autoComplete="off"
-                      min="0.0"
-                      step="any"
-                      defaultValue={projectDetails.plotSpacing || ""}
-                      disabled={plotDistribution != "gridded"}
-                    />
-                  </div>
-                  <hr />
-                  <h3>Plot Shape</h3>
-                  <div className="form-check form-check-inline">
-                    <input
-                      className="form-check-input"
-                      type="radio"
-                      id="plot-shape-circle"
-                      name="plot-shape"
-                      defaultValue="circle"
-                      onChange={() => this.props.setPlotShape("circle")}
-                      checked={plotShape === "circle"}
-                      disabled={plotDistribution === "shp"}
-                    />
-                    <label
-                      className="form-check-label"
-                      htmlFor="plot-shape-circle"
-                    >
-                      Circle
-                    </label>
-                  </div>
-                  <div className="form-check form-check-inline">
-                    <input
-                      className="form-check-input"
-                      type="radio"
-                      id="plot-shape-square"
-                      name="plot-shape"
-                      defaultValue="square"
-                      onChange={() => this.props.setPlotShape("square")}
-                      checked={plotShape === "square"}
-                      disabled={plotDistribution === "shp"}
-                    />
-                    <label
-                      className="form-check-label"
-                      htmlFor="plot-shape-square"
-                    >
-                      Square
-                    </label>
-                  </div>
-                  <br/>
-                  <label htmlFor="plot-size" className="mt-3">
-                    {plotShape == "circle" ? "Diameter (m)" : "Width (m)"}
-                  </label>
-                  <input
-                    className="form-control form-control-sm"
-                    type="number"
-                    id="plot-size"
-                    name="plot-size"
-                    autoComplete="off"
-                    min="0.0"
-                    step="any"
-                    defaultValue={projectDetails.plotSize}
-                    disabled={plotDistribution === "shp"}
-                  />
-                </Fragment>
-              )}
+                    </Fragment>
+                )}
             </div>
           </div>
         </div>
       </SectionBlock>
     );
-  }
 }
 
 
-class SampleDesign extends React.Component {
-    constructor(props) {
-        super(props);
-    };
-    encodeImageFileAsURL(event) {
-        console.log(event)
-        let file = event.target.files[0];
-        let reader = new FileReader();
-        reader.onloadend = function () {
-            let base64Data = reader.result;
-            console.log("RESULT", base64Data);
-        };
-        reader.readAsDataURL(file);
-    }
-    render() {
-        const { project: { projectDetails: { plotDistribution, sampleDistribution, samplesPerPlot, sampleResolution } } } = this.props;
-        return (
-            <SectionBlock title="Sample Design">
-                <div id="sample-design">
-                    <h3>Spatial Distribution</h3>
-                    <div className="form-check form-check-inline">
-                        <input
-                            className="form-check-input" 
-                            type="radio" 
-                            id="sample-distribution-random"
-                            name="sample-distribution" 
-                            defaultValue="random"
-                            onChange={() => this.props.setSampleDistribution("random")}
-                            checked={sampleDistribution === "random"}
-                            disabled={plotDistribution === "shp"}
-                        />
-                        <label className="form-check-label"
-                            htmlFor="sample-distribution-random">
-                            Random
-                        </label>
-                    </div>
-                    <div className="form-check form-check-inline">
-                        <input
-                            className="form-check-input" 
-                            type="radio" 
-                            id="sample-distribution-gridded"
-                            name="sample-distribution" 
-                            defaultValue="gridded"
-                            onChange={() => this.props.setSampleDistribution("gridded")}
-                            checked={sampleDistribution === "gridded"}
-                            disabled={plotDistribution === "shp"}
-                        />
-                        <label className="form-check-label"
-                            htmlFor="sample-distribution-gridded">
-                            Gridded
-                        </label>
-                    </div>
-                    <div className="form-check form-check-inline">
-                        <input
-                            className="form-check-input" 
-                            type="radio" 
-                            id="sample-distribution-csv"
-                            name="sample-distribution" 
-                            defaultValue="csv"
-                            onChange={() => this.props.setSampleDistribution("csv")}
-                            checked={sampleDistribution === "csv"}
-                            disabled={plotDistribution === "random" || plotDistribution === "gridded"}
-                        />
-                        <label className="btn btn-sm btn-block btn-outline-lightgreen btn-file py-0 my-0"
-                            style={{opacity: plotDistribution === "random" || plotDistribution === "gridded" ? "0.25" : "1.0"}}
-                            id="sample-custom-csv-upload"
-                            htmlFor="sample-distribution-csv-file">
-                            Upload CSV
-                            <input 
-                                type="file" 
-                                accept="text/csv" 
-                                id="sample-distribution-csv-file"
-                                name="sample-distribution-csv-file"
-                                defaultValue=""
-                                onChange={this.encodeImageFileAsURL}
-                                style={{ display: "none" }}
-                                disabled={sampleDistribution !== "csv"}
-                            />
-                        </label>
-                    </div>
-                    <div className="form-check form-check-inline">
-                        <input
-                            className="form-check-input" 
-                            type="radio" 
-                            id="sample-distribution-shp"
-                            name="sample-distribution" 
-                            defaultValue="shp"
-                            onChange={() => this.props.setSampleDistribution("shp")}
-                            checked={sampleDistribution === "shp"}
-                            disabled={plotDistribution === "random" || plotDistribution === "gridded"}
-                        />
-                        <label className="btn btn-sm btn-block btn-outline-lightgreen btn-file py-0 my-0"
-                            style={{opacity: plotDistribution === "random" || plotDistribution === "gridded" ? "0.25" : "1.0"}}
-                            id="sample-custom-shp-upload"
-                            htmlFor="sample-distribution-shp-file">
-                            Upload SHP
-                            <input
-                                type="file" 
-                                accept="application/zip" 
-                                id="sample-distribution-shp-file"
-                                name="sample-distribution-shp-file"
-                                defaultValue=""
-                                onChange={this.encodeImageFileAsURL}
-                                style={{ display: "none" }}
-                                disabled={sampleDistribution != "shp"}
-                            />
-                        </label>
-                    </div>
-                    <p id="sample-design-text" className="font-italic ml-2 small">-
-                        {sampleDistribution === "random" &&
-                            "Sample points will be randomly distributed within the plot boundary."}
-                        {sampleDistribution === "gridded" &&
-                            "Sample points will be arranged on a grid within the plot boundary using the sample resolution selected below."}
-                        {sampleDistribution === "csv" &&
-                            "Specify your own sample points by uploading a CSV with these fields: LONGITUDE,LATITUDE,PLOTID,SAMPLEID."}
-                        {sampleDistribution === "shp" &&
-                            "Specify your own sample shapes by uploading a zipped Shapefile (containing SHP, SHX, DBF, and PRJ files) of polygon features. Each feature must have PLOTID and SAMPLEID fields."}
-                    </p>
-                    <div className="form-group mb-3">
-                        <label htmlFor="samples-per-plot">Samples per plot</label>
-                        <input
-                            className="form-control form-control-sm" 
-                            type="number" 
-                            id="samples-per-plot"
-                            name="samples-per-plot" 
-                            autoComplete="off" 
-                            min="0" 
-                            step="1"
-                            defaultValue={samplesPerPlot || ""}
-                            disabled={sampleDistribution != "random"}
-                        />
-                    </div>
-                    <div className="form-group mb-1">
-                        <label htmlFor="sample-resolution">Sample resolution (m)</label>
-                        <input
-                            className="form-control form-control-sm" 
-                            type="number" 
-                            id="sample-resolution"
-                            name="sample-resolution" 
-                            autoComplete="off" 
-                            min="0.0" 
-                            step="any"
-                            defaultValue={sampleResolution || ""}
-                            disabled={sampleDistribution != "gridded"}
-                        />
-                    </div>
+function SampleDesign ({
+    setProjectDetail, 
+    projectDetails: { plotDistribution, sampleDistribution, samplesPerPlot, sampleResolution }
+    }) {
+    return (
+        <SectionBlock title="Sample Design">
+            <div id="sample-design">
+                <h3>Spatial Distribution</h3>
+                <div className="form-check form-check-inline">
+                    <input
+                        className="form-check-input" 
+                        type="radio" 
+                        id="sample-distribution-random"
+                        name="sample-distribution" 
+                        defaultValue="random"
+                        onChange={() => setProjectDetail("sampleDistribution", "random")}
+                        checked={sampleDistribution === "random"}
+                        disabled={plotDistribution === "shp"}
+                    />
+                    <label className="form-check-label"
+                        htmlFor="sample-distribution-random">
+                        Random
+                    </label>
                 </div>
-            </SectionBlock>
-        );
-    }
+                <div className="form-check form-check-inline">
+                    <input
+                        className="form-check-input" 
+                        type="radio" 
+                        id="sample-distribution-gridded"
+                        name="sample-distribution" 
+                        defaultValue="gridded"
+                        onChange={() => setProjectDetail("sampleDistribution", "gridded")}
+                        checked={sampleDistribution === "gridded"}
+                        disabled={plotDistribution === "shp"}
+                    />
+                    <label className="form-check-label"
+                        htmlFor="sample-distribution-gridded">
+                        Gridded
+                    </label>
+                </div>
+                <div className="form-check form-check-inline">
+                    <input
+                        className="form-check-input" 
+                        type="radio" 
+                        id="sample-distribution-csv"
+                        name="sample-distribution" 
+                        defaultValue="csv"
+                        onChange={() => setProjectDetail("sampleDistribution", "csv")}
+                        checked={sampleDistribution === "csv"}
+                        disabled={plotDistribution === "random" || plotDistribution === "gridded"}
+                    />
+                    <label className="btn btn-sm btn-block btn-outline-lightgreen btn-file py-0 my-0"
+                        style={{opacity: plotDistribution === "random" || plotDistribution === "gridded" ? "0.25" : "1.0"}}
+                        id="sample-custom-csv-upload"
+                        htmlFor="sample-distribution-csv-file">
+                        Upload CSV
+                        <input 
+                            type="file" 
+                            accept="text/csv" 
+                            id="sample-distribution-csv-file"
+                            name="sample-distribution-csv-file"
+                            defaultValue=""
+                            onChange={encodeImageFileAsURL}
+                            style={{ display: "none" }}
+                            disabled={sampleDistribution !== "csv"}
+                        />
+                    </label>
+                </div>
+                <div className="form-check form-check-inline">
+                    <input
+                        className="form-check-input" 
+                        type="radio" 
+                        id="sample-distribution-shp"
+                        name="sample-distribution" 
+                        defaultValue="shp"
+                        onChange={() => setProjectDetail("sampleDistribution", "shp")}
+                        checked={sampleDistribution === "shp"}
+                        disabled={plotDistribution === "random" || plotDistribution === "gridded"}
+                    />
+                    <label className="btn btn-sm btn-block btn-outline-lightgreen btn-file py-0 my-0"
+                        style={{opacity: plotDistribution === "random" || plotDistribution === "gridded" ? "0.25" : "1.0"}}
+                        id="sample-custom-shp-upload"
+                        htmlFor="sample-distribution-shp-file">
+                        Upload SHP
+                        <input
+                            type="file" 
+                            accept="application/zip" 
+                            id="sample-distribution-shp-file"
+                            name="sample-distribution-shp-file"
+                            defaultValue=""
+                            onChange={encodeImageFileAsURL}
+                            style={{ display: "none" }}
+                            disabled={sampleDistribution != "shp"}
+                        />
+                    </label>
+                </div>
+                <p id="sample-design-text" className="font-italic ml-2 small">-
+                    {sampleDistribution === "random" &&
+                        "Sample points will be randomly distributed within the plot boundary."}
+                    {sampleDistribution === "gridded" &&
+                        "Sample points will be arranged on a grid within the plot boundary using the sample resolution selected below."}
+                    {sampleDistribution === "csv" &&
+                        "Specify your own sample points by uploading a CSV with these fields: LONGITUDE,LATITUDE,PLOTID,SAMPLEID."}
+                    {sampleDistribution === "shp" &&
+                        "Specify your own sample shapes by uploading a zipped Shapefile (containing SHP, SHX, DBF, and PRJ files) of polygon features. Each feature must have PLOTID and SAMPLEID fields."}
+                </p>
+                <div className="form-group mb-3">
+                    <label htmlFor="samples-per-plot">Samples per plot</label>
+                    <input
+                        className="form-control form-control-sm" 
+                        type="number" 
+                        id="samples-per-plot"
+                        name="samples-per-plot" 
+                        autoComplete="off" 
+                        min="0" 
+                        step="1"
+                        value={samplesPerPlot || ""}
+                        disabled={sampleDistribution != "random"}
+                        onChange={e => setProjectDetail("samplesPerPlot", e.target.value)}
+                    />
+                </div>
+                <div className="form-group mb-1">
+                    <label htmlFor="sample-resolution">Sample resolution (m)</label>
+                    <input
+                        className="form-control form-control-sm" 
+                        type="number" 
+                        id="sample-resolution"
+                        name="sample-resolution" 
+                        autoComplete="off" 
+                        min="0.0" 
+                        step="any"
+                        value={sampleResolution || ""}
+                        disabled={sampleDistribution != "gridded"}
+                        onChange={e => setProjectDetail("sampleResolution", e.target.value)}
+                    />
+                </div>
+            </div>
+        </SectionBlock>
+    );
 }
 
-function ProjectManagement(props) {
+function ProjectManagement({ createProject }) {
     return (
         <SectionBlock title="Project Management">
             <div id="project-management">
                 <div className="row">
-                    <input type="button" id="create-project" className="btn btn-outline-danger btn-sm btn-block"
-                        name="create-project" value="Create Project"
-                        onClick={props.createProject}/>
+                    <input
+                        type="button"
+                        id="create-project"
+                        className="btn btn-outline-danger btn-sm btn-block"
+                        name="create-project"
+                        value="Create Project"
+                        onClick={createProject}
+                    />
                     <div id="spinner"></div>
                 </div>
             </div>

--- a/src/main/resources/public/jsx/create-project.js
+++ b/src/main/resources/public/jsx/create-project.js
@@ -130,6 +130,16 @@ class Project extends React.Component {
             alert("A plot size is required");
             return false;
 
+        } else if (projectDetails.plotDistribution === "csv" 
+                    && !(projectDetails.plotFileName && projectDetails.plotFileName.includes(".csv"))) {
+            alert("A plot CSV file is required");
+            return false;
+
+        } else if (projectDetails.plotDistribution === "shp" 
+                    && !(projectDetails.plotFileName && projectDetails.plotFileName.includes(".shp"))) {
+            alert("A plot SHP file is required");
+            return false;
+
         } else if (projectDetails.sampleDistribution === "random" 
                     && (!projectDetails.samplesPerPlot || projectDetails.samplesPerPlot === 0)) {
             alert("A number of samples per plot is required for random sample distribution");
@@ -138,6 +148,16 @@ class Project extends React.Component {
         } else if (projectDetails.sampleDistribution === "gridded" 
                 && (!projectDetails.sampleResolution || projectDetails.sampleResolution === 0)) {
             alert("A sample resolution is required for gridded sample distribution");
+            return false;
+
+        } else if (projectDetails.sampleDistribution === "csv" 
+                    && !(projectDetails.sampleFileName && projectDetails.sampleFileName.includes(".csv"))) {
+            alert("A sample CSV file is required");
+            return false;
+
+            } else if (projectDetails.sampleDistribution === "shp" 
+                    && !(projectDetails.sampleFileName && projectDetails.sampleFileName.includes(".shp"))) {
+            alert("A sample SHP file is required");
             return false;
 
         } else if (projectDetails.surveyQuestions.length === 0) {
@@ -283,7 +303,7 @@ class Project extends React.Component {
                             setProjectTemplate={this.setProjectTemplate} 
                             setSurveyQuestions={this.setSurveyQuestions}
                             toggleTemplatePlots={this.toggleTemplatePlots}
-                            useTemplatePlots={this.useTemplatePlots}
+                            useTemplatePlots={this.state.useTemplatePlots}
                         />
                         <ProjectManagement createProject={this.createProject} />
                     </Fragment>
@@ -298,7 +318,6 @@ function ProjectDesignForm(props) {
         <form id="project-design-form" className="px-2 pb-2" method="post"
               action={props.documentRoot + "/create-project"}
               encType="multipart/form-data">
-        
                 {props.projectList && 
                     <ProjectTemplateVisibility 
                         projectId={props.projectDetails.id} 
@@ -562,19 +581,8 @@ function ProjectImagery({ baseMapSource, imageryList, setProjectDetail }) {
     );
 }
 
-function encodeImageFileAsURL(event) {
-      console.log(event)
-    const file = event.target.files[0];
-    let reader = new FileReader();
-    reader.onloadend = function() {
-      let base64Data = reader.result;
-      console.log("RESULT", base64Data);
-    };
-    reader.readAsDataURL(file);
-  }
-
 function PlotDesign ({
-    projectDetails: { id, plotDistribution, plotShape, numPlots, plotSpacing, plotSize },
+    projectDetails: { id, plotDistribution, plotShape, numPlots, plotSpacing, plotSize, plotFileName },
     setProjectDetail,
     toggleTemplatePlots,
     useTemplatePlots,
@@ -665,7 +673,7 @@ function PlotDesign ({
                             id="plot-distribution-csv-file"
                             defaultValue=""
                             name="plot-distribution-csv-file"
-                            onChange={encodeImageFileAsURL}
+                            onChange={e => setProjectDetail("plotFileName", e.target.files[0].name)}
                             style={{ display: "none" }}
                             disabled={plotDistribution != "csv"}
                         />
@@ -693,12 +701,17 @@ function PlotDesign ({
                             id="plot-distribution-shp-file"
                             defaultValue=""
                             name="plot-distribution-shp-file"
-                            onChange={encodeImageFileAsURL}
+                            onChange={e => setProjectDetail("plotFileName", e.target.files[0].name)}
                             style={{ display: "none" }}
                             disabled={plotDistribution != "shp"}
                         />
                         </label>
                     </div>
+                    {["csv", "shp"].includes(plotDistribution) &&
+                        <div className="PlotDesign__file-display ml-3 d-inline">
+                            File: {!plotFileName ? <span className="font-italic">None</span> : plotFileName}
+                        </div>
+                    }
                     <p id="plot-design-text" className="font-italic ml-2 small">-
                         {plotDistribution === "random" &&
                         "Plot centers will be randomly distributed within the AOI."}
@@ -806,7 +819,7 @@ function PlotDesign ({
 
 function SampleDesign ({
     setProjectDetail, 
-    projectDetails: { plotDistribution, sampleDistribution, samplesPerPlot, sampleResolution }
+    projectDetails: { plotDistribution, sampleDistribution, samplesPerPlot, sampleResolution, sampleFileName }
     }) {
     return (
         <SectionBlock title="Sample Design">
@@ -866,7 +879,7 @@ function SampleDesign ({
                             id="sample-distribution-csv-file"
                             name="sample-distribution-csv-file"
                             defaultValue=""
-                            onChange={encodeImageFileAsURL}
+                            onChange={e => setProjectDetail("shapeFileName", e.target.files[0].name)}
                             style={{ display: "none" }}
                             disabled={sampleDistribution !== "csv"}
                         />
@@ -894,12 +907,17 @@ function SampleDesign ({
                             id="sample-distribution-shp-file"
                             name="sample-distribution-shp-file"
                             defaultValue=""
-                            onChange={encodeImageFileAsURL}
+                            onChange={() => setProjectDetail("sampleFileName", event.target.files[0].name)}
                             style={{ display: "none" }}
                             disabled={sampleDistribution != "shp"}
                         />
                     </label>
                 </div>
+                {["csv", "shp"].includes(sampleDistribution) &&
+                    <div className="SampleDesign__file-display ml-3 d-inline">
+                        File: {!sampleFileName ? <span className="font-italic">None</span> : sampleFileName}
+                    </div>
+                }
                 <p id="sample-design-text" className="font-italic ml-2 small">-
                     {sampleDistribution === "random" &&
                         "Sample points will be randomly distributed within the plot boundary."}

--- a/src/main/resources/public/jsx/create-project.js
+++ b/src/main/resources/public/jsx/create-project.js
@@ -11,7 +11,7 @@ class Project extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            projectDetails: {baseMapSource = ""},
+            projectDetails: {baseMapSource: ""},
             templateId: "0",
             useTemplatePlots: false,
             imageryList: [],

--- a/src/main/resources/public/jsx/home.js
+++ b/src/main/resources/public/jsx/home.js
@@ -210,15 +210,15 @@ class SideBar extends React.Component {
 
         const filteredProjects = this.props.projects
                 .filter(proj => this.state.filterInstitution
-                                    || this.state.useFirstLetter 
+                                    || (this.state.useFirstLetter 
                                         ? proj.name.toLocaleLowerCase().startsWith(filterTextLower)
-                                        : proj.name.toLocaleLowerCase().includes(filterTextLower));
-
+                                        : proj.name.toLocaleLowerCase().includes(filterTextLower)));
+                                        
         const filteredInstitutions = this.state.institutions
                 .filter(inst => !this.state.filterInstitution
-                                    || this.state.useFirstLetter 
+                                    || (this.state.useFirstLetter 
                                         ? inst.name.toLocaleLowerCase().startsWith(filterTextLower)
-                                        : inst.name.toLocaleLowerCase().includes(filterTextLower))
+                                        : inst.name.toLocaleLowerCase().includes(filterTextLower)))
                 .filter(inst => this.state.filterInstitution 
                                     || filteredProjects.some(proj => inst.id === proj.institution))
                 .filter(inst => !(this.state.filterInstitution && this.state.containsProjects) 

--- a/src/main/resources/public/jsx/review-project.js
+++ b/src/main/resources/public/jsx/review-project.js
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom";
 
 import { FormLayout, SectionBlock, StatsCell, StatsRow } from "./components/FormComponents";
 import SurveyCardList from "./components/SurveyCardList";
+import { convertSampleValuesToSurveyQuestions } from "./utils/SurveyUtils"
 import { mercator, ceoMapStyles } from "../js/mercator-openlayers.js";
 import { utils } from "../js/utils.js";
 
@@ -147,33 +148,6 @@ class Project extends React.Component {
         window.open(this.props.documentRoot + "/dump-project-raw-data/" + this.state.projectDetails.id, "_blank");
     }
 
-    convertSampleValuesToSurveyQuestions(sampleValues) {
-        return sampleValues.map(sampleValue => {
-            if (sampleValue.name && sampleValue.values) {
-                const surveyQuestionAnswers = sampleValue.values.map(value => {
-                    if (value.name) {
-                        return {
-                            id: value.id,
-                            answer: value.name,
-                            color: value.color
-                        };
-                    } else {
-                        return value;
-                    }
-                });
-                return {
-                    id: sampleValue.id,
-                    question: sampleValue.name,
-                    answers: surveyQuestionAnswers,
-                    parent_question: -1,
-                    parent_answer: -1
-                };
-            } else {
-                return sampleValue;
-            }
-        });
-    }
-
     getProjectById = () => {
         const { projectId } = this.props
         fetch(this.props.documentRoot + "/get-project-by-id/" + projectId)
@@ -190,8 +164,8 @@ class Project extends React.Component {
                     alert("No project found with ID " + projectId + ".");
                     window.location = this.state.documentRoot + "/home";
                 } else {                   
-                    const newSampleValues = this.convertSampleValuesToSurveyQuestions(data.sampleValues);
-                    this.setState({projectDetails: {...data, sampleValues: newSampleValues}});
+                    const newSurveyQuestions = convertSampleValuesToSurveyQuestions(data.sampleValues);
+                    this.setState({projectDetails: { ...data, surveyQuestions: newSurveyQuestions }});
                 }
             });
     }
@@ -479,7 +453,7 @@ function ProjectDesignReview({ project, projectId }) {
             }
             <PlotReview project={project}/>
             <SampleReview project={project}/>
-            <SurveyReview surveyQuestions={project.projectDetails.sampleValues} />
+            <SurveyReview surveyQuestions={project.projectDetails.surveyQuestions} />
         </div>
     );
 }

--- a/src/main/resources/public/jsx/utils/SurveyUtils.js
+++ b/src/main/resources/public/jsx/utils/SurveyUtils.js
@@ -20,5 +20,5 @@ export function convertSampleValuesToSurveyQuestions(sampleValues) {
 }
 
 export function removeEnumerator(questionText) {
-    return questionText.replace('/[\s][(][\d]*[[)]$/', '')
+    return questionText.replace(/[\s][(][\d]*[[)]$/, '')
 }

--- a/src/main/resources/public/jsx/utils/SurveyUtils.js
+++ b/src/main/resources/public/jsx/utils/SurveyUtils.js
@@ -1,0 +1,51 @@
+
+export function convertSampleValuesToSurveyQuestions(sampleValues) {
+    return (sampleValues || []).map(sv => {
+        const newAnswers = (sv.answers || sv.values).map(value => ({
+            id: value.id,
+            answer: value.answer || value.name || "",
+            color: value.color
+          }));
+
+        return {
+            id: sv.id,
+            question: sv.question || sv.name || "",
+            answers: newAnswers,
+            parentQuestion: parseInt(sv.parentQuestion || sv.parent_question || -1),
+            parentAnswer: parseInt(sv.parentAnswer || sv.parent_answer || -1),
+            componentType: (sv.componentType || "button").toLocaleLowerCase(),
+            dataType: (sv.dataType || "text").toLocaleLowerCase()
+        };
+    });
+}
+
+export function getChildQuestionIds(questionId) {
+    const childQuestions = this.props.surveyQuestions.filter(sv => sv.parentQuestion === questionId);
+    if (childQuestions.length === 0) {
+        return [questionId];
+    } else {
+        return childQuestions.reduce((acc, cur) => {
+                        return [...acc, ...this.getChildQuestionIds(cur.id)];
+                    }, [questionId])
+    }
+}
+
+export function getAllChildQuestions(currentQuestion, surveyQuestions) {
+    const childQuestions = surveyQuestions.filter(sv => sv.parentQuestion === currentQuestion.id);
+
+    if (childQuestions.length === 0) {
+        return [currentQuestion];
+    } else {
+        return childQuestions.reduce((acc, cq) => {
+            return [...acc, ...this.getAllChildQuestions(cq, surveyQuestions)];
+        }, [currentQuestion])
+    }
+}
+
+// export function extractUserSamples(samples) {
+//     return newPlot.samples.map((obj, s) => {
+//                     obj[s.id] = s.value || {}
+//                     return obj;
+//                     }, {})  
+//                 : {},
+// }

--- a/src/main/resources/public/jsx/utils/SurveyUtils.js
+++ b/src/main/resources/public/jsx/utils/SurveyUtils.js
@@ -19,33 +19,6 @@ export function convertSampleValuesToSurveyQuestions(sampleValues) {
     });
 }
 
-export function getChildQuestionIds(questionId) {
-    const childQuestions = this.props.surveyQuestions.filter(sv => sv.parentQuestion === questionId);
-    if (childQuestions.length === 0) {
-        return [questionId];
-    } else {
-        return childQuestions.reduce((acc, cur) => {
-                        return [...acc, ...this.getChildQuestionIds(cur.id)];
-                    }, [questionId])
-    }
+export function removeEnumerator(questionText) {
+    return questionText.replace('/[\s][(][\d]*[[)]$/', '')
 }
-
-export function getAllChildQuestions(currentQuestion, surveyQuestions) {
-    const childQuestions = surveyQuestions.filter(sv => sv.parentQuestion === currentQuestion.id);
-
-    if (childQuestions.length === 0) {
-        return [currentQuestion];
-    } else {
-        return childQuestions.reduce((acc, cq) => {
-            return [...acc, ...this.getAllChildQuestions(cq, surveyQuestions)];
-        }, [currentQuestion])
-    }
-}
-
-// export function extractUserSamples(samples) {
-//     return newPlot.samples.map((obj, s) => {
-//                     obj[s.id] = s.value || {}
-//                     return obj;
-//                     }, {})  
-//                 : {},
-// }


### PR DESCRIPTION
Facing the user
- Prompt user on duplicate question and append enumerator 
-- Show in designer, hide elsewhere
- Validate project and survey before submitting.
-- Show selected file name on plot and sample design.
- Fix filter on home 

Behind the scenes
- Refactor convert survey values to survey quesions
-- Update to convert snake to camel
-- Add defaults for componentType and dataType
-- Force type for the few bad projects
-- Store result as `surveyQuestions` to distinguish good data and allow reference in the code

- Store surveyQuestion as selected instead of just text
-- Eliminates many conversions from text to id and back
-- Use .id everywhere that does not directly touch userSamples (still uses keys)

- Update create-projects page
-- Move map to life cylce
-- Use arrow functions
-- Update some of the state saving
-- Initialize new project in state instead of API call to empty project
-- Remove encode64() which was not doing anything, make plot and sample design stateless
