### PR TITLE
Update sidebar

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -74,6 +74,7 @@ module.exports = {
         "no-console": 0,
         "no-multi-spaces": 2,
         "no-useless-return": 1,
+        "no-unused-vars": 1,
         "no-var": 2,
         "object-curly-newline": [1, { "multiline": true, "consistent": true }],
         "object-curly-spacing": [1, "always", { "objectsInObjects": false }],

--- a/src/main/resources/public/css/custom.css
+++ b/src/main/resources/public/css/custom.css
@@ -173,6 +173,12 @@ h4 {font-size: 0.5rem;}
 }
 /* Buttons */
 /*****************/
+
+.btn {
+    border-width: 1.5px;
+    font-weight: bold;
+}
+
 .btn-outline-lightgreen{
     color: #31BAB0;
     background-color: transparent;

--- a/src/main/resources/public/jsx/collection.js
+++ b/src/main/resources/public/jsx/collection.js
@@ -416,7 +416,7 @@ class Collection extends React.Component {
             });
     };
 
-    resetPlotValues = (newPlot) => this.setState({ ...this.newPlotValues(newPlot) })
+    resetPlotValues = (newPlot) => this.setState(this.newPlotValues(newPlot));
 
     newPlotValues = (newPlot) => ({
         newPlotInput: newPlot.plotId ? newPlot.plotId : newPlot.id,
@@ -1401,7 +1401,11 @@ class ProjectTitle extends React.Component {
         const { props } = this;
         return (
             <div style={{ height: "3rem", cursor: "default" }} onClick={() => this.setState({ showStats: !this.state.showStats })}>
-                <h2 className="header" style={{ height: "100%", marginBottom: "0" }}>
+                <h2
+                    className="header overflow-hidden text-truncate"
+                    title={props.projectName}
+                    style={{ height: "100%", marginBottom: "0" }}
+                >
                     {"\u25BC " + props.projectName}
                 </h2>
                 {this.state.showStats &&

--- a/src/main/resources/public/jsx/collection.js
+++ b/src/main/resources/public/jsx/collection.js
@@ -1124,8 +1124,8 @@ function SideBar(props) {
 }
 
 function CollapsableTitle({ title, showGroup, toggleShow }) {
-    const buttonDownStyle = { width: "1.5rem", height: "1.5rem", paddingTop: "2px", paddingLeft: "4px" };
-    const buttonRightStyle = { width: "1.5rem", height: "1.5rem", paddingTop: "0px", paddingLeft: "7px" };
+    const buttonDownStyle = { width: "1.5rem", height: "1.5rem", paddingTop: "1px", paddingLeft: "3px" };
+    const buttonRightStyle = { width: "1.5rem", height: "1.5rem", paddingTop: "0px", paddingLeft: "6px", fontSize: ".8rem" };
     const downArrow = "\u25BC";
     const rightArrow = "\u25B6";
     return (

--- a/src/main/resources/public/jsx/collection.js
+++ b/src/main/resources/public/jsx/collection.js
@@ -91,7 +91,7 @@ class Collection extends React.Component {
             // Changing questions shows different set of samples
             if (this.state.selectedQuestion.id !== prevState.selectedQuestion.id
                 || this.state.sampleOutlineBlack !== prevState.sampleOutlineBlack
-                || this.state.userSamples !== prevState.userSamples
+                || (this.state.userSamples !== prevState.userSamples && this.state.selectedQuestion.visible)
                 || !prevState.selectedQuestion.visible) {
 
                 this.showPlotSamples();
@@ -317,7 +317,7 @@ class Collection extends React.Component {
                     const newPlot = JSON.parse(data);
                     this.setState({
                         currentPlot: newPlot,
-                        ...this.resetPlotValues(newPlot),
+                        ...this.newPlotValues(newPlot),
                         prevPlotButtonDisabled: false,
                         nextPlotButtonDisabled: false,
                     });
@@ -354,7 +354,7 @@ class Collection extends React.Component {
                     const newPlot = JSON.parse(data);
                     this.setState({
                         currentPlot: newPlot,
-                        ...this.resetPlotValues(newPlot),
+                        ...this.newPlotValues(newPlot),
                         prevPlotButtonDisabled: plotId === -1,
                     });
                 }
@@ -386,7 +386,7 @@ class Collection extends React.Component {
                     const newPlot = JSON.parse(data);
                     this.setState({
                         currentPlot: newPlot,
-                        ...this.resetPlotValues(newPlot),
+                        ...this.newPlotValues(newPlot),
                         nextPlotButtonDisabled: false,
                     });
                 }
@@ -416,7 +416,9 @@ class Collection extends React.Component {
             });
     };
 
-    resetPlotValues = (newPlot) => ({
+    resetPlotValues = (newPlot) => this.setState({ ...this.newPlotValues(newPlot) })
+
+    newPlotValues = (newPlot) => ({
         newPlotInput: newPlot.plotId ? newPlot.plotId : newPlot.id,
         userSamples: newPlot.samples
             ? newPlot.samples.reduce((obj, s) => {
@@ -614,9 +616,7 @@ class Collection extends React.Component {
         }
     };
 
-    intersection = (array1, array2) => {
-        return array1.filter(value => array2.includes(value));
-    };
+    intersection = (array1, array2) => array1.filter(value => array2.includes(value));
 
     getSelectedSampleIds = () => {
         const allFeatures = mercator.getAllFeatures(this.state.mapConfig, "currentSamples");
@@ -646,22 +646,25 @@ class Collection extends React.Component {
 
     checkRuleSumOfAnswers = (surveyRule, questionToSet, answerId, answerText) => {
         if (surveyRule.questions.includes(questionToSet.id)) {
-            const answeredQuestions = this.state.currentProject.surveyQuestions.filter(q => surveyRule.questions.includes(q.id) && q.answered.length > 0 && q.id != questionToSet.id);
+            const answeredQuestions = this.state.currentProject.surveyQuestions
+                .filter(q => surveyRule.questions.includes(q.id) && q.answered.length > 0 && q.id !== questionToSet.id);
             if (surveyRule.questions.length === answeredQuestions.length + 1) {
                 const sampleIds = this.getSelectedSampleIds();
                 const answeredSampleIds = answeredQuestions.map(q => q.answered.map(a => a.sampleId));
                 const commonSampleIds = answeredSampleIds.reduce(this.intersection, sampleIds);
                 if (commonSampleIds.length > 0) {
                     return commonSampleIds.map(sampleId => {
-                            const answeredSum = answeredQuestions
-                                .map(q => q.answered.find(ques => ques.sampleId === sampleId).answerText)
-                                .reduce((sum, num) => sum + parseInt(num), 0);
-                            if (answeredSum + parseInt(answerText) !== surveyRule.validSum) {
-                                return "Sum of answers validation failed: Possible sum for questions [" + surveyRule.questionsText.toString() + "] is " + (surveyRule.validSum - answeredSum).toString() + ".";
-                            } else {
-                                return null;
-                            }
+                        const answeredSum = answeredQuestions
+                            .map(q => q.answered.find(ques => ques.sampleId === sampleId).answerText)
+                            .reduce((sum, num) => sum + parseInt(num), 0);
+                        if (answeredSum + parseInt(answerText) !== surveyRule.validSum) {
+                            return "Sum of answers validation failed: Possible sum for questions ["
+                                    + surveyRule.questionsText.toString() + "] is "
+                                    + (surveyRule.validSum - answeredSum).toString() + ".";
+                        } else {
+                            return null;
                         }
+                    }
                     ).find(res => res !== null);
                 } else {
                     return null;
@@ -676,8 +679,10 @@ class Collection extends React.Component {
 
     checkRuleMatchingSums = (surveyRule, questionToSet, answerId, answerText) => {
         if (surveyRule.questionSetIds1.includes(questionToSet.id) || surveyRule.questionSetIds2.includes(questionToSet.id)) {
-            const answeredQuestions1 = this.state.currentProject.surveyQuestions.filter(q => surveyRule.questionSetIds1.includes(q.id) && q.answered.length > 0 && q.id != questionToSet.id);
-            const answeredQuestions2 = this.state.currentProject.surveyQuestions.filter(q => surveyRule.questionSetIds2.includes(q.id) && q.answered.length > 0 && q.id != questionToSet.id);
+            const answeredQuestions1 = this.state.currentProject.surveyQuestions
+                .filter(q => surveyRule.questionSetIds1.includes(q.id) && q.answered.length > 0 && q.id !== questionToSet.id);
+            const answeredQuestions2 = this.state.currentProject.surveyQuestions
+                .filter(q => surveyRule.questionSetIds2.includes(q.id) && q.answered.length > 0 && q.id !== questionToSet.id);
             if (surveyRule.questionSetIds1.length + surveyRule.questionSetIds2.length === answeredQuestions1.length + answeredQuestions2.length + 1) {
                 const sampleIds = this.getSelectedSampleIds();
                 const answeredSampleIds1 = answeredQuestions1.map(q => q.answered.map(a => a.sampleId));
@@ -755,17 +760,19 @@ class Collection extends React.Component {
         }
     };
 
-    ruleFunctions = {"text-match":           this.checkRuleTextMatch,
-                     "numeric-range":        this.checkRuleNumericRange,
-                     "sum-of-answers":       this.checkRuleSumOfAnswers,
-                     "matching-sums":        this.checkRuleMatchingSums,
-                     "incompatible-answers": this.checkRuleIncompatibleAnswers};
+    ruleFunctions = {
+        "text-match":           this.checkRuleTextMatch,
+        "numeric-range":        this.checkRuleNumericRange,
+        "sum-of-answers":       this.checkRuleSumOfAnswers,
+        "matching-sums":        this.checkRuleMatchingSums,
+        "incompatible-answers": this.checkRuleIncompatibleAnswers,
+    };
 
     rulesViolated = (questionToSet, answerId, answerText) => {
         if (this.state.currentProject.surveyRules) {
-            return this.state.currentProject.surveyRules.map(surveyRule => {
-                return this.ruleFunctions[surveyRule.ruleType](surveyRule, questionToSet, answerId, answerText);
-            }).find(msg => msg !== null);
+            return this.state.currentProject.surveyRules.map(surveyRule =>
+                this.ruleFunctions[surveyRule.ruleType](surveyRule, questionToSet, answerId, answerText)
+            ).find(msg => msg !== null);
         } else {
             return null;
         }
@@ -796,7 +803,7 @@ class Collection extends React.Component {
                 const childQuestionArray = this.getChildQuestions(questionToSet.id);
                 const clearedSubQuestions = Object.entries(this.state.userSamples[sampleId])
                     .filter(entry => !childQuestionArray.includes(entry[0]))
-                    .reduce((acc, cur) => ({...acc, [cur[0]]: cur[1]}), {});
+                    .reduce((acc, cur) => ({ ...acc, [cur[0]]: cur[1] }), {});
 
                 return {
                     ...acc,
@@ -818,8 +825,8 @@ class Collection extends React.Component {
                 }), {});
 
             this.setState({
-                userSamples: {...this.state.userSamples, ...newSamples},
-                userImages: {...this.state.userImages, ...newUserImages},
+                userSamples: { ...this.state.userSamples, ...newSamples },
+                userImages: { ...this.state.userImages, ...newUserImages },
                 selectedQuestion: questionToSet,
             });
             return true;
@@ -832,13 +839,13 @@ class Collection extends React.Component {
         }
     };
 
-    setSelectedQuestion = (newselectedQuestion) => this.setState({ selectedQuestion: newselectedQuestion });
+    setSelectedQuestion = (newSelectedQuestion) => this.setState({ selectedQuestion: newSelectedQuestion });
 
     invertColor(hex) {
-        const dehashed = hex.indexOf("#") === 0 ? hex.slice(1) : hex;
-        const hexFormatted = dehashed.length === 3
-                            ? dehashed[0] + dehashed[0] + dehashed[1] + dehashed[1] + dehashed[2] + dehashed[2]
-                            : dehashed;
+        const deHashed = hex.indexOf("#") === 0 ? hex.slice(1) : hex;
+        const hexFormatted = deHashed.length === 3
+                            ? deHashed[0] + deHashed[0] + deHashed[1] + deHashed[1] + deHashed[2] + deHashed[2]
+                            : deHashed;
 
         // invert color components
         const r = (255 - parseInt(hexFormatted.slice(0, 2), 16)).toString(16);
@@ -876,8 +883,6 @@ class Collection extends React.Component {
                 mercator.highlightSampleGeometry(feature, color);
             });
     };
-
-    toggleSampleBW = () => this.setState({ sampleOutlineBlack: !this.state.sampleOutlineBlack });
 
     getVisibleSamples = (currentQuestionId) => {
         const { currentProject : { surveyQuestions }, userSamples } = this.state;
@@ -927,6 +932,34 @@ class Collection extends React.Component {
         });
     };
 
+    unansweredColor = () => (
+        <div className="PlotNavigation__change-color row justify-content-center">
+            Unanswered Color
+            <div className="form-check form-check-inline">
+                <input
+                    className="form-check-input ml-2"
+                    checked={this.state.sampleOutlineBlack}
+                    id="radio1"
+                    onChange={() => this.setState({ sampleOutlineBlack: true })}
+                    type="radio"
+                    name="color-radios"
+                />
+                <label htmlFor="radio1" className="form-check-label">Black</label>
+            </div>
+            <div className="form-check form-check-inline">
+                <input
+                    className="form-check-input"
+                    checked={!this.state.sampleOutlineBlack}
+                    id="radio2"
+                    onChange={() => this.setState({ sampleOutlineBlack: false })}
+                    type="radio"
+                    name="color-radios"
+                />
+                <label htmlFor="radio2" className="form-check-label">White</label>
+            </div>
+        </div>
+    )
+
     render() {
         const plotId = this.state.currentPlot
                         && (this.state.currentPlot.plotId ? this.state.currentPlot.plotId : this.state.currentPlot.id);
@@ -937,35 +970,29 @@ class Collection extends React.Component {
                     projectId={this.props.projectId}
                     plotId={plotId}
                     documentRoot={this.props.documentRoot}
+                    flagPlotInDB={this.flagPlotInDB}
                     postValuesToDB={this.postValuesToDB}
                     projectName={this.state.currentProject.name}
+                    clearAnswers={() => this.resetPlotValues(this.state.currentPlot)}
                     surveyQuestions={this.state.currentProject.surveyQuestions}
                     userName={this.props.userName}
                 >
-                    {this.state.currentPlot && this.state.KMLFeatures &&
-                    <a className="btn btn-outline-lightgreen btn-sm btn-block my-2"
-                       href={"data:earth.kml+xml application/vnd.google-earth.kmz, "
-                             + encodeURIComponent(this.state.KMLFeatures)}
-                       download={"ceo_" + this.props.projectId + "_" + (this.state.currentPlot.plotId || this.state.currentPlot.id) + ".kml"}
-                    >
-                        Download Plot KML
-                    </a>
-                    }
                     <PlotNavigation
                         plotId={plotId}
+                        projectId={this.props.projectId}
                         navButtonsShown={this.state.currentPlot != null}
                         nextPlotButtonDisabled={this.state.nextPlotButtonDisabled}
                         prevPlotButtonDisabled={this.state.prevPlotButtonDisabled}
-                        sampleOutlineBlack={this.state.sampleOutlineBlack}
                         reviewPlots={this.state.reviewPlots}
-                        flagPlotInDB={this.flagPlotInDB}
+                        showGeoDash={this.showGeoDash}
                         goToFirstPlot={this.goToFirstPlot}
                         goToPlot={this.goToPlot}
                         nextPlot={this.nextPlot}
                         prevPlot={this.prevPlot}
                         setReviewPlots={this.setReviewPlots}
-                        toggleSampleBW={this.toggleSampleBW}
                         loadingPlots={this.state.plotList.length === 0}
+                        KMLFeatures={this.state.KMLFeatures}
+                        zoomMapToPlot={() => mercator.zoomMapToLayer(this.state.mapConfig, "currentPlot")}
                     />
                     <ImageryOptions
                         baseMapSource={this.state.currentImagery.id}
@@ -985,16 +1012,19 @@ class Collection extends React.Component {
                     />
                     {this.state.currentPlot
                         ?
-                            <SurveyCollection
-                                selectedQuestion={this.state.selectedQuestion}
-                                surveyQuestions={this.state.currentProject.surveyQuestions}
-                                surveyRules={this.state.currentProject.surveyRules}
-                                setCurrentValue={this.setCurrentValue}
-                                setSelectedQuestion={this.setSelectedQuestion}
-                                selectedSampleId={Object.keys(this.state.userSamples).length === 1
-                                    ? parseInt(Object.keys(this.state.userSamples)[0])
-                                    : this.state.selectedSampleId}
-                            />
+                            <>
+                                {this.unansweredColor()}
+                                <SurveyCollection
+                                    selectedQuestion={this.state.selectedQuestion}
+                                    surveyQuestions={this.state.currentProject.surveyQuestions}
+                                    surveyRules={this.state.currentProject.surveyRules}
+                                    setCurrentValue={this.setCurrentValue}
+                                    setSelectedQuestion={this.setSelectedQuestion}
+                                    selectedSampleId={Object.keys(this.state.userSamples).length === 1
+                                        ? parseInt(Object.keys(this.state.userSamples)[0])
+                                        : this.state.selectedSampleId}
+                                />
+                            </>
                         :
                             <fieldset className="mb-3 justify-content-center text-center">
                                 <h3>Survey Questions</h3>
@@ -1015,12 +1045,12 @@ class Collection extends React.Component {
     }
 }
 
-function ImageAnalysisPane(props) {
+function ImageAnalysisPane({ imageryAttribution }) {
     return (
         // Mercator hooks into image-analysis-pane
         <div id="image-analysis-pane" className="col-xl-9 col-lg-9 col-md-12 pl-0 pr-0 full-height">
             <div id="imagery-info" className="row">
-                <p className="col small">{ props.imageryAttribution }</p>
+                <p className="col small">{ imageryAttribution }</p>
             </div>
         </div>
     );
@@ -1030,30 +1060,53 @@ function SideBar(props) {
     const saveValuesButtonEnabled = props.surveyQuestions
         .every(sq => sq.visible && sq.visible.length === sq.answered.length);
 
+    const saveButtonGroup = () => (
+        <>
+            <input
+                id="save-values-button"
+                className="btn btn-outline-lightgreen btn-sm btn-block"
+                type="button"
+                name="save-values"
+                value="Save"
+                onClick={props.postValuesToDB}
+                style={{ opacity: saveValuesButtonEnabled ? "1.0" : ".25" }}
+                disabled={!saveValuesButtonEnabled}
+            />
+            <div className="my-2 d-flex justify-content-between">
+                <input
+                    id="save-values-button"
+                    className="btn btn-outline-danger btn-sm col mr-1"
+                    type="button"
+                    name="save-values"
+                    value="Flag Plot"
+                    onClick={props.flagPlotInDB}
+                />
+                <input
+                    id="save-values-button"
+                    className="btn btn-outline-danger btn-sm col"
+                    type="button"
+                    name="save-values"
+                    value="Clear All"
+                    onClick={props.clearAnswers}
+                />
+            </div>
+        </>
+    );
+
     return (
         <div id="sidebar" className="col-xl-3 border-left full-height" style={{ overflowY: "scroll", overflowX: "hidden" }}>
-            <h2 className="header">{props.projectName || ""}</h2>
-
+            <ProjectTitle
+                documentRoot={props.documentRoot}
+                projectId={props.projectId}
+                plotId={props.plotId}
+                userName={props.userName}
+                projectName={props.projectName || ""}
+            />
             {props.children}
 
             <div className="row">
                 <div className="col-sm-12 btn-block">
-                    <input
-                        id="save-values-button"
-                        className="btn btn-outline-lightgreen btn-sm btn-block"
-                        type="button"
-                        name="save-values"
-                        value="Save"
-                        onClick={props.postValuesToDB}
-                        style={{ opacity: saveValuesButtonEnabled ? "1.0" : ".25" }}
-                        disabled={!saveValuesButtonEnabled}
-                    />
-                    <ProjectStatsGroup
-                        documentRoot={props.documentRoot}
-                        projectId={props.projectId}
-                        plotId={props.plotId}
-                        userName={props.userName}
-                    />
+                    {props.plotId && saveButtonGroup()}
                     <button
                         id="collection-quit-button"
                         className="btn btn-outline-danger btn-block btn-sm mb-4"
@@ -1070,11 +1123,31 @@ function SideBar(props) {
     );
 }
 
+function CollapsableTitle({ title, showGroup, toggleShow }) {
+    const buttonDownStyle = { width: "1.5rem", height: "1.5rem", paddingTop: "2px", paddingLeft: "4px" };
+    const buttonRightStyle = { width: "1.5rem", height: "1.5rem", paddingTop: "0px", paddingLeft: "7px" };
+    const downArrow = "\u25BC";
+    const rightArrow = "\u25B6";
+    return (
+        <div className="PlotNavigation__Title row">
+            <h3
+                className="ml-3 btn btn-sm btn-outline-darkgray"
+                style={showGroup ? buttonDownStyle : buttonRightStyle}
+                onClick={toggleShow}
+            >
+                {showGroup ? downArrow : rightArrow}
+            </h3>
+            <h3 className="ml-2">{title}</h3>
+        </div>
+    );
+}
+
 class PlotNavigation extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
             newPlotInput: "",
+            showNav: true,
         };
     }
 
@@ -1086,90 +1159,107 @@ class PlotNavigation extends React.Component {
 
     updateNewPlotId = (value) => this.setState({ newPlotInput: value });
 
+    gotoButton = () => (
+        <div className="PlotNavigation__first row" id="go-to-first-plot">
+            <div className="col">
+                <input
+                    id="go-to-first-plot-button"
+                    className="btn btn-outline-lightgreen btn-sm btn-block"
+                    type="button"
+                    name="new-plot"
+                    value="Go to first plot"
+                    onClick={() => {
+                        this.setState({ showNav: false });
+                        this.props.goToFirstPlot();
+                    }}
+                />
+            </div>
+        </div>
+    );
+
+    navButtons = () => (
+        <div className="PlotNavigation__nav-buttons row justify-content-center" id="plot-nav">
+            <input
+                id="prev-plot-button"
+                className="btn btn-outline-lightgreen"
+                type="button"
+                name="new-plot"
+                value={"\u25C0"}
+                onClick={this.props.prevPlot}
+                style={{ opacity: this.props.prevPlotButtonDisabled ? "0.25" : "1.0" }}
+                disabled={this.props.prevPlotButtonDisabled}
+            />
+            <input
+                id="new-plot-button"
+                className="btn btn-outline-lightgreen mx-1"
+                type="button"
+                name="new-plot"
+                value={"\u25B6"}
+                onClick={this.props.nextPlot}
+                style={{ opacity: this.props.nextPlotButtonDisabled ? "0.25" : "1.0" }}
+                disabled={this.props.nextPlotButtonDisabled}
+            />
+            <input
+                type="text"
+                id="plotId"
+                autoComplete="off"
+                className="col-4 px-0 ml-2 mr-1"
+                value={this.state.newPlotInput}
+                onChange={e => this.updateNewPlotId(e.target.value)}
+            />
+            <input
+                id="goto-plot-button"
+                className="btn btn-outline-lightgreen"
+                type="button"
+                name="goto-plot"
+                value="Go to plot"
+                onClick={() => this.props.goToPlot(this.state.newPlotInput)}
+            />
+        </div>
+    );
+
+    geoButtons = () => (
+        <div className="PlotNavigation__geo-buttons d-flex justify-content-between" id="plot-nav">
+            <input
+                className="btn btn-outline-lightgreen btn-sm col-6 mr-1"
+                type="button"
+                value="Re-Zoom"
+                onClick={this.props.zoomMapToPlot}
+            />
+            <input
+                className="btn btn-outline-lightgreen btn-sm col-6"
+                type="button"
+                value="Geodash"
+                onClick={this.props.showGeoDash}
+            />
+        </div>
+    );
+
+    kmlButton = () => (
+        <a
+            className="btn btn-outline-lightgreen btn-sm btn-block my-2"
+            href={"data:earth.kml+xml application/vnd.google-earth.kmz, "
+                + encodeURIComponent(this.state.KMLFeatures)}
+            download={"ceo_" + this.props.projectId + "_" + this.props.plotId + ".kml"}
+        >
+            Download Plot KML
+        </a>
+    );
+
     render() {
         const { props } = this;
         return (
-            <fieldset className="mb-3 text-center">
-                <h3 className="mb-2">Plot Navigation</h3>
-                {props.loadingPlots
-                    ? <h3>Loading plot data...</h3>
-                    : <Fragment>
-                        {props.plotId &&
-                            <div className="row py-2 justify-content-center">
-                                <h3 className="mt-2">Current Plot ID:</h3>
-                                <input
-                                    type="text"
-                                    id="plotId"
-                                    autoComplete="off"
-                                    className="col-4 px-0 mx-2"
-                                    value={this.state.newPlotInput}
-                                    onChange={e => this.updateNewPlotId(e.target.value)}
-                                />
-                                <input
-                                    id="goto-plot-button"
-                                    className="text-center btn btn-outline-lightgreen btn-sm"
-                                    type="button"
-                                    name="goto-plot"
-                                    value="Go to plot"
-                                    onClick={() => props.goToPlot(this.state.newPlotInput)}
-                                />
-                            </div>
-                        }
-
-                        {!props.navButtonsShown
-                        ?
-                            <div className="row" id="go-to-first-plot">
-                                <div className="col">
-                                    <input
-                                        id="go-to-first-plot-button"
-                                        className="btn btn-outline-lightgreen btn-sm btn-block"
-                                        type="button"
-                                        name="new-plot"
-                                        value="Go to first plot"
-                                        onClick={props.goToFirstPlot}
-                                    />
-                                </div>
-                            </div>
-                        :
-                            <div className="row justify-content-center py-2" id="plot-nav">
-                                <div className="px-1">
-                                    <input
-                                        id="prev-plot-button"
-                                        className="btn btn-outline-lightgreen"
-                                        type="button"
-                                        name="new-plot"
-                                        value="Prev"
-                                        onClick={props.prevPlot}
-                                        style={{ opacity: props.prevPlotButtonDisabled ? "0.25" : "1.0" }}
-                                        disabled={props.prevPlotButtonDisabled}
-                                    />
-                                </div>
-                                <div className="px-1">
-                                    <input
-                                        id="new-plot-button"
-                                        className="btn btn-outline-lightgreen"
-                                        type="button"
-                                        name="new-plot"
-                                        value="Next"
-                                        onClick={props.nextPlot}
-                                        style={{ opacity: props.nextPlotButtonDisabled ? "0.25" : "1.0" }}
-                                        disabled={props.nextPlotButtonDisabled}
-                                    />
-                                </div>
-                                <div className="px-1">
-                                    <input
-                                        id="flag-plot-button"
-                                        className="btn btn-outline-lightgreen"
-                                        type="button"
-                                        name="flag-plot"
-                                        value="Flag"
-                                        onClick={props.flagPlotInDB}
-                                    />
-                                </div>
-                            </div>
-                        }
-
-                        <div className="PlotNavigation__review-option row justify-content-center">
+            <div className="text-center mt-2">
+                <CollapsableTitle
+                    title={`Plot Navigation ${this.props.plotId ? `- ID: ${this.props.plotId}` : ""}`}
+                    showGroup={this.state.showNav}
+                    toggleShow={() => this.setState({ showNav: !this.state.showNav })}
+                />
+                {props.loadingPlots && <h3>Loading plot data...</h3>}
+                {this.state.showNav && !props.loadingPlots &&
+                    <Fragment>
+                        {!props.navButtonsShown ? this.gotoButton() : this.navButtons()}
+                        <div className="PlotNavigation__review-option row justify-content-center mb-3">
                             <div className="form-check">
                                 <input
                                     className="form-check-input"
@@ -1181,106 +1271,44 @@ class PlotNavigation extends React.Component {
                                 <label htmlFor="reviewCheck" className="form-check-label">Review your analyzed plots</label>
                             </div>
                         </div>
-
-                        <div className="PlotNavigation__change-color row justify-content-center">
-                            Unanswered Color
-                            <div className="form-check form-check-inline">
-                                <input
-                                    className="form-check-input ml-2"
-                                    checked={props.sampleOutlineBlack}
-                                    id="radio1"
-                                    onChange={props.toggleSampleBW}
-                                    type="radio"
-                                    name="color-radios"
-                                />
-                                <label htmlFor="radio1" className="form-check-label">Black</label>
-                            </div>
-                            <div className="form-check form-check-inline">
-                                <input
-                                    className="form-check-input"
-                                    checked={!props.sampleOutlineBlack}
-                                    id="radio2"
-                                    onChange={props.toggleSampleBW}
-                                    type="radio"
-                                    name="color-radios"
-                                />
-                                <label htmlFor="radio2" className="form-check-label">White</label>
-                            </div>
-                        </div>
+                        {props.plotId && this.geoButtons()}
+                        {props.KMLFeatures && props.plotId && this.kmlButton()}
                     </Fragment>
                 }
-            </fieldset>
+            </div>
         );
     }
 }
 
-function ImageryOptions(props) {
-    return (
-        <fieldset className="mb-3 justify-content-center text-center">
-            <h3 className="mb-2">Imagery Options</h3>
-            {props.loadingImages
-                ? <h3>Loading imagery data...</h3>
-                : <Fragment>
-                    <select
-                        className="form-control form-control-sm"
-                        id="base-map-source"
-                        name="base-map-source"
-                        size="1"
-                        value={props.baseMapSource || ""}
-                        onChange={e => props.setBaseMapSource(parseInt(e.target.value))}
-                    >
-                        {
-                            props.imageryList.map(
-                                (imagery, uid) =>
-                                    <option key={uid} value={imagery.id}>{imagery.title}</option>
-                            )
-                        }
-                    </select>
-                    {props.imageryTitle === "DigitalGlobeWMSImagery" &&
-                        <DigitalGlobeMenus
-                            imageryYearDG={props.imageryYearDG}
-                            stackingProfileDG={props.stackingProfileDG}
-                            setImageryYearDG={props.setImageryYearDG}
-                            setStackingProfileDG={props.setStackingProfileDG}
-                        />
-                    }
-                    {props.imageryTitle === "PlanetGlobalMosaic" &&
-                        <PlanetMenus
-                            imageryYearPlanet={props.imageryYearPlanet}
-                            imageryMonthPlanet={props.imageryMonthPlanet}
-                            imageryMonthNamePlanet={props.imageryMonthNamePlanet}
-                            setImageryYearPlanet={props.setImageryYearPlanet}
-                            setImageryMonthPlanet={props.setImageryMonthPlanet}
-                        />
-                    }
-                </Fragment>
-            }
-        </fieldset>
-    );
-}
+class ImageryOptions extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            showImg: true,
+        };
+    }
 
-function DigitalGlobeMenus(props) {
-    return (
+    digitalGlobeMenus = () => (
         <div className="DG-Menu my-2">
             <div className="slidecontainer form-control form-control-sm">
                 <input
                     type="range"
                     min="2000"
                     max="2018"
-                    value={props.imageryYearDG}
+                    value={this.props.imageryYearDG}
                     className="slider"
                     id="myRange"
-                    onChange={e => props.setImageryYearDG(parseInt(e.target.value))}
+                    onChange={e => this.props.setImageryYearDG(parseInt(e.target.value))}
                 />
-                <p>Year: <span id="demo">{props.imageryYearDG}</span></p>
+                <p>Year: <span id="demo">{this.props.imageryYearDG}</span></p>
             </div>
             <select
                 className="form-control form-control-sm"
                 id="dg-stacking-profile"
                 name="dg-stacking-profile"
                 size="1"
-                value={props.stackingProfileDG}
-                onChange={e => props.setStackingProfileDG(e.target.value)}
+                value={this.props.stackingProfileDG}
+                onChange={e => this.props.setStackingProfileDG(e.target.value)}
             >
                 {
                     ["Accuracy_Profile", "Cloud_Cover_Profile", "Global_Currency_Profile", "MyDG_Color_Consumer_Profile", "MyDG_Consumer_Profile"]
@@ -1289,40 +1317,73 @@ function DigitalGlobeMenus(props) {
             </select>
         </div>
     );
-}
 
-function PlanetMenus(props) {
-    return (
+    planetMenus = () => (
         <div className="PlanetsMenu my-2">
             <div className="slidecontainer form-control form-control-sm">
                 <input
                     type="range"
                     min="2016"
                     max="2018"
-                    value={props.imageryYearPlanet}
+                    value={this.props.imageryYearPlanet}
                     className="slider"
                     id="myRange"
-                    onChange={e => props.setImageryYearPlanet(parseInt(e.target.value))}
+                    onChange={e => this.props.setImageryYearPlanet(parseInt(e.target.value))}
                 />
-                <p>Year: <span id="demo">{props.imageryYearPlanet}</span></p>
+                <p>Year: <span id="demo">{this.props.imageryYearPlanet}</span></p>
             </div>
             <div className="slidecontainer form-control form-control-sm">
                 <input
                     type="range"
                     min="1"
                     max="12"
-                    value={props.imageryMonthPlanet}
+                    value={this.props.imageryMonthPlanet}
                     className="slider"
                     id="myRangemonth"
-                    onChange={e => props.setImageryMonthPlanet(parseInt(e.target.value))}
+                    onChange={e => this.props.setImageryMonthPlanet(parseInt(e.target.value))}
                 />
-                <p>Month: <span id="demo">{props.imageryMonthNamePlanet}</span></p>
+                <p>Month: <span id="demo">{this.props.imageryMonthNamePlanet}</span></p>
             </div>
         </div>
     );
+
+    render() {
+        const { props } = this;
+        return (
+            <div className="justify-content-center text-center">
+                <CollapsableTitle
+                    title="Imagery Options"
+                    showGroup={this.state.showImg}
+                    toggleShow={() => this.setState({ showImg: !this.state.showImg })}
+                />
+                {props.loadingImages && <h3>Loading imagery data...</h3>}
+                {(this.state.showImg && !props.loadingImages) &&
+                    <Fragment>
+                        <select
+                            className="form-control form-control-sm"
+                            id="base-map-source"
+                            name="base-map-source"
+                            size="1"
+                            value={props.baseMapSource || ""}
+                            onChange={e => props.setBaseMapSource(parseInt(e.target.value))}
+                        >
+                            {
+                                props.imageryList.map(
+                                    (imagery, uid) =>
+                                        <option key={uid} value={imagery.id}>{imagery.title}</option>
+                                )
+                            }
+                        </select>
+                        {props.imageryTitle === "DigitalGlobeWMSImagery" && this.digitalGlobeMenus()}
+                        {props.imageryTitle === "PlanetGlobalMosaic" && this.planetMenus()}
+                    </Fragment>
+                }
+            </div>
+        );
+    }
 }
 
-class ProjectStatsGroup extends React.Component {
+class ProjectTitle extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
@@ -1336,18 +1397,13 @@ class ProjectStatsGroup extends React.Component {
         }
     }
 
-    updateShown = () => this.setState({ showStats: !this.state.showStats });
-
     render() {
+        const { props } = this;
         return (
-            <div className="ProjectStatsGroup">
-                <button
-                    type="button"
-                    className="btn btn-outline-lightgreen btn-sm btn-block my-2"
-                    onClick={this.updateShown}
-                >
-                    Project Stats
-                </button>
+            <div style={{ height: "3rem", cursor: "default" }} onClick={() => this.setState({ showStats: !this.state.showStats })}>
+                <h2 className="header" style={{ height: "100%", marginBottom: "0" }}>
+                    {"\u25BC " + props.projectName}
+                </h2>
                 {this.state.showStats &&
                     <ProjectStats
                         documentRoot={this.props.documentRoot}
@@ -1394,7 +1450,18 @@ class ProjectStats extends React.Component {
         const userStats = stats.userStats && stats.userStats.find(user => user.user === this.props.userName);
         const numPlots = stats.flaggedPlots + stats.analyzedPlots + stats.unanalyzedPlots;
         return (
-            <div className="row mb-1">
+            <div
+                className="row"
+                style={{
+                    backgroundColor: "#f1f1f1",
+                    boxShadow: "0px 8px 16px 0px rgba(0,0,0,0.2)",
+                    cursor: "default",
+                    marginLeft: "2rem",
+                    overflow: "auto",
+                    position: "absolute",
+                    zIndex: "10",
+                }}
+            >
                 <div className="col-lg-12">
                     <fieldset id="projStats" className="projNoStats">
                         <table className="table table-sm">
@@ -1466,7 +1533,6 @@ class ProjectStats extends React.Component {
 
 // remains hidden, shows a styled menu when the quit button is clicked
 function QuitMenu({ userId, projectId, documentRoot }) {
-
     return (
         <div
             className="modal fade"

--- a/src/main/resources/public/jsx/components/SurveyCollection.js
+++ b/src/main/resources/public/jsx/components/SurveyCollection.js
@@ -61,10 +61,10 @@ export class SurveyCollection extends React.Component {
     };
 
     getTopColor = (node) => this.checkAllSubAnswers(node.id)
-                                ? "0px 0px 15px 4px green inset"
+                                ? "0px 0px 6px 4px blue inset"
                                 : node.answered.length > 0
-                                    ? "0px 0px 15px 4px yellow inset"
-                                    : "0px 0px 15px 4px red inset";
+                                    ? "0px 0px 6px 4px yellow inset"
+                                    : "0px 0px 6px 4px red inset";
 
     getNodeById = (id) => this.props.surveyQuestions.find(sq => sq.id === id);
 
@@ -151,10 +151,10 @@ class SurveyQuestionTree extends React.Component {
         const childNodes = this.props.surveyQuestions.filter(surveyNode => surveyNode.parentQuestion === this.props.surveyNode.id);
 
         const shadowColor = this.props.surveyNode.answered.length === 0
-                            ? "0px 0px 15px 4px red inset"
+                            ? "0px 0px 6px 4px red inset"
                             : this.props.surveyNode.answered.length === this.props.surveyNode.visible.length
-                                ? "0px 0px 15px 4px green inset"
-                                : "0px 0px 15px 4px yellow inset";
+                                ? "0px 0px 6px 4px blue inset"
+                                : "0px 0px 6px 4px yellow inset";
         return (
             <fieldset className={"mb-1 justify-content-center text-center"}>
                 <div className="SurveyQuestionTree__question-buttons btn-block my-2 d-flex">

--- a/src/main/resources/public/jsx/components/SurveyCollection.js
+++ b/src/main/resources/public/jsx/components/SurveyCollection.js
@@ -61,7 +61,7 @@ export class SurveyCollection extends React.Component {
     };
 
     getTopColor = (node) => this.checkAllSubAnswers(node.id)
-                                ? "0px 0px 6px 4px blue inset"
+                                ? "0px 0px 6px 4px #3bb9d6 inset"
                                 : node.answered.length > 0
                                     ? "0px 0px 6px 4px yellow inset"
                                     : "0px 0px 6px 4px red inset";
@@ -153,7 +153,7 @@ class SurveyQuestionTree extends React.Component {
         const shadowColor = this.props.surveyNode.answered.length === 0
                             ? "0px 0px 6px 4px red inset"
                             : this.props.surveyNode.answered.length === this.props.surveyNode.visible.length
-                                ? "0px 0px 6px 4px blue inset"
+                                ? "0px 0px 6px 5px #3bb9d6 inset"
                                 : "0px 0px 6px 4px yellow inset";
         return (
             <fieldset className={"mb-1 justify-content-center text-center"}>

--- a/src/main/resources/public/jsx/review-institution.js
+++ b/src/main/resources/public/jsx/review-institution.js
@@ -578,7 +578,7 @@ class Project extends React.Component {
             .then(response => response.ok ? response.json() : Promise.reject(response))
             .then(data => this.setState({
                 boxShadow: data.unanalyzedPlots === 0
-                    ? "0px 0px 6px 1px blue inset"
+                    ? "0px 0px 6px 2px #3bb9d6 inset"
                     : (data.flaggedPlots + data.analyzedPlots) > 0
                         ? "0px 0px 6px 1px yellow inset"
                         : "0px 0px 6px 1px red inset",

--- a/src/main/resources/public/jsx/review-institution.js
+++ b/src/main/resources/public/jsx/review-institution.js
@@ -578,10 +578,10 @@ class Project extends React.Component {
             .then(response => response.ok ? response.json() : Promise.reject(response))
             .then(data => this.setState({
                 boxShadow: data.unanalyzedPlots === 0
-                    ? "0px 0px 8px 1px green inset"
+                    ? "0px 0px 6px 1px blue inset"
                     : (data.flaggedPlots + data.analyzedPlots) > 0
-                        ? "0px 0px 8px 1px yellow inset"
-                        : "0px 0px 8px 1px red inset",
+                        ? "0px 0px 6px 1px yellow inset"
+                        : "0px 0px 6px 1px red inset",
             }))
             .catch(response => console.log(response));
     };


### PR DESCRIPTION
-Open Geo-Dash button in collection in case user closes the tab 
-Add button to zoom back to plot if user zooms and pans map
-Add reset all survey answers by save button 
-Move go to plot feature to a less UI forward location (many users clicked it not knowing what it’s for and since it’s a feature only a few would use it should not be the top item)
-Move next, skip, back buttons to bottom by save buttons ?
-Rethink colors (Not started, progress, complete) to be 502 compliant on surveys (red or green very bad for color challenged people
-Make buttons bold with a thicker boarder so they have higher contrast.