### PR TITLE
Monday changes (PR 606 / 609)

### DIFF
--- a/src/clj/org/openforis/ceo/utils/type_conversion.clj
+++ b/src/clj/org/openforis/ceo/utils/type_conversion.clj
@@ -14,7 +14,7 @@
 
 (defn str->long
   ([string]
-   (str->int string -1))
+   (str->long string -1))
   ([string default]
    (if (number? string)
      string
@@ -24,7 +24,7 @@
 
 (defn str->float
   ([string]
-   (str->int string -1))
+   (str->float string -1))
   ([string default]
    (if (number? string)
      string


### PR DESCRIPTION
Comments for the following PRs:

606 (FB Partial conversion of PostgresGeoDash.java)
609 (FB Convert PostgresPlots.java to plots.clj)
custom.css:

Section "GEO DASH PAGE" was removed. Were these styles moved somewhere else?
- Yes, a while ago Billy created geo-dash.css and didnt remove the styles he moved.

collection.js:

Lines *: Remove documentRoot from all fetch calls and don't pass it as a component parameter anywhere in this file.
Line 291: Update mercator.createMap to not take documentRoot arg.
- This is done in master. When its time to rebase/merge, these changes are successfully combined.

PostgresGeoDash.java -> geodash.clj:

Line 4: clj-http needs to be added to deps.edn.
- This was a little out of order, its added in the proxy PR where I used it first.

Line 16: :projectId -> :projectID (Also note that PostgresGeoDash.java was returning project-id as a string, not an int).
- Neither forms of projectId are used on the front end.

Lines 24,38,48: PostgresGeoDash.java used (UUID/fromString (:dashID params)). How does str->pg-uuid compare to this?
- Its just like clj->jsonb, a PGOject of type uuid is created.  In Java the (UUID/fromString ) does the same thing and tells PG that a uuid object is coming.

Line 38: PostgresGeoDash.java replaces a nil dashID with "". str->pg-uuid creates a PGObject with value nil as is. Can dashID actually ever be nil when this route is called from the front end? If so, then why are we not doing nil checking for all routes that take dashID. If not, then this comment may be ignored.
- PG still needs a PGObject when posting a nil value. DashId should never be nil, the front end spits back the dashId passed to it in `geodash-id`.  I think a "" uuid would cause an error vs a nil uuid.

PostgresPlots.java -> plots.clj:

Lines 5,59,64: call-sql-opts is not defined in this PR.
- This was a little out of order, its added in the projects PR where I used it first.

Line 16: PostgresPlots.java doesn't set a default max. Why 1000?
- Right now the sql is slow. 1000 matches the front end. I have a note to clean up the sql so I can lift the limit.

Line 42: project-id -> project_id. Destructure project_id in let on line 40.
- We already know project-id, there is no reason to get it from plot info. The SQL can be updated to match and not return project-id

Lines 63,68,76,115,137: Does (:userId params) return a string or an integer?
- Integer, when its on the session, its already parsed.

Line 74: institution-id is not passed to get-plot-by-id (or is it?)
- It is not, but that should be ok inst-admin? will be false

Line 133: (data-response plot-id)

Lines 138-140: You left out the conditional return value logic. Are we using return-id on the front-end?
- We dont use any of the responses on the front end.

type_conversion.clj:
Line 19: (catch Exception _ default)
- The base branch clojure_it_is_about_time is correct.
