### PR TITLE
update JSON to match PG changes

### DIFF
--- a/src/main/java/org/openforis/ceo/local/JsonPlots.java
+++ b/src/main/java/org/openforis/ceo/local/JsonPlots.java
@@ -41,10 +41,10 @@ public class JsonPlots implements Plots {
     }
 
     public String getProjectPlot(Request req, Response res) {
-        final var projectId = req.queryParams("projectId");
-        final var plotId = req.queryParams("plotId");
-        final var plots = elementToArray(readJsonFile("plot-data-" + projectId + ".json"));
-        final var matchingPlot = findInJsonArray(plots, plot -> plot.get("id").getAsString().equals(plotId));
+        final var projectId    = req.queryParams("projectId");
+        final var plotId       = Integer.parseInt(req.queryParams("plotId"));
+        final var plots        = elementToArray(readJsonFile("plot-data-" + projectId + ".json"));
+        final var matchingPlot = findInJsonArray(plots, pl -> getBestPlotId(pl).equals(plotId));
         if (matchingPlot.isPresent()) {
             return matchingPlot.get().toString();
         } else {


### PR DESCRIPTION
Use external plotId when available for getProjectPlot.  This makes the necessary changes to the JSON DB.