### PR TITLE
Move all rules to modal

### DIFF
--- a/src/js/components/SurveyQuestionRules.js
+++ b/src/js/components/SurveyQuestionRules.js
@@ -1,6 +1,7 @@
 import React from "react";
 
 import SvgIcon from "./SvgIcon";
+import {pluralize} from "../utils/generalUtils";
 
 class SurveyRulesModal extends React.Component {
     constructor(props) {
@@ -21,7 +22,7 @@ class SurveyRulesModal extends React.Component {
                 >
                     <SvgIcon icon="rule" size="1.5rem"/>
                     <div className="tooltip_content survey_tree">
-                        {`This question has ${rules.length} rules. Click to see the rule list.`}
+                        {`This question has ${rules.length} ${pluralize(rules.length, "rule", "rules")}. Click to see the rule list.`}
                     </div>
                 </button>
                 <div
@@ -70,18 +71,6 @@ class SurveyRulesModal extends React.Component {
     }
 }
 
-function SurveyRulesTooltip({rules}) {
-    return (
-        <div className="text-center btn btn-outline-lightgreen mr-1 tooltip_wrapper">
-            <SvgIcon icon="rule" size="1.5rem"/>
-            <ul className="tooltip_content survey_tree">{rules}</ul>
-        </div>
-    );
-}
-
 export default function SurveyQuestionRules({rules}) {
-    return rules.length > 0 && (
-        rules.length <= 2
-            ? <SurveyRulesTooltip rules={rules}/>
-            : <SurveyRulesModal rules={rules}/>);
+    return rules.length > 0 && <SurveyRulesModal rules={rules}/>;
 }

--- a/src/js/components/SurveyQuestionRules.js
+++ b/src/js/components/SurveyQuestionRules.js
@@ -3,7 +3,7 @@ import React from "react";
 import SvgIcon from "./SvgIcon";
 import {pluralize} from "../utils/generalUtils";
 
-class SurveyRulesModal extends React.Component {
+export default class SurveyQuestionRules extends React.Component {
     constructor(props) {
         super(props);
         this.state = {showModal: false};
@@ -14,63 +14,62 @@ class SurveyRulesModal extends React.Component {
         const {rules} = this.props;
 
         return (
-            <>
-                <button
-                    className="text-center btn btn-outline-lightgreen mr-1 tooltip_wrapper"
-                    onClick={() => this.setState({showModal: true})}
-                    type="button"
-                >
-                    <SvgIcon icon="rule" size="1.5rem"/>
-                    <div className="tooltip_content survey_tree">
-                        {`This question has ${rules.length} ${pluralize(rules.length, "rule", "rules")}. Click to see the rule list.`}
-                    </div>
-                </button>
-                <div
-                    aria-hidden="true"
-                    className="modal fade show"
-                    onClick={() => this.setState({showModal: false})}
-                    role="dialog"
-                    style={{display: (showModal ? "block" : "none"), background: "rgba(0,0,0,0.3)"}}
-                    tabIndex="-1"
-                >
-                    <div className="modal-dialog" role="document">
-                        <div className="modal-content text-left" onClick={e => e.stopPropagation()}>
-                            <div className="modal-header" >
-                                <h5 className="modal-title">
-                                    Survey Rules
-                                </h5>
-                                <button
-                                    aria-label="Close"
-                                    className="close"
-                                    data-dismiss="modal"
-                                    onClick={() => this.setState({showModal: false})}
-                                    type="button"
-                                >
-                                    <span aria-hidden="true">
-                                        <SvgIcon icon="close" size="1.25rem"/>
-                                    </span>
-                                </button>
-                            </div>
-                            <div className="modal-body text-left">
-                                <ul>{rules}</ul>
-                            </div>
-                            <div className="modal-footer">
-                                <button
-                                    className="btn btn-secondary"
-                                    onClick={() => this.setState({showModal: false})}
-                                    type="button"
-                                >
-                                    Close
-                                </button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </>
+            rules.length > 0
+              && (
+                  <>
+                      <button
+                          className="text-center btn btn-outline-lightgreen mr-1 tooltip_wrapper"
+                          onClick={() => this.setState({showModal: true})}
+                          type="button"
+                      >
+                          <SvgIcon icon="rule" size="1.5rem"/>
+                          <div className="tooltip_content survey_tree">
+                              {`This question has ${rules.length} ${pluralize(rules.length, "rule", "rules")}. Click to see the rule list.`}
+                          </div>
+                      </button>
+                      <div
+                          aria-hidden="true"
+                          className="modal fade show"
+                          onClick={() => this.setState({showModal: false})}
+                          role="dialog"
+                          style={{display: (showModal ? "block" : "none"), background: "rgba(0,0,0,0.3)"}}
+                          tabIndex="-1"
+                      >
+                          <div className="modal-dialog" role="document">
+                              <div className="modal-content text-left" onClick={e => e.stopPropagation()}>
+                                  <div className="modal-header" >
+                                      <h5 className="modal-title">
+                                      Survey Rules
+                                      </h5>
+                                      <button
+                                          aria-label="Close"
+                                          className="close"
+                                          data-dismiss="modal"
+                                          onClick={() => this.setState({showModal: false})}
+                                          type="button"
+                                      >
+                                          <span aria-hidden="true">
+                                              <SvgIcon icon="close" size="1.25rem"/>
+                                          </span>
+                                      </button>
+                                  </div>
+                                  <div className="modal-body text-left">
+                                      <ul>{rules}</ul>
+                                  </div>
+                                  <div className="modal-footer">
+                                      <button
+                                          className="btn btn-secondary"
+                                          onClick={() => this.setState({showModal: false})}
+                                          type="button"
+                                      >
+                                      Close
+                                      </button>
+                                  </div>
+                              </div>
+                          </div>
+                      </div>
+                  </>
+              )
         );
     }
-}
-
-export default function SurveyQuestionRules({rules}) {
-    return rules.length > 0 && <SurveyRulesModal rules={rules}/>;
 }

--- a/src/js/utils/generalUtils.js
+++ b/src/js/utils/generalUtils.js
@@ -153,3 +153,7 @@ export function invertColor(hex) {
     const padZero = str => (new Array(2).join("0") + str).slice(-2);
     return "#" + padZero(r) + padZero(g) + padZero(b);
 }
+
+export function pluralize(number, single, plural) {
+    return (number === 1) ? single : plural;
+}


### PR DESCRIPTION
### Purpose
Move displaying rules to the rules modal to prevent very long tooltips.

### Related Issues
Fix #1190

### Screenshots

2+ Rules
![Screen Shot 2021-04-16 at 11 23 15 AM](https://user-images.githubusercontent.com/1829313/115067697-248e5700-9ea6-11eb-9ead-9c891eab5255.png)

1 Rule:
![Screen Shot 2021-04-16 at 11 23 38 AM](https://user-images.githubusercontent.com/1829313/115067755-340da000-9ea6-11eb-85a1-28bd99699e7f.png)

No Rules:
![Screen Shot 2021-04-16 at 11 24 22 AM](https://user-images.githubusercontent.com/1829313/115067835-4c7dba80-9ea6-11eb-929b-4dc9ea3aaad5.png)

