### PR TITLE
block scinetific notation for survey answers

### DIFF
--- a/src/js/project/SurveyQuestions.js
+++ b/src/js/project/SurveyQuestions.js
@@ -299,6 +299,9 @@ class NewAnswerDesigner extends React.Component {
                         className="value-name"
                         autoComplete="off"
                         value={this.state.newAnswerText}
+                        onKeyDown={e => {
+                            if (e.key === "e" && this.props.surveyQuestion.dataType === "number") e.preventDefault();
+                        }}
                         onChange={e => this.setState({newAnswerText: e.target.value})}
                     />
                 </div>


### PR DESCRIPTION
JS does not fire an on change event for scientific notation, even though a number input allows it. Block this to avoid confusing error messaging.