### PR TITLE
Add TOS Page - Closes #1153

### DIFF
--- a/src/clj/org/openforis/ceo/routing.clj
+++ b/src/clj/org/openforis/ceo/routing.clj
@@ -46,6 +46,7 @@
                                               :auth-type   :admin
                                               :auth-action :redirect}
    [:get  "/support"]                        {:handler     (render-page "/support")}
+   [:get  "/terms"]                          {:handler     (render-page "/terms")}
    [:get  "/widget-layout-editor"]           {:handler     (render-page "/widget-layout-editor")
                                               :auth-type   :admin
                                               :auth-action :redirect}

--- a/src/clj/org/openforis/ceo/routing.clj
+++ b/src/clj/org/openforis/ceo/routing.clj
@@ -46,7 +46,7 @@
                                               :auth-type   :admin
                                               :auth-action :redirect}
    [:get  "/support"]                        {:handler     (render-page "/support")}
-   [:get  "/terms"]                          {:handler     (render-page "/terms")}
+   [:get  "/terms-of-service"]               {:handler     (render-page "/terms-of-service")}
    [:get  "/widget-layout-editor"]           {:handler     (render-page "/widget-layout-editor")
                                               :auth-type   :admin
                                               :auth-action :redirect}

--- a/src/js/about.js
+++ b/src/js/about.js
@@ -24,30 +24,9 @@ function About() {
                     shared through the Open Foris Initiative of the Food And
                     Agriculture Organization of the United Nations.
                 </p>
-                <h1>Disclaimers</h1>
+                <p>Please view our <a href="/terms">Terms of Service here.</a></p>
                 <p>
-                    The SERVIR Network, NASA, and USAID make no express or
-                    implied warranty of this application and associated data
-                    as to the merchantability or fitness for a particular
-                    purpose. Neither the US Government nor its contractors
-                    shall be liable for special, consequential or incidental
-                    damages attributed to this application and associated
-                    data.
-                </p>
-                <p>
-                    FAO declines all responsibility for errors or deficiencies
-                    in the database or software or in the documentation
-                    accompanying it, for program maintenance and upgrading as
-                    well as for any damage that may arise from them.
-                </p>
-                <p className="mb-4">
-                    FAO also declines any responsibility for updating the data
-                    and assumes no responsibility for errors and omissions in
-                    the data provided. Users are, however, kindly asked to
-                    report any errors or deficiencies in this product.
-                </p>
-                <p>
-                    Please access
+                    Please access&nbsp;
                     <a
                         href="http://www.openforis.org/tools/sepal.html"
                         target="_blank"
@@ -55,7 +34,7 @@ function About() {
                     >
                         OpenForis-SEPAL
                     </a>
-                    for more information about SEPAL.
+                    &nbsp;for more information about SEPAL.
                 </p>
                 <LogoBanner/>
             </div>

--- a/src/js/about.js
+++ b/src/js/about.js
@@ -24,7 +24,7 @@ function About() {
                     shared through the Open Foris Initiative of the Food And
                     Agriculture Organization of the United Nations.
                 </p>
-                <p>Please view our <a href="/terms">Terms of Service here.</a></p>
+                <p>Please view our <a href="/terms-of-service">Terms of Service here.</a></p>
                 <p>
                     Please access&nbsp;
                     <a

--- a/src/js/support.js
+++ b/src/js/support.js
@@ -71,6 +71,10 @@ function Support() {
                     <p className="text-center col-lg-10 offset-lg-1 mb-4">
                         Please access the <a href="/geo-dash/geo-dash-help" target="_blank" rel="noreferrer">Geo-Dash Help Center</a> for details on configuring the Geo-Dash for your project.
                     </p>
+                    <h1>Terms of Service</h1>
+                    <p className="text-center col-lg-10 offset-lg-1 mb-4">
+                        Please view our <a href="/terms">Terms of Service here</a>
+                    </p>
                 </div>
             </div>
         </section>

--- a/src/js/support.js
+++ b/src/js/support.js
@@ -73,7 +73,7 @@ function Support() {
                     </p>
                     <h1>Terms of Service</h1>
                     <p className="text-center col-lg-10 offset-lg-1 mb-4">
-                        Please view our <a href="/terms">Terms of Service here</a>
+                        Please view our <a href="/terms-of-service">Terms of Service here</a>
                     </p>
                 </div>
             </div>

--- a/src/js/terms-of-service.js
+++ b/src/js/terms-of-service.js
@@ -1,0 +1,70 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import {NavigationBar} from "./components/PageComponents";
+
+function TermsOfService() {
+    return (
+        <section id="about" className="container pt-3">
+            <div className="col-xl-8 offset-xl-2 col-lg-10 justify-content-center">
+                <h1>Collect Earth Online Terms of Service</h1>
+
+                <h2>Disclaimers</h2>
+                <p>
+                    The SERVIR Network, NASA, and USAID make no express or
+                    implied warranty of this application and associated data
+                    as to the merchantability or fitness for a particular
+                    purpose. Neither the US Government nor its contractors
+                    shall be liable for special, consequential or incidental
+                    damages attributed to this application and associated
+                    data.
+                </p>
+                <p>
+                    FAO declines all responsibility for errors or deficiencies
+                    in the database or software or in the documentation
+                    accompanying it, for program maintenance and upgrading as
+                    well as for any damage that may arise from them.
+                </p>
+                <p className="mb-4">
+                    FAO also declines any responsibility for updating the data
+                    and assumes no responsibility for errors and omissions in
+                    the data provided. Users are, however, kindly asked to
+                    report any errors or deficiencies in this product.
+                </p>
+
+                <h2>Data Retention Policy</h2>
+                <p>
+                    Collect Earth Online makes no guarentee of retention of data.  Please ensure that you keep local copies of any information used to create a project and any results downloaded.
+                </p>
+                <p>
+                    Specific clean up activities are described below:
+                </p>
+                <ul>
+                    <li>Projects will be removed when the survey has not been collected in a certain amount of time.
+                        <ul>
+                            <li>The project has been inactive for 180 days, and the phase is not published, and the number of plots collected is under 5%</li>
+                            <li>The project has been inactive for 270 days, and the number of plots collected is under 5%</li>
+                            <li>The project has been inactive for 730 days, and the number of plots collected is under 20%</li>
+                        </ul>
+                    </li>
+                    <li>Institutions will be removed when there contain no Projects
+                        <ul>
+                            <li>Institutions with no projects, and was created over 180 days ago</li>
+                        </ul>
+                    </li>
+                </ul>
+                <p>
+                    Admin discretion can be used at any point for projects or institutions that are created with malformed or test data.
+                </p>
+            </div>
+        </section>
+    );
+}
+
+export function pageInit(args) {
+    ReactDOM.render(
+        <NavigationBar userName={args.userName} userId={args.userId}>
+            <TermsOfService/>
+        </NavigationBar>,
+        document.getElementById("app")
+    );
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,7 +28,7 @@ module.exports = env => ({
         support                : path.resolve(__dirname, "src/js/support.js"),
         unsubscribeMailingList : path.resolve(__dirname, "src/js/unsubscribe-mailing-list.js"),
         widgetLayoutEditor     : path.resolve(__dirname, "src/js/widget-layout-editor.js"),
-        terms                  : path.resolve(__dirname, "src/js/terms-of-service.js"),
+        termsOfService         : path.resolve(__dirname, "src/js/terms-of-service.js"),
     },
     output: {
         path: path.resolve(__dirname, outdir),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,6 +28,7 @@ module.exports = env => ({
         support                : path.resolve(__dirname, "src/js/support.js"),
         unsubscribeMailingList : path.resolve(__dirname, "src/js/unsubscribe-mailing-list.js"),
         widgetLayoutEditor     : path.resolve(__dirname, "src/js/widget-layout-editor.js"),
+        terms                  : path.resolve(__dirname, "src/js/terms-of-service.js"),
     },
     output: {
         path: path.resolve(__dirname, outdir),


### PR DESCRIPTION
### Purpose
- Adds Terms of Service page (`/terms-of-service`)
- Links TOS page from About/Support pages
- Moved 'Disclaimer' from About page to TOS page
- Added Data Retention policy

### Related Issues
Closes #1153
