### PR TITLE
Fix SQL query for institution admin

### DIFF
--- a/src/sql/functions/member.sql
+++ b/src/sql/functions/member.sql
@@ -2,6 +2,65 @@
 -- REQUIRES: clear, project
 
 --
+-- ROUTE AUTHENTICATION FUNCTIONS
+--
+
+-- Check if user is admin of institution
+CREATE OR REPLACE FUNCTION is_institution_admin(_user_id integer, _institution_id integer)
+ RETURNS boolean AS $$
+
+    SELECT count(1) > 0
+    FROM institution_users as iu
+    INNER JOIN institutions as i
+        ON institution_rid = institution_uid
+    WHERE iu.user_rid = _user_id
+        AND institution_rid = _institution_id
+        AND role_rid = 1
+        AND archived = FALSE
+
+$$ LANGUAGE SQL;
+
+-- Check if user has collection rights (read rights) for the project
+CREATE OR REPLACE FUNCTION can_user_collect_project(_user_id integer, _project_id integer)
+ RETURNS boolean AS $$
+
+    SELECT count(1) > 0
+    FROM projects as p
+    LEFT JOIN institution_users iu
+        ON p.institution_rid = iu.institution_rid
+        AND user_rid = _user_id
+    LEFT JOIN roles r
+        ON iu.role_rid = role_uid
+    WHERE project_uid = _project_id
+        AND ((r.title = 'admin' AND p.availability <> 'archived')
+            OR (r.title = 'member'
+                AND p.privacy_level IN ('public', 'institution', 'users')
+                AND p.availability = 'published')
+            OR (_user_id > 0
+                AND p.privacy_level IN ('public', 'users')
+                AND p.availability = 'published')
+            OR (p.privacy_level IN ('public')
+                AND p.availability = 'published'))
+
+$$ LANGUAGE SQL;
+
+-- Check if user has modify rights for the project
+CREATE OR REPLACE FUNCTION can_user_edit_project(_user_id integer, _project_id integer)
+ RETURNS boolean AS $$
+
+    SELECT count(1) > 0
+    FROM projects as p
+    LEFT JOIN institution_users iu
+        ON p.institution_rid = iu.institution_rid
+        AND user_rid = _user_id
+    LEFT JOIN roles r
+        ON iu.role_rid = role_uid
+    WHERE project_uid = _project_id
+        AND (r.title = 'admin' AND p.availability <> 'archived')
+
+$$ LANGUAGE SQL;
+
+--
 --  USER FUNCTIONS
 --
 
@@ -292,7 +351,7 @@ CREATE OR REPLACE FUNCTION select_institution_by_id(_institution_id integer, _us
         encode(logo_data, 'base64'),
         url,
         description,
-        (SELECT count(*) > 0 FROM institution_users WHERE user_rid = _user_id AND role_rid = 1)
+        (SELECT is_institution_admin(_user_id, _institution_id))
     FROM institutions
     WHERE institution_uid = _institution_id
         AND archived = false
@@ -374,66 +433,5 @@ CREATE OR REPLACE FUNCTION update_institution_user_role(_institution_id integer,
         AND user_rid = _user_id
         AND title = _role
     RETURNING inst_user_uid
-
-$$ LANGUAGE SQL;
-
---
--- ROUTE AUTHENTICATION FUNCTIONS
---
-
--- Check if user is admin of institution
-CREATE OR REPLACE FUNCTION is_institution_admin(_user_id integer, _institution_id integer)
- RETURNS boolean AS $$
-
-    SELECT count(1) > 0
-    FROM institution_users as iu
-    INNER JOIN roles as r
-        ON iu.role_rid = role_uid
-    INNER JOIN institutions as i
-        ON institution_rid = institution_uid
-    WHERE iu.user_rid = _user_id
-        AND institution_rid = _institution_id
-        AND title = 'admin'
-        AND archived = FALSE
-
-$$ LANGUAGE SQL;
-
--- Check if user has collection rights (read rights) for the project
-CREATE OR REPLACE FUNCTION can_user_collect_project(_user_id integer, _project_id integer)
- RETURNS boolean AS $$
-
-    SELECT count(1) > 0
-    FROM projects as p
-    LEFT JOIN institution_users iu
-        ON p.institution_rid = iu.institution_rid
-        AND user_rid = _user_id
-    LEFT JOIN roles r
-        ON iu.role_rid = role_uid
-    WHERE project_uid = _project_id
-        AND ((r.title = 'admin' AND p.availability <> 'archived')
-            OR (r.title = 'member'
-                AND p.privacy_level IN ('public', 'institution', 'users')
-                AND p.availability = 'published')
-            OR (_user_id > 0
-                AND p.privacy_level IN ('public', 'users')
-                AND p.availability = 'published')
-            OR (p.privacy_level IN ('public')
-                AND p.availability = 'published'))
-
-$$ LANGUAGE SQL;
-
--- Check if user has modify rights for the project
-CREATE OR REPLACE FUNCTION can_user_edit_project(_user_id integer, _project_id integer)
- RETURNS boolean AS $$
-
-    SELECT count(1) > 0
-    FROM projects as p
-    LEFT JOIN institution_users iu
-        ON p.institution_rid = iu.institution_rid
-        AND user_rid = _user_id
-    LEFT JOIN roles r
-        ON iu.role_rid = role_uid
-    WHERE project_uid = _project_id
-        AND (r.title = 'admin' AND p.availability <> 'archived')
 
 $$ LANGUAGE SQL;


### PR DESCRIPTION
Fixes #1100 

The SQL query for getting institution information incorrectly had institution_admin if the user was an admin of any institution.