### PR TITLE
Fix bug when matching sum is answered in reverse order

### DIFF
--- a/src/main/resources/public/jsx/collection.js
+++ b/src/main/resources/public/jsx/collection.js
@@ -1091,7 +1091,7 @@ class Collection extends React.Component {
                                 + surveyRule.questionSetText1.toString()
                                 + "] and ["
                                 + surveyRule.questionSetText2.toString()
-                                + "] do not match. Valid total is "
+                                + "] do not match.\n\nValid total is "
                                 + Math.abs(invalidSum[0] - invalidSum[1])
                                 + ".";
                     } else {

--- a/src/main/resources/public/jsx/collection.js
+++ b/src/main/resources/public/jsx/collection.js
@@ -1082,32 +1082,20 @@ class Collection extends React.Component {
                             .reduce((sum, num) => sum + parseInt(num), 0);
                         return [sum1, sum2];
                     });
-                    if (surveyRule.questionSetIds1.includes(questionToSet)) {
-                        const invalidSum = sampleSums.find(sums => sums[0] + parseInt(answerText) !== sums[1]);
-                        if (invalidSum) {
-                            return "Matching sums validation failed: Totals of the question sets ["
+                    const invalidSum = sampleSums.find(sums =>
+                        sums[0] + (surveyRule.questionSetIds1.includes(questionToSet.id) ? parseInt(answerText) : 0)
+                        !== sums[1] + (surveyRule.questionSetIds2.includes(questionToSet.id) ? parseInt(answerText) : 0)
+                    );
+                    if (invalidSum) {
+                        return "Matching sums validation failed: Totals of the question sets ["
                                 + surveyRule.questionSetText1.toString()
                                 + "] and ["
                                 + surveyRule.questionSetText2.toString()
                                 + "] do not match. Valid total is "
-                                + (invalidSum[1] - invalidSum[0])
+                                + Math.abs(invalidSum[0] - invalidSum[1])
                                 + ".";
-                        } else {
-                            return null;
-                        }
                     } else {
-                        const invalidSum = sampleSums.find(sums => sums[0] !== sums[1] + parseInt(answerText));
-                        if (invalidSum) {
-                            return "Matching sums validation failed: Totals of the question sets ["
-                                + surveyRule.questionSetText1.toString()
-                                + "] and ["
-                                + surveyRule.questionSetText2.toString()
-                                + "] do not match. Valid total is "
-                                + (invalidSum[0] - invalidSum[1])
-                                + ".";
-                        } else {
-                            return null;
-                        }
+                        return null;
                     }
                 } else {
                     return null;


### PR DESCRIPTION
The bug ended up being just line 1085 where `(surveyRule.questionSetIds1.includes(questionToSet))` should have been `(surveyRule.questionSetIds1.includes(questionToSet.id))`.  I went ahead and simplified this code a little.