### PR TITLE
Update clojure packages

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,23 +1,26 @@
 {:paths ["src/clj" "resources" "target"]
 
  :deps {bk/ring-gzip              {:mvn/version "0.3.0"}
-        clj-http/clj-http         {:mvn/version "3.10.1"}
+        clj-http/clj-http         {:mvn/version "3.10.3"}
         com.draines/postal        {:mvn/version "2.0.3"}
         com.cognitect/transit-clj {:mvn/version "1.0.324"}
         hiccup/hiccup             {:mvn/version "2.0.0-alpha2"}
         org.clojure/clojure       {:mvn/version "1.10.1"}
-        org.clojure/core.async    {:mvn/version "1.0.567"}
+        org.clojure/core.async    {:mvn/version "1.3.610"}
         org.clojure/data.json     {:mvn/version "1.0.0"}
         org.clojure/tools.cli     {:mvn/version "1.0.194"}
-        org.postgresql/postgresql {:mvn/version "42.2.10"}
+        org.postgresql/postgresql {:mvn/version "42.2.18"}
         ring/ring                 {:mvn/version "1.8.0"}
-        ring/ring-defaults        {:mvn/version "0.3.2"} ; FIXME I dont believe we actually use ring-defaults anymore in any project
+        ring/ring-headers         {:mvn/version "0.3.0"}
+        ring/ring-ssl             {:mvn/version "0.3.0"}
         ring/ring-json            {:mvn/version "0.5.0"}
-        seancorfield/next.jdbc    {:mvn/version "1.0.384"}}
+        seancorfield/next.jdbc    {:mvn/version "1.1.613"}}
 
  :aliases {:build-db    {:main-opts ["-m" "org.openforis.ceo.build-db"]}
            :ssl-key-gen {:main-opts ["-m" "org.openforis.ceo.https"]}
            :rebel       {:extra-deps {com.bhauman/rebel-readline {:mvn/version "0.1.4"}}
                          :main-opts  ["-m" "rebel-readline.main"]}
            :production  {:jvm-opts  ["-Xmx4096m" "-XX:+PrintFlagsFinal"]}
-           :run-server  {:main-opts ["-m" "org.openforis.ceo.server"]}}}
+           :run-server  {:main-opts ["-m" "org.openforis.ceo.server"]}
+           :check-deps  {:extra-deps {olical/depot {:mvn/version "1.8.4"}}
+                         :main-opts ["-m" "depot.outdated.main"]}}}


### PR DESCRIPTION
ring/ring-defaults was importing ring/ring-headers and ring/ring-ssl for us.  we dont need ring/defaults with ring/ring-headers and ring/ring-ssl correctly imported.