### PR TITLE
Update handler stack

### DIFF
--- a/src/clj/org/openforis/ceo/handler.clj
+++ b/src/clj/org/openforis/ceo/handler.clj
@@ -152,7 +152,7 @@
           (data-response cause {:status (or status 500)}))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Handler Stacks
+;; Handler Stack
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn optional-middleware [handler mw use?]
@@ -160,7 +160,7 @@
     (mw handler)
     handler))
 
-(defn create-handler-sack [ssl? reload?]
+(defn create-handler-stack [ssl? reload?]
   (-> authenticated-routing-handler
       (optional-middleware wrap-ssl-redirect ssl?)
       wrap-bad-uri

--- a/src/clj/org/openforis/ceo/handler.clj
+++ b/src/clj/org/openforis/ceo/handler.clj
@@ -151,8 +151,18 @@
           (log-str "Error: " cause)
           (data-response cause {:status (or status 500)}))))))
 
-(defn wrap-common [handler]
-  (-> handler
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Handler Stacks
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn optional-middleware [handler mw use?]
+  (if use?
+    (mw handler)
+    handler))
+
+(defn create-handler-sack [ssl? reload?]
+  (-> authenticated-routing-handler
+      (optional-middleware wrap-ssl-redirect ssl?)
       wrap-bad-uri
       wrap-request-logging
       wrap-persistent-session
@@ -172,16 +182,5 @@
       (wrap-content-type-options :nosniff)
       wrap-response-logging
       wrap-gzip
-      wrap-exceptions))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Handler Stacks
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(def production-app (-> authenticated-routing-handler
-                        wrap-ssl-redirect
-                        wrap-common))
-
-(defonce development-app (-> authenticated-routing-handler
-                             wrap-common
-                             wrap-reload))
+      wrap-exceptions
+      (optional-middleware wrap-reload reload?))) ; TODO, is wrap-reload harmful in prod mode?

--- a/src/clj/org/openforis/ceo/server.clj
+++ b/src/clj/org/openforis/ceo/server.clj
@@ -3,7 +3,7 @@
             [clojure.string :as str]
             [clojure.tools.cli  :refer [parse-opts]]
             [ring.adapter.jetty :refer [run-jetty]]
-            [org.openforis.ceo.handler :refer [development-app production-app]]
+            [org.openforis.ceo.handler :refer [create-handler-sack]]
             [org.openforis.ceo.logging :refer [log-str]]))
 
 (defonce server           (atom nil))
@@ -53,14 +53,13 @@
         (println (str "Usage:\n" summary)))
       (let [mode       (:mode options)
             has-key?   (.exists (io/file "./.key/keystore.pkcs12"))
-            handler    (if (= mode "prod")
-                         #'production-app
-                         #'development-app)
             https-port (:https-port options)
+            ssl?       (and has-key? https-port)
+            handler    (create-handler-sack ssl? (= mode "dev"))
             config     (merge
                         {:port  (:http-port options)
                          :join? false}
-                        (when (and has-key? https-port)
+                        (when ssl?
                           {:ssl?          true
                            :ssl-port      https-port
                            :keystore      "./.key/keystore.pkcs12"

--- a/src/clj/org/openforis/ceo/server.clj
+++ b/src/clj/org/openforis/ceo/server.clj
@@ -3,7 +3,7 @@
             [clojure.string :as str]
             [clojure.tools.cli  :refer [parse-opts]]
             [ring.adapter.jetty :refer [run-jetty]]
-            [org.openforis.ceo.handler :refer [create-handler-sack]]
+            [org.openforis.ceo.handler :refer [create-handler-stack]]
             [org.openforis.ceo.logging :refer [log-str]]))
 
 (defonce server           (atom nil))
@@ -55,7 +55,7 @@
             has-key?   (.exists (io/file "./.key/keystore.pkcs12"))
             https-port (:https-port options)
             ssl?       (and has-key? https-port)
-            handler    (create-handler-sack ssl? (= mode "dev"))
+            handler    (create-handler-stack ssl? (= mode "dev"))
             config     (merge
                         {:port  (:http-port options)
                          :join? false}


### PR DESCRIPTION
I noticed that the handler stack for production has ssl-redirect, which means not having a cert with -m prod will still not work.  In looking at the two handler stacks, the only difference is ssl-redirect for prod, and reload for dev.

In your review of the run-server param updates you said
"Don't tie https to mode=prod. We specifically need to
be able to run production mode with http only on our Raspberry Pi.
This also makes it possible to test advanced mode compilation on our
local machines without https."

However, the back end does not have "advanced mode compilation". So we just need to use the production handler stack without ssl-redirect.  we will have to redefine the production handler stack to take a ssl? param.  Most of our middleware is the same in wrap-common handler.  We can also have a reload? param and consolidate into one handler stack function.

Something like (in handler.clj)
```clojure
(defn create-handler-sack [ssl? reload?]
  (as-> authenticated-routing-handler handler
    (if ssl?
      (wrap-ssl-redirect handler)
      handler)
    (wrap-common handler)
    (if reload?
      (wrap-reload handler)
      handler)))
```
and (in server.cljs)
```
handler #(create-handler-sack (and has-key? https-port) (= mode "dev"))
```

This code change appears to be working.  Im not sure what the '# notation was for, so Im not sure that this is a 1 for 1 update.