### PR TITLE
fix postgres geodash delete

### DIFF
--- a/src/main/java/org/openforis/ceo/postgres/PostgresGeoDash.java
+++ b/src/main/java/org/openforis/ceo/postgres/PostgresGeoDash.java
@@ -1,6 +1,7 @@
 package org.openforis.ceo.postgres;
 
 import static org.openforis.ceo.utils.DatabaseUtils.connect;
+import static org.openforis.ceo.utils.JsonUtils.elementToObject;
 import static org.openforis.ceo.utils.JsonUtils.parseJson;
 
 import com.google.gson.JsonArray;
@@ -34,7 +35,7 @@ public class PostgresGeoDash implements GeoDash {
 
         try (var conn = connect();
              var pstmt = conn.prepareStatement("SELECT * FROM get_project_widgets_by_project_id(?)")) {
-                 
+
             pstmt.setInt(1, Integer.parseInt(projectId));
             try(var rs = pstmt.executeQuery()){
                 if (rs.next()) {
@@ -126,11 +127,14 @@ public class PostgresGeoDash implements GeoDash {
     // Deletes a dashboard widget by widget_id
     public String deleteDashBoardWidgetById(Request req, Response res) {
         var widgetId = req.params(":id");
+        var jsonInputs = elementToObject(parseJson(req.body()));
+        var dashboardId = jsonInputs.get("dashID").getAsString();
 
         try (var conn = connect();
-            var pstmt = conn.prepareStatement("SELECT * FROM delete_project_widget_by_widget_id(?)")) {
+            var pstmt = conn.prepareStatement("SELECT * FROM delete_project_widget_by_widget_id(?, ?)")) {
 
             pstmt.setInt(1, Integer.parseInt(widgetId));
+            pstmt.setObject(2, UUID.fromString(dashboardId));
             pstmt.execute();
 
             return "";

--- a/src/main/java/org/openforis/ceo/postgres/PostgresGeoDash.java
+++ b/src/main/java/org/openforis/ceo/postgres/PostgresGeoDash.java
@@ -3,6 +3,7 @@ package org.openforis.ceo.postgres;
 import static org.openforis.ceo.utils.DatabaseUtils.connect;
 import static org.openforis.ceo.utils.JsonUtils.elementToObject;
 import static org.openforis.ceo.utils.JsonUtils.parseJson;
+import static org.openforis.ceo.utils.ProjectUtils.getOrEmptyString;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
@@ -105,7 +106,7 @@ public class PostgresGeoDash implements GeoDash {
     public String updateDashBoardWidgetById(Request req, Response res) {
         var widgetId = req.params(":id");
         var jsonInputs = parseJson(req.body()).getAsJsonObject();
-        var dashboardId = jsonInputs.get("dashID").getAsString();
+        var dashboardId = getOrEmptyString(jsonInputs, "dashID").getAsString();
         var widgetJsonString = jsonInputs.get("widgetJSON").getAsString();
 
         try (var conn = connect();

--- a/src/main/java/org/openforis/ceo/postgres/PostgresProjects.java
+++ b/src/main/java/org/openforis/ceo/postgres/PostgresProjects.java
@@ -662,7 +662,7 @@ public class PostgresProjects implements Projects {
                         try (var rs = pstmt.executeQuery()) {
                             while (rs.next()) {
                                 var plotCenter = new Double[] {rs.getDouble("lon"), rs.getDouble("lat")};
-                                createProjectSamples(conn, rs.getInt("id"), sampleDistribution,
+                                createProjectSamples(conn, rs.getInt("plot_uid"), sampleDistribution,
                                     plotCenter, plotShape, plotSize, samplesPerPlot, sampleResolution, plotDistribution.equals("shp"));
                             }
                         }

--- a/src/main/java/org/openforis/ceo/postgres/PostgresProjects.java
+++ b/src/main/java/org/openforis/ceo/postgres/PostgresProjects.java
@@ -73,7 +73,7 @@ public class PostgresProjects implements Projects {
             newProject.addProperty("samplesPerPlot",       rs.getInt("samples_per_plot"));
             newProject.addProperty("sampleResolution",     rs.getDouble("sample_resolution"));
             newProject.addProperty("classification_times", "");
-            newProject.addProperty("editable",             rs.getString("editable"));
+            newProject.addProperty("editable",             rs.getBoolean("editable"));
             newProject.addProperty("validBoundary",        rs.getBoolean("valid_boundary"));
             newProject.add("sampleValues", parseJson(rs.getString("survey_questions")).getAsJsonArray());
             newProject.add("surveyRules",  parseJson(rs.getString("survey_rules")).getAsJsonArray());

--- a/src/main/resources/csv/csv2postgres.sh
+++ b/src/main/resources/csv/csv2postgres.sh
@@ -1,4 +1,3 @@
 #!/bin/sh
-cname=${1//-/_}_csv
-csvname=${1}.csv
-PGPASSWORD=ceo psql -h localhost -U ceo -d ceo -c "\copy ext_tables.$cname FROM $csvname DELIMITER ',' CSV HEADER"
+cname=`printf ext_tables.$1_csv | sed -e 's/-/_/g'`
+PGPASSWORD=ceo psql -h localhost -U ceo -d ceo -c "\copy $cname FROM $1.csv DELIMITER ',' CSV HEADER"

--- a/src/main/resources/scripts/data_migration.py
+++ b/src/main/resources/scripts/data_migration.py
@@ -143,7 +143,6 @@ def insert_project_widgets(project_id, dash_id, conn):
         widget = json.load(dash_json)
         if widget["projectID"] is not None and int(project_id)==int(widget["projectID"]) and len(str(widget["widgets"]))>2:
             for awidget in widget["widgets"]:
-                print("adding single widget")
                 cur.execute("select * from add_project_widget(%s, %s::uuid, %s::jsonb)",
                     (widget["projectID"], widget["dashboardID"], json.dumps(awidget)))
                 conn.commit()
@@ -194,7 +193,6 @@ def insert_projects():
                         dash_id = dash["dashboard"]
                         try:
                             if int(dash["projectID"]) == int(project_id):
-                                print("inserting dash")
                                 insert_project_widgets(project_id,dash_id,conn)
                         except: pass
 
@@ -235,7 +233,7 @@ def insert_plots_samples_by_file(project_id, mainconn):
         conn.commit()
         cur_plot.close()
         conn.close()
-        # insert_plots(project_id, mainconn)
+        insert_plots(project_id, mainconn)
     cur_plot.close()
     conn.close()
 

--- a/src/main/resources/scripts/data_migration.py
+++ b/src/main/resources/scripts/data_migration.py
@@ -143,6 +143,7 @@ def insert_project_widgets(project_id, dash_id, conn):
         widget = json.load(dash_json)
         if widget["projectID"] is not None and int(project_id)==int(widget["projectID"]) and len(str(widget["widgets"]))>2:
             for awidget in widget["widgets"]:
+                print("adding single widget")
                 cur.execute("select * from add_project_widget(%s, %s::uuid, %s::jsonb)",
                     (widget["projectID"], widget["dashboardID"], json.dumps(awidget)))
                 conn.commit()
@@ -193,6 +194,7 @@ def insert_projects():
                         dash_id = dash["dashboard"]
                         try:
                             if int(dash["projectID"]) == int(project_id):
+                                print("inserting dash")
                                 insert_project_widgets(project_id,dash_id,conn)
                         except: pass
 
@@ -233,7 +235,7 @@ def insert_plots_samples_by_file(project_id, mainconn):
         conn.commit()
         cur_plot.close()
         conn.close()
-        insert_plots(project_id, mainconn)
+        # insert_plots(project_id, mainconn)
     cur_plot.close()
     conn.close()
 
@@ -602,8 +604,8 @@ if __name__ == "__main__":
         insert_institutions()
         print("inserting imagery")
         insert_imagery()
-        print("inserting projects")
 
+    print("inserting projects")
     insert_projects()
     print("Done with projects")
     update_sequence()

--- a/src/main/resources/scripts/redo-dash.py
+++ b/src/main/resources/scripts/redo-dash.py
@@ -1,0 +1,86 @@
+import datetime
+import json
+import psycopg2
+import shutil
+import os
+import glob
+import csv
+import re
+import subprocess
+import sys
+from config import config
+
+params = config()
+
+jsonpath = r"../../../../target/classes/json"
+csvpath = r"../../../../target/classes/csv"
+csvScriptPath = r"../csv"
+shppath = r"../../../../target/classes/shp"
+shpScriptPath = r"../shp"
+
+def insert_project_widgets(project_id, dash_id, conn):
+    try:
+        cur = conn.cursor()
+        dirname = os.path.dirname(os.path.realpath(__file__))
+        dash_json = open(os.path.abspath(os.path.realpath(os.path.join(dirname, jsonpath , "dash-" + dash_id + ".json"))), "r")
+        widget = json.load(dash_json)
+        if widget["projectID"] is not None and int(project_id)==int(widget["projectID"]) and len(str(widget["widgets"]))>2:
+            for awidget in widget["widgets"]:
+                try:
+                    cur.execute("select CAST(jsonb_extract_path_text(widget, 'id') as int), widget_uid from project_widgets where dashboard_id = %s and CAST(jsonb_extract_path_text(widget, 'id') as int) = CAST(jsonb_extract_path_text(%s, 'id') as int)", (widget["dashboardID"], json.dumps(awidget)))
+                    rows = cur.fetchall()
+
+                    if len(rows)==0:
+                        print("adding single widget")
+                        cur.execute("select * from add_project_widget(%s, %s::uuid, %s::jsonb)",
+                            (widget["projectID"], widget["dashboardID"], json.dumps(awidget)))
+                    else:
+                        print(rows)
+                except: pass
+                conn.commit()
+        cur.close()
+    except (Exception, psycopg2.DatabaseError) as error:
+        print("project widgets: "+ str(error))
+
+def insert_projects():
+    conn = None
+    try:
+        conn = psycopg2.connect(**params)
+        cur = conn.cursor()
+        dirname = os.path.dirname(os.path.realpath(__file__))
+        project_list_json = open(os.path.abspath(os.path.realpath(os.path.join(dirname, jsonpath , "project-list.json"))), "r")
+        projectArr = json.load(project_list_json)
+        project_dash_list_json = open(os.path.abspath(os.path.realpath(os.path.join(dirname, jsonpath , "proj.json"))), "r")
+        dashArr = json.load(project_dash_list_json)
+        print(len(projectArr))
+        for project in projectArr:
+            try:
+                project_id = project["id"]
+                if project_id > 0:
+                    print(project_id)
+                    for dash in dashArr:
+                        dash_id = dash["dashboard"]
+                        try:
+                            if int(dash["projectID"]) == int(project_id):
+                                print("inserting dash")
+                                insert_project_widgets(project_id,dash_id,conn)
+                        except: pass
+                    conn.commit()
+            except(Exception, psycopg2.DatabaseError) as error:
+                print("project for loop: "+ str(error))
+                conn.commit()
+        cur.close()
+    except (Exception, psycopg2.DatabaseError) as error:
+        print("project outer: "+ str(error))
+    finally:
+        if conn is not None:
+            conn.close()
+
+if __name__ == "__main__":
+    print(datetime.datetime.now().strftime("%Y-%m-%d %H:%M"))
+
+    print("inserting widgets")
+    insert_projects()
+    print("Done with widgets")
+    print("Done migration")
+    print(datetime.datetime.now().strftime("%Y-%m-%d %H:%M"))

--- a/src/main/resources/sql/load_ceo_functions.sql
+++ b/src/main/resources/sql/load_ceo_functions.sql
@@ -869,7 +869,7 @@ CREATE OR REPLACE FUNCTION csv_boundary(_project_uid integer, _m_buffer float)
 
     UPDATE projects SET boundary = b
     FROM (
-        SELECT ST_Expand(ST_SetSRID(ST_Extent(center) , 4326) , _m_buffer / 1000.0) as b
+        SELECT ST_Envelope(ST_Buffer(ST_SetSRID(ST_Extent(center) , 4326)::geography , _m_buffer)::geometry) as b
         FROM select_partial_table_by_name((
             SELECT plots_ext_table
             FROM projects
@@ -1586,7 +1586,7 @@ CREATE OR REPLACE FUNCTION select_unassigned_plot_by_id(_project_rid integer, _p
  RETURNS setOf plots_return AS $$
 
     SELECT * FROM select_all_unlocked_project_plots(_project_rid) as spp
-    WHERE spp.plot_id = _plot_uid
+    WHERE spp.plotId = _plot_uid
         AND flagged = 0
         AND assigned = 0
 
@@ -1597,7 +1597,7 @@ CREATE OR REPLACE FUNCTION select_user_plot_by_id(_project_rid integer, _plot_ui
  RETURNS setOf plots_return AS $$
 
     SELECT * FROM select_all_project_plots(_project_rid) as spp
-    WHERE spp.plot_id = _plot_uid
+    WHERE spp.plotId = _plot_uid
         AND spp.username = _username
 
 $$ LANGUAGE SQL;

--- a/src/main/resources/sql/load_ceo_functions.sql
+++ b/src/main/resources/sql/load_ceo_functions.sql
@@ -634,11 +634,12 @@ CREATE OR REPLACE FUNCTION add_project_widget(_project_rid integer, _dashboard_i
 $$ LANGUAGE SQL;
 
 -- Deletes a delete_project_widget_by_widget_id from the database.
-CREATE OR REPLACE FUNCTION delete_project_widget_by_widget_id(_widget_uid integer)
+CREATE OR REPLACE FUNCTION delete_project_widget_by_widget_id(_widget_uid integer, _dashboard_id uuid)
  RETURNS integer AS $$
 
     DELETE FROM project_widgets
-    WHERE CAST(jsonb_extract_path_text(widget, 'id') as int) = _widget_uid
+    WHERE dashboard_id = _dashboard_id
+        AND CAST(jsonb_extract_path_text(widget, 'id') as int) = _widget_uid
     RETURNING widget_uid
 
 $$ LANGUAGE SQL;


### PR DESCRIPTION
A bad postgres api was deleting too many widgets. 
- Fix bad api
- Create script to re-add deleted widgets.

Handle null dash_id
Fix editable field on projects
Change plot_id to plotId for goto plots
Change "id" to "plot_id" in PostgresProjects
Update csv boudary logic