### PR TITLE
Add SQL function to reset projects that incorrectly have other institution imagery

### DIFF
--- a/src/sql/changes/update_2021-02-22_fix_cross_project_imagery.sql
+++ b/src/sql/changes/update_2021-02-22_fix_cross_project_imagery.sql
@@ -1,0 +1,10 @@
+UPDATE projects
+SET imagery_rid = (SELECT select_first_public_imagery())
+WHERE project_uid IN (
+    SELECT project_uid
+    FROM imagery i
+    INNER JOIN projects p
+        ON imagery_uid = imagery_rid
+    WHERE i.institution_rid <> p.institution_rid
+        AND i.institution_rid <> 3
+);


### PR DESCRIPTION
This issue does not seem to be persistent.  This PR does a one time reset of the invalid assignment.

close #1082 