### PR TITLE
fix check logic for templates

### DIFF
--- a/src/main/resources/public/jsx/create-project.js
+++ b/src/main/resources/public/jsx/create-project.js
@@ -143,12 +143,30 @@ class Project extends React.Component {
     };
 
     validateProject = () => {
-        const { projectDetails, coordinates } = this.state;
+        const { projectDetails } = this.state;
         if (projectDetails.name === "" || projectDetails.description === "") {
             alert("A project must contain a name and description");
             return false;
 
-        } else if (["random", "gridded"].includes(projectDetails.plotDistribution) && coordinates.latMax === "") {
+        } else if (!this.state.useTemplatePlots && !this.validatePlotData()) {
+            return false;
+
+        } else if (projectDetails.surveyQuestions.length === 0) {
+            alert("A survey must include at least one question");
+            return false;
+
+        } else if (projectDetails.surveyQuestions.some(sq => sq.answers.length === 0)) {
+            alert("All survey questions must contain at least one answer");
+            return false;
+
+        } else {
+            return true;
+        }
+    };
+
+    validatePlotData = () => {
+        const { projectDetails, coordinates } = this.state;
+        if (["random", "gridded"].includes(projectDetails.plotDistribution) && coordinates.latMax === "") {
             alert("Please select a boundary");
             return false;
 
@@ -197,18 +215,10 @@ class Project extends React.Component {
             alert("A sample SHP (.zip) file is required");
             return false;
 
-        } else if (projectDetails.surveyQuestions.length === 0) {
-            alert("A survey must include at least one question");
-            return false;
-
-        } else if (projectDetails.surveyQuestions.some(sq => sq.answers.length === 0)) {
-            alert("All survey questions must contain at least one answer");
-            return false;
-
         } else {
             return true;
         }
-    };
+    }
 
     setProjectTemplate = (newTemplateId) => {
         if (parseInt(newTemplateId) === 0) {

--- a/src/main/resources/public/jsx/create-project.js
+++ b/src/main/resources/public/jsx/create-project.js
@@ -218,7 +218,7 @@ class Project extends React.Component {
         } else {
             return true;
         }
-    }
+    };
 
     setProjectTemplate = (newTemplateId) => {
         if (parseInt(newTemplateId) === 0) {


### PR DESCRIPTION
Error was being thrown for templates which had shp files, when using copy template plots instead of uploading a new shp file.