### PR TITLE
Clean up survey rule designer

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1,7 +1,7 @@
 /***********/
 /* General */
 /***********/
-#srd td {
+.srd td {
     border-collapse: collapse;
     border: 2px solid rgb(200, 200, 200);
     letter-spacing: 1px;

--- a/src/js/project/ManageProject.js
+++ b/src/js/project/ManageProject.js
@@ -21,9 +21,11 @@ export default class ManageProject extends React.Component {
     /// API Calls
 
     getProjectDetails = () =>
-        Promise.all([this.getProjectById(this.context.projectId),
-                     this.getProjectImagery(this.context.projectId),
-                     this.getProjectPlots(this.context.projectId)])
+        Promise.all([
+            this.getProjectById(this.context.projectId),
+            this.getProjectImagery(this.context.projectId),
+            this.getProjectPlots(this.context.projectId),
+        ])
             .catch(response => {
                 console.log(response);
                 alert("Error retrieving the project info. See console for details.");

--- a/src/js/project/SurveyRules.js
+++ b/src/js/project/SurveyRules.js
@@ -23,7 +23,9 @@ export class SurveyRuleDesign extends React.Component {
                     inDesignMode
                 />
                 <table id="ruleDesigner">
-                    <label className="font-weight-bold mt-2">New Rule:</label>
+                    <caption style={{color: "black", captionSide: "top", fontWeight: "bold"}}>
+                        New Rule:
+                    </caption>
                     <tbody className="srd">
                         <tr>
                             <td>
@@ -95,8 +97,7 @@ export class SurveyRulesList extends React.Component {
 
         "numeric-range": ({min, max, questionsText}) => (
             <>
-                <td>Min: {min}</td>
-                <td>Max: {max}</td>
+                <td>Min: {min}, Max: {max}</td>
                 <td>Questions: {questionsText.toString()}</td>
             </>
         ),
@@ -612,7 +613,7 @@ export class IncompatibleAnswers extends React.Component {
             ));
         const errorMessages = [
             conflictingRule
-                && "A incompatible answers rule already exists for these question / answer pairs. (Rule "
+                && "An incompatible answers rule already exists for these question / answer pairs. (Rule "
                 + conflictingRule.id
                 + ")",
             (questionId1 === questionId2) && "You must select two different questions.",

--- a/src/js/project/SurveyRules.js
+++ b/src/js/project/SurveyRules.js
@@ -1,6 +1,9 @@
 import React from "react";
+import {isNumber, arraysSameElements} from "../utils/generalUtils";
 
 import {ProjectContext} from "./constants";
+
+const getNextId = (array) => array.reduce((maxId, obj) => Math.max(maxId, obj.id), 0) + 1;
 
 export class SurveyRuleDesign extends React.Component {
     constructor(props) {
@@ -8,186 +11,9 @@ export class SurveyRuleDesign extends React.Component {
 
         this.state = {
             selectedRuleType: "text-match",
-            regex: "",
-            min: -1,
-            max: -1,
-            validSum: 0,
-            questionIds: [],
-            dropdownQuestions: [],
-            answers1: [],
-            answers2: [],
-            question1: 0,
-            question2: 0,
-            answer1: 0,
-            answer2: 0,
-            questionText1: "",
-            questionText2: "",
-            answerText1: "",
-            answerText2: "",
-            questions: [],
-            questionsSet1: [],
-            questionsSet2: [],
-            questionSetIds1: [],
-            questionSetIds2: [],
         };
     }
 
-    setNewRule = (ruleType) => {
-        this.setState({selectedRuleType: ruleType});
-    };
-
-    updateMin = (min) => {
-        this.setState({min: min});
-    };
-
-    updateMax = (max) => {
-        this.setState({max: max});
-    };
-
-    updateRegex = (expression) => {
-        this.setState({regex: expression});
-    };
-
-    updateMaxSum = (sum) => {
-        this.setState({validSum: sum});
-    };
-
-    updateOptions = (target, type) => {
-        const selection = Array.from(target.options).filter(option => option.selected);
-        if (this.state.selectedRuleType === "incompatible-answers") {
-            selection.map(option => {
-                const questionId = parseInt(option.value);
-                if (target.id === "question1") {
-                    const dropdownQuestions = this.context.surveyQuestions.filter(question => question.id !== questionId && question.componentType !== "input");
-                    const currentQuestion = this.context.surveyQuestions.find(ques => ques.id === questionId);
-                    const answers = currentQuestion.answers;
-                    this.setState({
-                        question1: questionId,
-                        dropdownQuestions: dropdownQuestions,
-                        answers1: answers,
-                        questionText1: currentQuestion.question,
-                        answers2: [],
-                    });
-                } else if (target.id === "question2") {
-                    const currentQuestion = this.context.surveyQuestions.find(ques => ques.id === questionId);
-                    const answers = currentQuestion ? currentQuestion.answers : [];
-                    this.setState({
-                        question2: questionId,
-                        questionText2: currentQuestion.question,
-                        answers2: answers,
-                    });
-                } else if (target.id === "answer1") {
-                    const currentQuestion = this.context.surveyQuestions.find(ques => ques.id === this.state.question1);
-                    const answer = currentQuestion.answers.find(ans => ans.id === questionId);
-                    this.setState({answer1: questionId, answerText1: answer.answer});
-                } else if (target.id === "answer2") {
-                    const currentQuestion = this.context.surveyQuestions.find(ques => ques.id === this.state.question2);
-                    const answer = currentQuestion.answers.find(ans => ans.id === questionId);
-                    this.setState({answer2: questionId, answerText2: answer.answer});
-                }
-            });
-        } else if (this.state.selectedRuleType === "matching-sums" && selection.length > 1) {
-            const questions = selection.map(option => {
-                const question = this.context.surveyQuestions.find(surveyQuestion => surveyQuestion.id === parseInt(option.value));
-                return question.question;
-            });
-            if (type === "questionSet1") {
-                this.setState({
-                    questionSetIds1: selection.map(option => parseInt(option.value)),
-                    questionsSet1: questions,
-                });
-            } else if (type === "questionSet2") {
-                this.setState({
-                    questionSetIds2: selection.map(option => parseInt(option.value)),
-                    questionsSet2: questions,
-                });
-            }
-        } else if ((this.state.selectedRuleType === "sum-of-answers" && selection.length > 1) || (this.state.selectedRuleType !== "sum-of-answers" && selection.length > 0)) {
-            const questions = selection.map(option => {
-                const question = this.context.surveyQuestions.find(surveyQuestion => surveyQuestion.id === parseInt(option.value));
-                return question.question;
-            });
-            this.setState({questionIds: selection.map(option => parseInt(option.value)), questions: questions});
-        }
-
-    };
-
-    getMaxId = (array) => array.reduce((maxId, obj) => Math.max(maxId, obj.id), 0);
-
-    addSurveyRule = (ruleType) => {
-        const rules = this.context.surveyRules.map(rule =>
-            (rule.ruleType === "numeric-range"
-                && rule.questionId === this.state.questionIds[0])
-                ? {...rule, min: this.state.min, max: this.state.max}
-            : (rule.ruleType === "text-match"
-                && rule.questionId === this.state.questionIds[0])
-                ? {...rule, regex: this.state.regex}
-            : (rule.ruleType === "sum-of-answers"
-                && this.state.questionIds.every(qId => rule.questions.includes(qId)))
-                ? {...rule, validSum: this.state.validSum}
-            : (rule.ruleType === "matching-sums"
-                && this.state.questionSetIds1.every(qId => rule.questionSetIds1.includes(qId))
-                && this.state.questionSetIds2.every(qId => rule.questionSetIds2.includes(qId)))
-                ? {...rule}
-            : rule);
-
-        const numExists = this.context.surveyRules.some(rule => rule.ruleType === "numeric-range" && rule.questionId === this.state.questionIds[0]);
-        const textExists = this.context.surveyRules.some(rule => rule.ruleType === "text-match" && rule.questionId === this.state.questionIds[0]);
-        const sumExists = this.context.surveyRules.some(rule => rule.ruleType === "sum-of-answers"
-                && this.state.questionIds.every(qId => rule.questions.includes(qId)));
-        const matchingSumsExists = this.context.surveyRules.some(rule => rule.ruleType === "matching-sums"
-                && this.state.questionSetIds1.every(qId => rule.questionSetIds1.includes(qId))
-                && this.state.questionSetIds2.every(qId => rule.questionSetIds2.includes(qId)));
-        const incompatibleExists = this.context.surveyRules.some(rule => rule.ruleType === "incompatible-answers"
-                && rule.question1 === this.state.question1
-                && rule.question2 === this.state.question2
-                && rule.answer1 === this.state.answer1
-                && rule.answer2 === this.state.answer2);
-
-        const newRule =
-            (ruleType === "numeric-range" && numExists === false && this.state.min >= 0 && this.state.max >= 0) ? {
-                id: rules.length > 0 ? this.getMaxId(rules) + 1 : 1,
-                ruleType: ruleType,
-                questionId: this.state.questionIds[0],
-                questionsText: this.state.questions,
-                min: this.state.min,
-                max: this.state.max,
-            } : (ruleType === "text-match" && textExists === false && this.state.regex.length > 0) ? {
-                id: rules.length > 0 ? this.getMaxId(rules) + 1 : 1,
-                ruleType: ruleType,
-                questionId: this.state.questionIds[0],
-                questionsText: this.state.questions,
-                regex: this.state.regex,
-            } : (ruleType === "sum-of-answers" && sumExists === false && this.state.questions.length > 1) ? {
-                id: rules.length > 0 ? this.getMaxId(rules) + 1 : 1,
-                ruleType: ruleType,
-                questions: this.state.questionIds,
-                questionsText: this.state.questions,
-                validSum: this.state.validSum,
-            } : (ruleType === "matching-sums" && matchingSumsExists === false && this.state.questionSetIds1.length > 1 && this.state.questionSetIds2.length > 1) ? {
-                id: rules.length > 0 ? this.getMaxId(rules) + 1 : 1,
-                ruleType: ruleType,
-                questionSetIds1: this.state.questionSetIds1,
-                questionSetIds2: this.state.questionSetIds2,
-                questionSetText1: this.state.questionsSet1,
-                questionSetText2: this.state.questionsSet2,
-            } : (ruleType === "incompatible-answers" && incompatibleExists === false
-                    && this.state.question1 > 0 && this.state.question2 > 0
-                    && this.state.answer1 > 0 && this.state.answer2 > 0)
-            ? {
-                id: rules.length > 0 ? this.getMaxId(rules) + 1 : 1,
-                ruleType: ruleType,
-                question1: this.state.question1,
-                question2: this.state.question2,
-                answer1: this.state.answer1,
-                answer2: this.state.answer2,
-                questionText1: this.state.questionText1,
-                questionText2: this.state.questionText2,
-                answerText1: this.state.answerText1,
-                answerText2: this.state.answerText2,
-            } : null;
-        this.context.setProjectDetails({surveyRules: newRule ? [...rules, newRule] : rules});
-    };
 
     render() {
         return (
@@ -207,8 +33,8 @@ export class SurveyRuleDesign extends React.Component {
                                     <td>
                                         <select
                                             className="form-control form-control-sm"
-                                            size="1"
-                                            onChange={e => this.setNewRule(e.target.value)}
+                                            value={this.selectedRuleType}
+                                            onChange={e => this.setState({selectedRuleType: e.target.value})}
                                         >
                                             <option value="text-match">Text Regex Match</option>
                                             <option value="numeric-range">Numeric Range</option>
@@ -223,335 +49,19 @@ export class SurveyRuleDesign extends React.Component {
                     </td>
                 </tr>
                 {
-                    this.state.selectedRuleType === "text-match" ? (
-                        <TextMatch
-                            surveyQuestions={this.context.surveyQuestions}
-                            updateRegex={this.updateRegex}
-                            updateOptions={this.updateOptions}
-                        />
-                    ) : this.state.selectedRuleType === "numeric-range" ? (
-                        <NumericRange
-                            surveyQuestions={this.context.surveyQuestions}
-                            surveyRules={this.context.surveyRules}
-                            updateMin={this.updateMin}
-                            updateMax={this.updateMax}
-                            updateOptions={this.updateOptions}
-                        />
-                    ) : this.state.selectedRuleType === "sum-of-answers" ? (
-                        <SumOfAnswers
-                            surveyQuestions={this.context.surveyQuestions}
-                            surveyRules={this.context.surveyRules}
-                            updateMaxSum={this.updateMaxSum}
-                            updateOptions={this.updateOptions}
-                        />
-                    ) : this.state.selectedRuleType === "matching-sums" ? (
-                        <MatchingSums
-                            surveyQuestions={this.context.surveyQuestions}
-                            surveyRules={this.context.surveyRules}
-                            updateOptions={this.updateOptions}
-                        />
-                    ) : this.state.selectedRuleType === "incompatible-answers" ? (
-                        <IncompatibleAnswers
-                            answers1={this.state.answers1}
-                            answers2={this.state.answers2}
-                            dropdownQuestions={this.state.dropdownQuestions}
-                            surveyQuestions={this.context.surveyQuestions}
-                            surveyRules={this.context.surveyRules}
-                            updateOptions={this.updateOptions}
-                        />
-                    ) : <tr><td></td><td></td></tr>
+                    {
+                        "text-match": <TextMatch/>,
+                        "numeric-range": <NumericRange/>,
+                        "sum-of-answers": <SumOfAnswers/>,
+                        "matching-sums": <MatchingSums/>,
+                        "incompatible-answers": <IncompatibleAnswers/>,
+                    }[this.state.selectedRuleType]
                 }
-                <tr>
-                    <td colSpan="6">
-                        <input
-                            type="button"
-                            className="button"
-                            value="Add Survey Rule"
-                            onClick={() => this.addSurveyRule(this.state.selectedRuleType)}
-                        />
-                    </td>
-                </tr>
             </SurveyRulesList>
         );
     }
 }
 SurveyRuleDesign.contextType = ProjectContext;
-
-function TextMatch(props) {
-    const surveyQuestions = props.surveyQuestions
-        .filter(question => question.componentType === "input" && question.dataType === "text");
-    return surveyQuestions.length > 0
-        ?
-            <tr>
-                <td colSpan="6">
-                    <table>
-                        <tbody>
-                            <tr>
-                                <td><label>Survey Question: </label></td>
-                                <td>
-                                    <select
-                                        className="form-control form-control-sm"
-                                        onChange={e => props.updateOptions(e.target, "")}
-                                    >
-                                        <option value="-1">- Select Question -</option>
-                                        {surveyQuestions && surveyQuestions.map((question, uid) =>
-                                            <option key={uid} value={question.id}>{question.question}</option>)
-                                        }
-                                    </select>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td><label>Enter regular expression: </label></td>
-                                <td>
-                                    <input
-                                        id="text-match"
-                                        className="form-control form-control-sm"
-                                        type="text"
-                                        placeholder="Regular expression"
-                                        onChange={e => props.updateRegex(e.target.value)}
-                                    />
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </td>
-            </tr>
-        :
-            <tr><td colSpan="5"><label>No questions for this rule type</label></td></tr>;
-}
-
-function NumericRange(props) {
-    const surveyQuestions = props.surveyQuestions
-        .filter(question => question.componentType === "input" && question.dataType === "number");
-    return surveyQuestions.length > 0
-        ?
-            <tr>
-                <td colSpan="6">
-                    <table>
-                        <tbody>
-                            <tr>
-                                <td><label>Survey Question: </label></td>
-                                <td colSpan="4">
-                                    <select
-                                        className="form-control form-control-sm"
-                                        onChange={e => props.updateOptions(e.target, "")}
-                                    >
-                                        <option value="-1">- Select Question -</option>
-                                        {surveyQuestions && surveyQuestions.map((question, uid) =>
-                                            <option key={uid} value={question.id}>{question.question}</option>)
-                                        }
-                                    </select>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td><label>Enter minimum: </label></td>
-                                <td>
-                                    <input
-                                        id="min-val"
-                                        className="form-control form-control-sm"
-                                        type="number"
-                                        placeholder="Minimum value"
-                                        onChange={e => props.updateMin(parseInt(e.target.value))}
-                                    />
-                                </td>
-                            </tr>
-                            <tr>
-                                <td><label>Enter maximum: </label></td>
-                                <td>
-                                    <input
-                                        id="max-val"
-                                        className="form-control form-control-sm"
-                                        type="number"
-                                        placeholder="Maximum value"
-                                        onChange={e => props.updateMax(parseInt(e.target.value))}
-                                    />
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </td>
-            </tr>
-        :
-            <tr><td colSpan="6"><label>No questions for this rule type</label></td></tr>;
-}
-
-function SumOfAnswers(props) {
-    const surveyQuestions = props.surveyQuestions.filter(question => question.dataType === "number");
-    return surveyQuestions.length > 0
-        ?
-            <tr>
-                <td colSpan="6">
-                    <table>
-                        <tbody>
-                            <tr>
-                                <td>
-                                    <label>
-                                        <p>Select survey question:</p><p>(Hold ctrl/cmd and select multiple questions)</p>
-                                    </label>
-                                </td>
-                                <td colSpan="3">
-                                    <select
-                                        className="form-control form-control-sm overflow-auto"
-                                        multiple="multiple"
-                                        onChange={e => props.updateOptions(e.target, "")}
-                                    >
-                                        {surveyQuestions.length > 1 && surveyQuestions.map((question, uid) =>
-                                            <option key={uid} value={question.id}>{question.question}</option>)
-                                        }
-                                    </select>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td><label>Enter valid sum: </label></td>
-                                <td>
-                                    <input
-                                        className="form-control form-control-sm"
-                                        id="expected-sum"
-                                        type="number"
-                                        placeholder="Valid sum"
-                                        onChange={e => props.updateMaxSum(parseInt(e.target.value))}
-                                    />
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </td>
-            </tr>
-        :
-            <tr><td colSpan="6"><label>No questions for this rule type</label></td></tr>;
-}
-
-function MatchingSums(props) {
-    const surveyQuestions = props.surveyQuestions.filter(question => question.dataType === "number");
-    return surveyQuestions.length > 1
-        ?
-            <tr>
-                <td colSpan="6">
-                    <table>
-                        <tbody>
-                            <tr>
-                                <td>
-                                    <label>
-                                        <p>Select first question set:</p><p>(Hold ctrl/cmd and select multiple questions)</p>
-                                    </label>
-                                </td>
-                                <td colSpan="4">
-                                    <select
-                                        className="form-control form-control-sm overflow-auto"
-                                        multiple="multiple"
-                                        onChange={e => props.updateOptions(e.target, "questionSet1")}
-                                    >
-                                        {surveyQuestions.length > 1 && surveyQuestions.map((question, uid) =>
-                                            <option key={uid} value={question.id}>{question.question}</option>)
-                                        }
-                                    </select>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>
-                                    <label>
-                                        <p>Select second question set:</p><p>(Hold ctrl/cmd and select multiple questions)</p>
-                                    </label>
-                                </td>
-                                <td>
-                                    <select
-                                        className="form-control form-control-sm overflow-auto"
-                                        multiple="multiple"
-                                        onChange={e => props.updateOptions(e.target, "questionSet2")}
-                                    >
-                                        {surveyQuestions.length > 1 && surveyQuestions.map((question, uid) =>
-                                            <option key={uid} value={question.id}>{question.question}</option>)
-                                        }
-                                    </select>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </td>
-            </tr>
-        :
-            <tr><td colSpan="6"><label>There must be at least 2 matching questions for this rule type</label></td></tr>;
-}
-
-function IncompatibleAnswers(props) {
-    const surveyQuestions = props.surveyQuestions.filter(question => question.componentType !== "input");
-    const {dropdownQuestions} = props;
-    return surveyQuestions.length > 1
-        ?
-            <tr>
-                <td colSpan="6">
-                    <table>
-                        <tbody>
-                            <tr>
-                                <td colSpan="4"><label>Select the incompatible questions and answers: </label></td>
-                            </tr>
-                            <tr>
-                                <td>Question 1:</td>
-                                <td colSpan="3">
-                                    <select
-                                        className="form-control form-control-sm"
-                                        id="question1"
-                                        onChange={e => props.updateOptions(e.target, "")}
-                                    >
-                                        <option value="-1">- Select Question 1 -</option>
-                                        {surveyQuestions && surveyQuestions.map((question, uid) =>
-                                            <option key={uid} value={question.id}>{question.question}</option>)
-                                        }
-                                    </select>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>Answer 1:</td>
-                                <td>
-                                    <select
-                                        className="form-control form-control-sm"
-                                        id="answer1"
-                                        onChange={e => props.updateOptions(e.target, "")}
-                                    >
-                                        <option value="-1">- Select Answer 1 -</option>
-                                        {props.answers1 && props.answers1.map((answer, uid) =>
-                                            <option key={uid} value={answer.id}>{answer.answer}</option>)
-                                        }
-                                    </select>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>Question 2:</td>
-                                <td>
-                                    <select
-                                        className="form-control form-control-sm"
-                                        id="question2"
-                                        onChange={e => props.updateOptions(e.target, "")}
-                                    >
-                                        <option value="-1">- Select Question 2 -</option>
-                                        {dropdownQuestions && dropdownQuestions.map((question, uid) =>
-                                            <option key={uid} value={question.id}>{question.question}</option>)
-                                        }
-                                    </select>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>Answer 2:</td>
-                                <td>
-                                    <select
-                                        className="form-control form-control-sm"
-                                        id="answer2"
-                                        onChange={e => props.updateOptions(e.target, "")}
-                                    >
-                                        <option value="-1">- Select Answer 2 -</option>
-                                        {props.answers2 && props.answers2.map((answer, uid) =>
-                                            <option key={uid} value={answer.id}>{answer.answer}</option>)
-                                        }
-                                    </select>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </td>
-            </tr>
-        :
-            <tr><td colSpan="6"><label>There must be at least 2 matching questions for this rule type</label></td></tr>;
-}
 
 export class SurveyRulesList extends React.Component {
     deleteSurveyRule = (ruleId) => {
@@ -655,3 +165,580 @@ export class SurveyRulesList extends React.Component {
         );
     }
 }
+
+export class TextMatch extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            regex: "",
+            questionId: -1,
+        };
+    }
+
+    addSurveyRule = () => {
+        const conflictingRule = this.context.surveyRules.find(rule => rule.ruleType === "text-match"
+            && rule.questionId === this.state.questionId);
+        const errorMessages = [
+            conflictingRule && "A Text Regex Match rule already exists for this question. (Rule #" + conflictingRule.id + ")",
+            this.state.questionId < 1 && "You must select a question.",
+            this.state.regex.length === 0 && "The regex string is missing.",
+        ].filter(m => m);
+        if (errorMessages.length > 0) {
+            alert(errorMessages.map(s => "- " + s).join("\n"));
+        } else {
+            this.context.setProjectDetails({
+                surveyRules: [...this.context.surveyRules, {
+                    id: getNextId(this.context.surveyRules),
+                    ruleType: "text-match",
+                    questionId: this.state.questionId,
+                    questionsText: [this.context.surveyQuestions.find(q => q.id === this.state.questionId).question],
+                    regex: this.state.regex,
+                }],
+            });
+        }
+    }
+
+    render() {
+        const availableQuestions = this.context.surveyQuestions
+            .filter(q => q.componentType === "input" && q.dataType === "text");
+        return availableQuestions.length > 0
+        ?
+            <tr>
+                <td colSpan="6">
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td><label>Survey Question: </label></td>
+                                <td>
+                                    <select
+                                        className="form-control form-control-sm"
+                                        value={this.state.questionId}
+                                        onChange={e => this.setState({questionId: Number(e.target.value)})}
+                                    >
+                                        <option value={-1}>- Select Question -</option>
+                                        {availableQuestions.map((question, uid) =>
+                                            <option key={uid} value={question.id}>{question.question}</option>)
+                                        }
+                                    </select>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td><label>Enter regular expression: </label></td>
+                                <td>
+                                    <input
+                                        className="form-control form-control-sm"
+                                        type="text"
+                                        placeholder="Regular expression"
+                                        value={this.state.regex}
+                                        onChange={e => this.setState({regex: e.target.value})}
+                                    />
+                                </td>
+                            </tr>
+                            <tr>
+                                <td style={{border: "none"}}></td>
+                                <td style={{border: "none"}}>
+                                    <input
+                                        type="button"
+                                        className="button mt-2"
+                                        value="Add Survey Rule"
+                                        onClick={this.addSurveyRule}
+                                    />
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </td>
+            </tr>
+        :
+            <tr><td colSpan="5"><label>No questions for this rule type</label></td></tr>;
+    }
+}
+TextMatch.contextType = ProjectContext;
+
+export class NumericRange extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            questionId: -1,
+            min: 0,
+            max: 0,
+        };
+    }
+
+    addSurveyRule = () => {
+        const conflictingRule = this.context.surveyRules.find(rule => rule.ruleType === "numeric-range"
+            && rule.questionId === this.state.questionId);
+        const errorMessages = [
+            conflictingRule && "This numeric range rule already exists. (Rule #" + conflictingRule.id + ")",
+            this.state.questionId < 1 && "You must select a question.",
+            (this.state.max <= this.state.min) && "Max must be larger than min.",
+        ].filter(m => m);
+        if (errorMessages.length > 0) {
+            alert(errorMessages.map(s => "- " + s).join("\n"));
+        } else {
+            this.context.setProjectDetails({
+                surveyRules: [...this.context.surveyRules, {
+                    id: getNextId(this.context.surveyRules),
+                    ruleType: "numeric-range",
+                    questionId: this.state.questionId,
+                    questionsText: [this.context.surveyQuestions.find(q => q.id === this.state.questionId).question],
+                    min: this.state.min,
+                    max: this.state.max,
+                }],
+            });
+        }
+    }
+
+    render() {
+        const availableQuestions = this.context.surveyQuestions
+            .filter(q => q.componentType === "input" && q.dataType === "number");
+        return availableQuestions.length > 0
+        ?
+            <tr>
+                <td colSpan="6">
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td><label>Survey Question: </label></td>
+                                <td colSpan="4">
+                                    <select
+                                        className="form-control form-control-sm"
+                                        value={this.state.questionId}
+                                        onChange={e => this.setState({questionId: Number(e.target.value)})}
+                                    >
+                                        <option value={-1}>- Select Question -</option>
+                                        {availableQuestions.map((question, uid) =>
+                                            <option key={uid} value={question.id}>{question.question}</option>)
+                                        }
+                                    </select>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td><label>Enter minimum: </label></td>
+                                <td>
+                                    <input
+                                        className="form-control form-control-sm"
+                                        type="number"
+                                        placeholder="Minimum value"
+                                        value={this.state.min}
+                                        onChange={e => this.setState({min: Number(e.target.value)})}
+                                    />
+                                </td>
+                            </tr>
+                            <tr>
+                                <td><label>Enter maximum: </label></td>
+                                <td>
+                                    <input
+                                        className="form-control form-control-sm"
+                                        type="number"
+                                        placeholder="Maximum value"
+                                        value={this.state.max}
+                                        onChange={e => this.setState({max: Number(e.target.value)})}
+                                    />
+                                </td>
+                            </tr>
+                            <tr>
+                                <td style={{border: "none"}}></td>
+                                <td style={{border: "none"}}>
+                                    <input
+                                        type="button"
+                                        className="button mt-2"
+                                        value="Add Survey Rule"
+                                        onClick={this.addSurveyRule}
+                                    />
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </td>
+            </tr>
+        :
+            <tr><td colSpan="6"><label>No questions for this rule type</label></td></tr>;
+    }
+}
+NumericRange.contextType = ProjectContext;
+
+export class SumOfAnswers extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            validSum: 0,
+            questionIds: [],
+        };
+    }
+
+    addSurveyRule = () => {
+        const conflictingRule = this.context.surveyRules.find(rule => rule.ruleType === "sum-of-answers"
+            && arraysSameElements(this.state.questionIds, rule.questions));
+        const errorMessages = [
+            conflictingRule && "This sum of answers rule already exists. (Rule #" + conflictingRule.id + ")",
+            (this.state.questionIds.length < 2) && "Sum of answers rule requires the selection of two or more questions.",
+            !isNumber(this.state.validSum) && "You must ender a valid sum number.",
+        ].filter(m => m);
+        if (errorMessages.length > 0) {
+            alert(errorMessages.map(s => "- " + s).join("\n"));
+        } else {
+            this.context.setProjectDetails({
+                surveyRules: [...this.context.surveyRules, {
+                    id: getNextId(this.context.surveyRules),
+                    ruleType: "sum-of-answers",
+                    questions: this.state.questionIds,
+                    questionsText: this.context.surveyQuestions
+                        .filter(q => this.state.questionIds.includes(q.id))
+                        .map(q => q.question),
+                    validSum: this.state.validSum,
+                }],
+            });
+        }
+    }
+
+    render() {
+        const availableQuestions = this.context.surveyQuestions.filter(q => q.dataType === "number");
+        return availableQuestions.length > 1
+        ?
+            <tr>
+                <td colSpan="6">
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>
+                                    <label>
+                                        <p>Select survey question:</p>
+                                        <p>(Hold ctrl/cmd and select multiple questions)</p>
+                                    </label>
+                                </td>
+                                <td colSpan="3">
+                                    <select
+                                        className="form-control form-control-sm overflow-auto"
+                                        multiple="multiple"
+                                        value={this.state.questionIds}
+                                        onChange={e => this.setState({
+                                            questionIds: Array.from(e.target.selectedOptions, i => Number(i.value)),
+                                        })}
+                                    >
+                                        {availableQuestions.map((question, uid) =>
+                                            <option key={uid} value={question.id}>{question.question}</option>)
+                                        }
+                                    </select>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td><label>Enter valid sum: </label></td>
+                                <td>
+                                    <input
+                                        className="form-control form-control-sm"
+                                        type="number"
+                                        placeholder="Valid sum"
+                                        value={this.state.validSum}
+                                        onChange={e => this.setState({validSum: Number(e.target.value)})}
+                                    />
+                                </td>
+                            </tr>
+                            <tr>
+                                <td style={{border: "none"}}></td>
+                                <td style={{border: "none"}}>
+                                    <input
+                                        type="button"
+                                        className="button mt-2"
+                                        value="Add Survey Rule"
+                                        onClick={this.addSurveyRule}
+                                    />
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </td>
+            </tr>
+        :
+            <tr><td colSpan="6"><label>There must be at least 2 number questions for this rule type</label></td></tr>;
+    }
+}
+SumOfAnswers.contextType = ProjectContext;
+
+export class MatchingSums extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            questionSetIds1: [],
+            questionSetIds2: [],
+        };
+    }
+
+    addSurveyRule = () => {
+        const conflictingRule = this.context.surveyRules.find(rule => rule.ruleType === "matching-sums"
+            && arraysSameElements(this.state.questionSetIds1, rule.questionSetIds1)
+            && arraysSameElements(this.state.questionSetIds2, rule.questionSetIds2));
+        const errorMessages = [
+            conflictingRule && "This matching sums rule already exists. (Rule #" + conflictingRule.id + ")",
+            (this.state.questionSetIds1.length < 2 && this.state.questionSetIds2.length < 2)
+                && "Matching sums rule requires that of the selections contain two or more questions.",
+            this.state.questionSetIds1.length === 0 && "You must select at least one question from the first set",
+            this.state.questionSetIds2.length === 0 && "You must select at least one question from the second set",
+            this.state.questionSetIds1.some(id => this.state.questionSetIds2.includes(id))
+                && "Question set 1 and 2 cannot contain the same question.",
+        ].filter(m => m);
+        if (errorMessages.length > 0) {
+            alert(errorMessages.map(s => "- " + s).join("\n"));
+        } else {
+            this.context.setProjectDetails({
+                surveyRules: [...this.context.surveyRules, {
+                    id: getNextId(this.context.surveyRules),
+                    ruleType: "matching-sums",
+                    questionSetIds1: this.state.questionSetIds1,
+                    questionSetIds2: this.state.questionSetIds2,
+                    questionSetText1: this.context.surveyQuestions
+                        .filter(q => this.state.questionSetIds1.includes(q.id))
+                        .map(q => q.question),
+                    questionSetText2: this.context.surveyQuestions
+                        .filter(q => this.state.questionSetIds2.includes(q.id))
+                        .map(q => q.question),
+                }],
+            });
+        }
+    }
+
+    render() {
+        const availableQuestions = this.context.surveyQuestions.filter(q => q.dataType === "number");
+        return availableQuestions.length > 1
+        ?
+            <tr>
+                <td colSpan="6">
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>
+                                    <label>
+                                        <p>Select first question set:</p>
+                                        <p>(Hold ctrl/cmd and select multiple questions)</p>
+                                    </label>
+                                </td>
+                                <td colSpan="4">
+                                    <select
+                                        className="form-control form-control-sm overflow-auto"
+                                        multiple="multiple"
+                                        value={this.state.questionSetIds1}
+                                        onChange={e => this.setState({
+                                            questionSetIds1: Array.from(e.target.selectedOptions, i => Number(i.value)),
+                                        })}
+                                    >
+                                        {availableQuestions.map((question, uid) =>
+                                            <option key={uid} value={question.id}>{question.question}</option>)
+                                        }
+                                    </select>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <label>
+                                        <p>Select second question set:</p>
+                                        <p>(Hold ctrl/cmd and select multiple questions)</p>
+                                    </label>
+                                </td>
+                                <td>
+                                    <select
+                                        className="form-control form-control-sm overflow-auto"
+                                        multiple="multiple"
+                                        value={this.state.questionSetIds2}
+                                        onChange={e => this.setState({
+                                            questionSetIds2: Array.from(e.target.selectedOptions, i => Number(i.value)),
+                                        })}
+                                    >
+                                        {availableQuestions.map((question, uid) =>
+                                            <option key={uid} value={question.id}>{question.question}</option>)
+                                        }
+                                    </select>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td style={{border: "none"}}></td>
+                                <td style={{border: "none"}}>
+                                    <input
+                                        type="button"
+                                        className="button mt-2"
+                                        value="Add Survey Rule"
+                                        onClick={this.addSurveyRule}
+                                    />
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </td>
+            </tr>
+        :
+            <tr><td colSpan="6"><label>There must be at least 2 number questions for this rule type</label></td></tr>;
+    }
+}
+MatchingSums.contextType = ProjectContext;
+
+export class IncompatibleAnswers extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            questionId1: -1,
+            questionId2: -1,
+            answerId1: -1,
+            answerId2: -1,
+        };
+    }
+
+    checkPair = (q1, a1, q2, a2) => q1 === q2 && a1 === a2;
+
+    checkEquivalent = (q1, a1, q2, a2, q3, a3, q4, a4) =>
+        (this.checkPair(q1, a1, q3, a3) && this.checkPair(q2, a2, q4, a4))
+        || (this.checkPair(q1, a1, q4, a4) && this.checkPair(q2, a2, q3, a3));
+
+    addSurveyRule = () => {
+        const conflictingRule = this.context.surveyRules.find(rule => rule.ruleType === "incompatible-answers"
+            && this.checkEquivalent(
+                rule.question1,
+                rule.answer1,
+                rule.question2,
+                rule.answer2,
+                this.state.questionId1,
+                this.state.answerId1,
+                this.state.questionId2,
+                this.state.answerId2
+            ));
+        const errorMessages = [
+            conflictingRule && "This incompatible answers rule already exists. (Rule #" + conflictingRule.id + ")",
+            (this.state.questionId1 === this.state.questionId2) && "You must select two different questions.",
+            this.state.questionId1 < 1 && "You must select a valid first question.",
+            this.state.questionId2 < 1 && "You must select a valid second question.",
+            (this.state.answerId1 < 1 || this.state.answerId2 < 1) && "You must select an answer for each question.",
+        ].filter(m => m);
+        if (errorMessages.length > 0) {
+            alert(errorMessages.map(s => "- " + s).join("\n"));
+        } else {
+            const q1 = this.context.surveyQuestions.find(q => q.id === this.state.questionId1);
+            const q2 = this.context.surveyQuestions.find(q => q.id === this.state.questionId2);
+            this.context.setProjectDetails({
+                surveyRules: [...this.context.surveyRules, {
+                    id: getNextId(this.context.surveyRules),
+                    ruleType: "incompatible-answers",
+                    question1: this.state.questionId1,
+                    question2: this.state.questionId2,
+                    answer1: this.state.answerId1,
+                    answer2: this.state.answerId2,
+                    questionText1: q1.question,
+                    questionText2: q2.question,
+                    answerText1: q1.answers.find(a => a.id === this.state.answerId1).answer,
+                    answerText2: q2.answers.find(a => a.id === this.state.answerId2).answer,
+                }],
+            });
+        }
+    }
+
+    safeFindAnswers = (questionId) => {
+        const question = this.context.surveyQuestions.find(q => q.id === questionId);
+        const answers = question && question.answers;
+        return answers || [];
+    }
+
+    render() {
+        const availableQuestions = this.context.surveyQuestions.filter(q => q.componentType !== "input");
+        return availableQuestions.length > 1
+        ?
+            <tr>
+                <td colSpan="6">
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td colSpan="4"><label>Select the incompatible questions and answers: </label></td>
+                            </tr>
+                            <tr>
+                                <td>Question 1:</td>
+                                <td colSpan="3">
+                                    <select
+                                        className="form-control form-control-sm"
+                                        value={this.state.questionId1}
+                                        onChange={e => this.setState({
+                                            questionId1: Number(e.target.value),
+                                            answerId1: -1,
+                                        })}
+                                    >
+                                        <option value="-1">- Select Question 1 -</option>
+                                        {availableQuestions.map((question, uid) =>
+                                            <option key={uid} value={question.id}>{question.question}</option>)
+                                        }
+                                    </select>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>Answer 1:</td>
+                                <td>
+                                    <select
+                                        className="form-control form-control-sm"
+                                        value={this.state.answerId1}
+                                        onChange={e => this.setState({answerId1: Number(e.target.value)})}
+                                    >
+                                        <option value="-1">- Select Answer 1 -</option>
+                                        {this.safeFindAnswers(this.state.questionId1).map((answer, uid) =>
+                                            <option key={uid} value={answer.id}>{answer.answer}</option>)
+                                        }
+                                    </select>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>Question 2:</td>
+                                <td>
+                                    <select
+                                        className="form-control form-control-sm"
+                                        value={this.state.questionId2}
+                                        onChange={e => this.setState({
+                                            questionId2: Number(e.target.value),
+                                            answerId2: -1,
+                                        })}
+                                    >
+                                        <option value="-1">- Select Question 2 -</option>
+                                        {availableQuestions.map((question, uid) =>
+                                            <option key={uid} value={question.id}>{question.question}</option>)
+                                        }
+                                    </select>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>Answer 2:</td>
+                                <td>
+                                    <select
+                                        className="form-control form-control-sm"
+                                        value={this.state.answerId2}
+                                        onChange={e => this.setState({answerId2: Number(e.target.value)})}
+                                    >
+                                        <option value="-1">- Select Answer 2 -</option>
+                                        {this.safeFindAnswers(this.state.questionId2).map((answer, uid) =>
+                                            <option key={uid} value={answer.id}>{answer.answer}</option>)
+                                        }
+                                    </select>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td style={{border: "none"}}></td>
+                                <td style={{border: "none"}}>
+                                    <input
+                                        type="button"
+                                        className="button mt-2"
+                                        value="Add Survey Rule"
+                                        onClick={this.addSurveyRule}
+                                    />
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </td>
+            </tr>
+        :
+            <tr>
+                <td colSpan="6">
+                    <label>
+                        There must be at least 2 questions where type is not input for this rule
+                    </label>
+                </td>
+            </tr>;
+    }
+}
+IncompatibleAnswers.contextType = ProjectContext;

--- a/src/js/project/SurveyRules.js
+++ b/src/js/project/SurveyRules.js
@@ -1,6 +1,6 @@
 import React from "react";
-import {isNumber, arraysSameElements} from "../utils/generalUtils";
 
+import {isNumber, sameContents} from "../utils/generalUtils";
 import {ProjectContext} from "./constants";
 
 const getNextId = (array) => array.reduce((maxId, obj) => Math.max(maxId, obj.id), 0) + 1;
@@ -14,50 +14,47 @@ export class SurveyRuleDesign extends React.Component {
         };
     }
 
-
     render() {
         return (
-            <SurveyRulesList
-                surveyRules={this.context.surveyRules}
-                setProjectDetails={this.context.setProjectDetails}
-                inDesignMode
-            >
-                <tr>
-                    <td colSpan="6">
-                        <table>
-                            <tbody>
-                                <tr>
-                                    <td>
-                                        <label htmlFor="ruletype">Rule Type:</label>
-                                    </td>
-                                    <td>
-                                        <select
-                                            className="form-control form-control-sm"
-                                            value={this.selectedRuleType}
-                                            onChange={e => this.setState({selectedRuleType: e.target.value})}
-                                        >
-                                            <option value="text-match">Text Regex Match</option>
-                                            <option value="numeric-range">Numeric Range</option>
-                                            <option value="sum-of-answers">Sum of Answers</option>
-                                            <option value="matching-sums">Matching Sums</option>
-                                            <option value="incompatible-answers">Incompatible Answers</option>
-                                        </select>
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </td>
-                </tr>
-                {
-                    {
-                        "text-match": <TextMatch/>,
-                        "numeric-range": <NumericRange/>,
-                        "sum-of-answers": <SumOfAnswers/>,
-                        "matching-sums": <MatchingSums/>,
-                        "incompatible-answers": <IncompatibleAnswers/>,
-                    }[this.state.selectedRuleType]
-                }
-            </SurveyRulesList>
+            <div id="survey-rule-design">
+                <SurveyRulesList
+                    surveyRules={this.context.surveyRules}
+                    setProjectDetails={this.context.setProjectDetails}
+                    inDesignMode
+                />
+                <table id="ruleDesigner">
+                    <label className="font-weight-bold mt-2">New Rule:</label>
+                    <tbody className="srd">
+                        <tr>
+                            <td>
+                                <div style={{display: "flex"}}>
+                                    <label className="text-nowrap m-2">Rule Type:</label>
+                                    <select
+                                        className="form-control form-control-sm"
+                                        value={this.state.selectedRuleType}
+                                        onChange={e => this.setState({selectedRuleType: e.target.value})}
+                                    >
+                                        <option value="text-match">Text Regex Match</option>
+                                        <option value="numeric-range">Numeric Range</option>
+                                        <option value="sum-of-answers">Sum of Answers</option>
+                                        <option value="matching-sums">Matching Sums</option>
+                                        <option value="incompatible-answers">Incompatible Answers</option>
+                                    </select>
+                                </div>
+                            </td>
+                        </tr>
+                        {
+                            {
+                                "text-match": <TextMatch/>,
+                                "numeric-range": <NumericRange/>,
+                                "sum-of-answers": <SumOfAnswers/>,
+                                "matching-sums": <MatchingSums/>,
+                                "incompatible-answers": <IncompatibleAnswers/>,
+                            }[this.state.selectedRuleType]
+                        }
+                    </tbody>
+                </table>
+            </div>
         );
     }
 }
@@ -80,88 +77,86 @@ export class SurveyRulesList extends React.Component {
         </button>
     );
 
-    render() {
-        const {surveyRules, inDesignMode, children} = this.props;
+    ruleTypeLabel = {
+        "text-match": "Text Regex Match",
+        "numeric-range": "Numeric Range",
+        "sum-of-answers": "Sum of Answers",
+        "matching-sums": "Matching Sums",
+        "incompatible-answers": "Incompatible Answers",
+    };
+
+    ruleSpecificColumns = {
+        "text-match": ({regex, questionsText}) => (
+            <>
+                <td>Regex: {regex}</td>
+                <td>Questions: {questionsText.toString()}</td>
+            </>
+        ),
+
+        "numeric-range": ({min, max, questionsText}) => (
+            <>
+                <td>Min: {min}</td>
+                <td>Max: {max}</td>
+                <td>Questions: {questionsText.toString()}</td>
+            </>
+        ),
+
+        "sum-of-answers": ({validSum, questionsText}) => (
+            <>
+                <td>Valid Sum: {validSum}</td>
+                <td>Questions: {questionsText.toString()}</td>
+            </>
+        ),
+
+        "matching-sums": ({questionSetText1, questionSetText2}) => (
+            <>
+                <td>Questions Set 1: {questionSetText1.toString()}</td>
+                <td>Questions Set 2: {questionSetText2.toString()}</td>
+            </>
+        ),
+
+        "incompatible-answers": ({questionText1, answerText1, questionText2, answerText2}) => (
+            <>
+                <td>Question 1: {questionText1}, Answer 1: {answerText1}</td>
+                <td>Question 2: {questionText2}, Answer 2: {answerText2}</td>
+            </>
+        ),
+    };
+
+    renderRuleRow = (rule, uid) => {
+        const {id, ruleType} = rule;
         return (
-            <div id="survey-rule-design">
-                <span className="font-weight-bold">Rules:</span>
-                <table id="srd">
-                    <tbody>
-                        {(surveyRules || []).length > 0
-                        ?
-                            surveyRules.map((rule, uid) => {
-                                if (rule.ruleType === "text-match") {
-                                    return <tr id={"rule" + rule.id} key={uid}>
-                                        {inDesignMode &&
-                                        <td>
-                                            {this.removeButton(rule.id)}
-                                        </td>
-                                        }
-                                        <td>{"Rule " + rule.id}</td>
-                                        <td>Type: Text Regex Match</td>
-                                        <td>Regex: {rule.regex}</td>
-                                        <td colSpan="2">Questions: {rule.questionsText.toString()}</td>
-                                    </tr>;
-                                } else if (rule.ruleType === "numeric-range") {
-                                    return <tr id={"rule" + rule.id} key={uid}>
-                                        {inDesignMode &&
-                                        <td>
-                                            {this.removeButton(rule.id)}
-                                        </td>
-                                        }
-                                        <td>{"Rule " + rule.id}</td>
-                                        <td>Type: Numeric Range</td>
-                                        <td>Min: {rule.min}</td>
-                                        <td>Max: {rule.max}</td>
-                                        <td>Questions: {rule.questionsText.toString()}</td>
-                                    </tr>;
-                                } else if (rule.ruleType === "sum-of-answers") {
-                                    return <tr id={"rule" + rule.id} key={uid}>
-                                        {inDesignMode &&
-                                        <td>
-                                            {this.removeButton(rule.id)}
-                                        </td>
-                                        }
-                                        <td>{"Rule " + rule.id}</td>
-                                        <td>Type: Sum of Answers</td>
-                                        <td>Valid Sum: {rule.validSum}</td>
-                                        <td colSpan="2">Questions: {rule.questionsText.toString()}</td>
-                                    </tr>;
-                                } else if (rule.ruleType === "matching-sums") {
-                                    return <tr id={"rule" + rule.id} key={uid}>
-                                        {inDesignMode &&
-                                        <td>
-                                            {this.removeButton(rule.id)}
-                                        </td>
-                                        }
-                                        <td>{"Rule " + rule.id}</td>
-                                        <td>Type: Matching Sums</td>
-                                        <td>Questions Set 1: {rule.questionSetText1.toString()}</td>
-                                        <td colSpan="2">Questions Set 2: {rule.questionSetText2.toString()}</td>
-                                    </tr>;
-                                } else if (rule.ruleType === "incompatible-answers") {
-                                    return <tr id={"rule" + rule.id} key={uid}>
-                                        {inDesignMode &&
-                                        <td>
-                                            {this.removeButton(rule.id)}
-                                        </td>
-                                        }
-                                        <td>{"Rule " + rule.id}</td>
-                                        <td>Type: Incompatible Answers</td>
-                                        <td>Question 1: {rule.questionText1}, Answer 1: {rule.answerText1}</td>
-                                        <td colSpan="2">Question 2: {rule.questionText2}, Answer 2: {rule.answerText2}</td>
-                                    </tr>;
-                                }
-                            })
-                        :
-                            <tr>
-                                <td colSpan="6"><span>No rules set for this survey</span></td>
-                            </tr>
-                        }
-                        {children}
-                    </tbody>
-                </table>
-            </div>
+            <tr id={"rule" + id} key={uid}>
+                {this.props.inDesignMode &&
+                    <td>{this.removeButton(id)}</td>
+                }
+                <td>{"Rule " + id}</td>
+                <td>Type: {this.ruleTypeLabel[ruleType]}</td>
+                {this.ruleSpecificColumns[ruleType].call(null, rule)}
+            </tr>
+        );
+    };
+
+    render() {
+        const {surveyRules} = this.props;
+        return (
+            <>
+                <label className="font-weight-bold">Rules:</label>
+                {(surveyRules || []).length > 0
+                ?
+                    <table
+                        id="rules"
+                        className="srd"
+                        style={{width: "100%"}}
+                    >
+                        <tbody>
+                            {surveyRules.map(this.renderRuleRow)}
+                        </tbody>
+                    </table>
+                :
+                    <label className="ml-3">No rules have been created for this survey.</label>
+                }
+            </>
         );
     }
 }
@@ -177,27 +172,29 @@ export class TextMatch extends React.Component {
     }
 
     addSurveyRule = () => {
-        const conflictingRule = this.context.surveyRules.find(rule => rule.ruleType === "text-match"
-            && rule.questionId === this.state.questionId);
+        const {surveyRules, surveyQuestions, setProjectDetails} = this.context;
+        const {questionId, regex} = this.state;
+        const conflictingRule = surveyRules.find(rule => rule.ruleType === "text-match"
+            && rule.questionId === questionId);
         const errorMessages = [
-            conflictingRule && "A Text Regex Match rule already exists for this question. (Rule #" + conflictingRule.id + ")",
-            this.state.questionId < 1 && "You must select a question.",
-            this.state.regex.length === 0 && "The regex string is missing.",
+            conflictingRule && "A text regex match rule already exists for this question. (Rule " + conflictingRule.id + ")",
+            questionId < 1 && "You must select a question.",
+            regex.length === 0 && "The regex string is missing.",
         ].filter(m => m);
         if (errorMessages.length > 0) {
             alert(errorMessages.map(s => "- " + s).join("\n"));
         } else {
-            this.context.setProjectDetails({
-                surveyRules: [...this.context.surveyRules, {
-                    id: getNextId(this.context.surveyRules),
+            setProjectDetails({
+                surveyRules: [...surveyRules, {
+                    id: getNextId(surveyRules),
                     ruleType: "text-match",
-                    questionId: this.state.questionId,
-                    questionsText: [this.context.surveyQuestions.find(q => q.id === this.state.questionId).question],
-                    regex: this.state.regex,
+                    questionId: questionId,
+                    questionsText: [surveyQuestions.find(q => q.id === questionId).question],
+                    regex: regex,
                 }],
             });
         }
-    }
+    };
 
     render() {
         const availableQuestions = this.context.surveyQuestions
@@ -205,7 +202,7 @@ export class TextMatch extends React.Component {
         return availableQuestions.length > 0
         ?
             <tr>
-                <td colSpan="6">
+                <td>
                     <table>
                         <tbody>
                             <tr>
@@ -251,7 +248,7 @@ export class TextMatch extends React.Component {
                 </td>
             </tr>
         :
-            <tr><td colSpan="5"><label>No questions for this rule type</label></td></tr>;
+            <tr><td><label>This rule requires a question of type input-text.</label></td></tr>;
     }
 }
 TextMatch.contextType = ProjectContext;
@@ -268,28 +265,30 @@ export class NumericRange extends React.Component {
     }
 
     addSurveyRule = () => {
-        const conflictingRule = this.context.surveyRules.find(rule => rule.ruleType === "numeric-range"
-            && rule.questionId === this.state.questionId);
+        const {surveyRules, surveyQuestions, setProjectDetails} = this.context;
+        const {questionId, min, max} = this.state;
+        const conflictingRule = surveyRules.find(rule => rule.ruleType === "numeric-range"
+            && rule.questionId === questionId);
         const errorMessages = [
-            conflictingRule && "This numeric range rule already exists. (Rule #" + conflictingRule.id + ")",
-            this.state.questionId < 1 && "You must select a question.",
-            (this.state.max <= this.state.min) && "Max must be larger than min.",
+            conflictingRule && "A numeric range rule already exists for this question. (Rule " + conflictingRule.id + ")",
+            questionId < 1 && "You must select a question.",
+            (max <= min) && "Max must be larger than min.",
         ].filter(m => m);
         if (errorMessages.length > 0) {
             alert(errorMessages.map(s => "- " + s).join("\n"));
         } else {
-            this.context.setProjectDetails({
-                surveyRules: [...this.context.surveyRules, {
-                    id: getNextId(this.context.surveyRules),
+            setProjectDetails({
+                surveyRules: [...surveyRules, {
+                    id: getNextId(surveyRules),
                     ruleType: "numeric-range",
-                    questionId: this.state.questionId,
-                    questionsText: [this.context.surveyQuestions.find(q => q.id === this.state.questionId).question],
-                    min: this.state.min,
-                    max: this.state.max,
+                    questionId: questionId,
+                    questionsText: [surveyQuestions.find(q => q.id === questionId).question],
+                    min: min,
+                    max: max,
                 }],
             });
         }
-    }
+    };
 
     render() {
         const availableQuestions = this.context.surveyQuestions
@@ -297,12 +296,12 @@ export class NumericRange extends React.Component {
         return availableQuestions.length > 0
         ?
             <tr>
-                <td colSpan="6">
+                <td>
                     <table>
                         <tbody>
                             <tr>
                                 <td><label>Survey Question: </label></td>
-                                <td colSpan="4">
+                                <td>
                                     <select
                                         className="form-control form-control-sm"
                                         value={this.state.questionId}
@@ -355,7 +354,7 @@ export class NumericRange extends React.Component {
                 </td>
             </tr>
         :
-            <tr><td colSpan="6"><label>No questions for this rule type</label></td></tr>;
+            <tr><td><label>This rule requires a question of type input-number.</label></td></tr>;
     }
 }
 NumericRange.contextType = ProjectContext;
@@ -371,36 +370,38 @@ export class SumOfAnswers extends React.Component {
     }
 
     addSurveyRule = () => {
-        const conflictingRule = this.context.surveyRules.find(rule => rule.ruleType === "sum-of-answers"
-            && arraysSameElements(this.state.questionIds, rule.questions));
+        const {surveyRules, surveyQuestions, setProjectDetails} = this.context;
+        const {questionIds, validSum} = this.state;
+        const conflictingRule = surveyRules.find(rule => rule.ruleType === "sum-of-answers"
+            && sameContents(questionIds, rule.questions));
         const errorMessages = [
-            conflictingRule && "This sum of answers rule already exists. (Rule #" + conflictingRule.id + ")",
-            (this.state.questionIds.length < 2) && "Sum of answers rule requires the selection of two or more questions.",
-            !isNumber(this.state.validSum) && "You must ender a valid sum number.",
+            conflictingRule && "A sum of answers rule already exists for these questions. (Rule " + conflictingRule.id + ")",
+            (questionIds.length < 2) && "Sum of answers rule requires the selection of two or more questions.",
+            !isNumber(validSum) && "You must ender a valid sum number.",
         ].filter(m => m);
         if (errorMessages.length > 0) {
             alert(errorMessages.map(s => "- " + s).join("\n"));
         } else {
-            this.context.setProjectDetails({
-                surveyRules: [...this.context.surveyRules, {
-                    id: getNextId(this.context.surveyRules),
+            setProjectDetails({
+                surveyRules: [...surveyRules, {
+                    id: getNextId(surveyRules),
                     ruleType: "sum-of-answers",
-                    questions: this.state.questionIds,
-                    questionsText: this.context.surveyQuestions
-                        .filter(q => this.state.questionIds.includes(q.id))
+                    questions: questionIds,
+                    questionsText: surveyQuestions
+                        .filter(q => questionIds.includes(q.id))
                         .map(q => q.question),
-                    validSum: this.state.validSum,
+                    validSum: validSum,
                 }],
             });
         }
-    }
+    };
 
     render() {
         const availableQuestions = this.context.surveyQuestions.filter(q => q.dataType === "number");
         return availableQuestions.length > 1
         ?
             <tr>
-                <td colSpan="6">
+                <td>
                     <table>
                         <tbody>
                             <tr>
@@ -410,7 +411,7 @@ export class SumOfAnswers extends React.Component {
                                         <p>(Hold ctrl/cmd and select multiple questions)</p>
                                     </label>
                                 </td>
-                                <td colSpan="3">
+                                <td>
                                     <select
                                         className="form-control form-control-sm overflow-auto"
                                         multiple="multiple"
@@ -453,7 +454,7 @@ export class SumOfAnswers extends React.Component {
                 </td>
             </tr>
         :
-            <tr><td colSpan="6"><label>There must be at least 2 number questions for this rule type</label></td></tr>;
+            <tr><td><label>There must be at least 2 number questions for this rule type.</label></td></tr>;
     }
 }
 SumOfAnswers.contextType = ProjectContext;
@@ -469,44 +470,46 @@ export class MatchingSums extends React.Component {
     }
 
     addSurveyRule = () => {
-        const conflictingRule = this.context.surveyRules.find(rule => rule.ruleType === "matching-sums"
-            && arraysSameElements(this.state.questionSetIds1, rule.questionSetIds1)
-            && arraysSameElements(this.state.questionSetIds2, rule.questionSetIds2));
+        const {surveyRules, surveyQuestions, setProjectDetails} = this.context;
+        const {questionSetIds1, questionSetIds2} = this.state;
+        const conflictingRule = surveyRules.find(rule => rule.ruleType === "matching-sums"
+            && sameContents(questionSetIds1, rule.questionSetIds1)
+            && sameContents(questionSetIds2, rule.questionSetIds2));
         const errorMessages = [
-            conflictingRule && "This matching sums rule already exists. (Rule #" + conflictingRule.id + ")",
-            (this.state.questionSetIds1.length < 2 && this.state.questionSetIds2.length < 2)
-                && "Matching sums rule requires that of the selections contain two or more questions.",
-            this.state.questionSetIds1.length === 0 && "You must select at least one question from the first set",
-            this.state.questionSetIds2.length === 0 && "You must select at least one question from the second set",
-            this.state.questionSetIds1.some(id => this.state.questionSetIds2.includes(id))
+            conflictingRule && "A matching sums rule already exists for these questions. (Rule " + conflictingRule.id + ")",
+            (questionSetIds1.length < 2 && questionSetIds2.length < 2)
+                && "Matching sums rule requires that at least one of the question sets contain two or more questions.",
+            questionSetIds1.length === 0 && "You must select at least one question from the first set.",
+            questionSetIds2.length === 0 && "You must select at least one question from the second set.",
+            questionSetIds1.some(id => questionSetIds2.includes(id))
                 && "Question set 1 and 2 cannot contain the same question.",
         ].filter(m => m);
         if (errorMessages.length > 0) {
             alert(errorMessages.map(s => "- " + s).join("\n"));
         } else {
-            this.context.setProjectDetails({
-                surveyRules: [...this.context.surveyRules, {
-                    id: getNextId(this.context.surveyRules),
+            setProjectDetails({
+                surveyRules: [...surveyRules, {
+                    id: getNextId(surveyRules),
                     ruleType: "matching-sums",
-                    questionSetIds1: this.state.questionSetIds1,
-                    questionSetIds2: this.state.questionSetIds2,
-                    questionSetText1: this.context.surveyQuestions
-                        .filter(q => this.state.questionSetIds1.includes(q.id))
+                    questionSetIds1: questionSetIds1,
+                    questionSetIds2: questionSetIds2,
+                    questionSetText1: surveyQuestions
+                        .filter(q => questionSetIds1.includes(q.id))
                         .map(q => q.question),
-                    questionSetText2: this.context.surveyQuestions
-                        .filter(q => this.state.questionSetIds2.includes(q.id))
+                    questionSetText2: surveyQuestions
+                        .filter(q => questionSetIds2.includes(q.id))
                         .map(q => q.question),
                 }],
             });
         }
-    }
+    };
 
     render() {
         const availableQuestions = this.context.surveyQuestions.filter(q => q.dataType === "number");
         return availableQuestions.length > 1
         ?
             <tr>
-                <td colSpan="6">
+                <td>
                     <table>
                         <tbody>
                             <tr>
@@ -516,7 +519,7 @@ export class MatchingSums extends React.Component {
                                         <p>(Hold ctrl/cmd and select multiple questions)</p>
                                     </label>
                                 </td>
-                                <td colSpan="4">
+                                <td>
                                     <select
                                         className="form-control form-control-sm overflow-auto"
                                         multiple="multiple"
@@ -569,7 +572,7 @@ export class MatchingSums extends React.Component {
                 </td>
             </tr>
         :
-            <tr><td colSpan="6"><label>There must be at least 2 number questions for this rule type</label></td></tr>;
+            <tr><td><label>There must be at least 2 number questions for this rule type.</label></td></tr>;
     }
 }
 MatchingSums.contextType = ProjectContext;
@@ -593,66 +596,72 @@ export class IncompatibleAnswers extends React.Component {
         || (this.checkPair(q1, a1, q4, a4) && this.checkPair(q2, a2, q3, a3));
 
     addSurveyRule = () => {
-        const conflictingRule = this.context.surveyRules.find(rule => rule.ruleType === "incompatible-answers"
+        const {surveyRules, surveyQuestions, setProjectDetails} = this.context;
+        const {questionId1, answerId1, questionId2, answerId2} = this.state;
+        const conflictingRule = surveyRules.find(({question1, answer1, question2, answer2, ruleType}) =>
+            ruleType === "incompatible-answers"
             && this.checkEquivalent(
-                rule.question1,
-                rule.answer1,
-                rule.question2,
-                rule.answer2,
-                this.state.questionId1,
-                this.state.answerId1,
-                this.state.questionId2,
-                this.state.answerId2
+                question1,
+                answer1,
+                question2,
+                answer2,
+                questionId1,
+                answerId1,
+                questionId2,
+                answerId2
             ));
         const errorMessages = [
-            conflictingRule && "This incompatible answers rule already exists. (Rule #" + conflictingRule.id + ")",
-            (this.state.questionId1 === this.state.questionId2) && "You must select two different questions.",
-            this.state.questionId1 < 1 && "You must select a valid first question.",
-            this.state.questionId2 < 1 && "You must select a valid second question.",
-            (this.state.answerId1 < 1 || this.state.answerId2 < 1) && "You must select an answer for each question.",
+            conflictingRule
+                && "A incompatible answers rule already exists for these question / answer pairs. (Rule "
+                + conflictingRule.id
+                + ")",
+            (questionId1 === questionId2) && "You must select two different questions.",
+            questionId1 < 1 && "You must select a valid first question.",
+            questionId2 < 1 && "You must select a valid second question.",
+            (answerId1 < 1 || answerId2 < 1) && "You must select an answer for each question.",
         ].filter(m => m);
         if (errorMessages.length > 0) {
             alert(errorMessages.map(s => "- " + s).join("\n"));
         } else {
-            const q1 = this.context.surveyQuestions.find(q => q.id === this.state.questionId1);
-            const q2 = this.context.surveyQuestions.find(q => q.id === this.state.questionId2);
-            this.context.setProjectDetails({
-                surveyRules: [...this.context.surveyRules, {
-                    id: getNextId(this.context.surveyRules),
+            const q1 = surveyQuestions.find(q => q.id === questionId1);
+            const q2 = surveyQuestions.find(q => q.id === questionId2);
+            setProjectDetails({
+                surveyRules: [...surveyRules, {
+                    id: getNextId(surveyRules),
                     ruleType: "incompatible-answers",
-                    question1: this.state.questionId1,
-                    question2: this.state.questionId2,
-                    answer1: this.state.answerId1,
-                    answer2: this.state.answerId2,
+                    question1: questionId1,
+                    question2: questionId2,
+                    answer1: answerId1,
+                    answer2: answerId2,
                     questionText1: q1.question,
                     questionText2: q2.question,
-                    answerText1: q1.answers.find(a => a.id === this.state.answerId1).answer,
-                    answerText2: q2.answers.find(a => a.id === this.state.answerId2).answer,
+                    answerText1: q1.answers.find(a => a.id === answerId1).answer,
+                    answerText2: q2.answers.find(a => a.id === answerId2).answer,
                 }],
             });
         }
-    }
+    };
 
     safeFindAnswers = (questionId) => {
         const question = this.context.surveyQuestions.find(q => q.id === questionId);
         const answers = question && question.answers;
         return answers || [];
-    }
+    };
 
     render() {
         const availableQuestions = this.context.surveyQuestions.filter(q => q.componentType !== "input");
         return availableQuestions.length > 1
         ?
             <tr>
-                <td colSpan="6">
+                <td>
                     <table>
                         <tbody>
                             <tr>
-                                <td colSpan="4"><label>Select the incompatible questions and answers: </label></td>
+                                <td><label>Select the incompatible questions and answers: </label></td>
                             </tr>
                             <tr>
                                 <td>Question 1:</td>
-                                <td colSpan="3">
+                                <td>
                                     <select
                                         className="form-control form-control-sm"
                                         value={this.state.questionId1}
@@ -733,9 +742,9 @@ export class IncompatibleAnswers extends React.Component {
             </tr>
         :
             <tr>
-                <td colSpan="6">
+                <td>
                     <label>
-                        There must be at least 2 questions where type is not input for this rule
+                        There must be at least 2 questions where type is not input for this rule.
                     </label>
                 </td>
             </tr>;

--- a/src/js/utils/generalUtils.js
+++ b/src/js/utils/generalUtils.js
@@ -117,3 +117,7 @@ export function removeFromSet(set, value) {
 export function safeLength(arr) {
     return (arr || []).length;
 }
+
+export function arraysSameElements(array1, array2) {
+    return array1.every(e => array2.includes(e)) && array2.every(e => array1.includes(e));
+}

--- a/src/js/utils/generalUtils.js
+++ b/src/js/utils/generalUtils.js
@@ -118,6 +118,6 @@ export function safeLength(arr) {
     return (arr || []).length;
 }
 
-export function arraysSameElements(array1, array2) {
+export function sameContents(array1, array2) {
     return array1.every(e => array2.includes(e)) && array2.every(e => array1.includes(e));
 }


### PR DESCRIPTION
Errors fixed
- Missing or incomplete validations
    - Example 1 many rules did not check to see if the selected question was valid
    - Example 2 most of the comparisons for lists were insufficient to determine equivalency (i.e. [1].every(e => [1, 2, 3].includes(e)) is true but the two arrays are not equivalent)
- No messages to users.  Errors failed silently
- Silently mutating existing rules without warning the user
- Invalid handling of invalid ui events
    - All of the form components did not have "value" set.  So if a UI change was invalid, the state did not update, but the UI was not reset to match the current (unchanged) state.
- State is not correctly reset when a change dictates.
    - Example 1, when changing from rule type where the different rules share this.state.questionIds
    - When changing a question in incompatible answers, question 2 could be eliminated from the dropdown but q2 and a2 were not reset. When selecting a new question the array of answers was updated without ensuring that the selected answer was a subset.
- Storing easily derived variables in state instead of calculating on submit
- Different types shared single state variables.
- updateOptions uses annoying nested logic without actually eliminating repeat code.