### PR TITLE
Add 'Plot' diameter/width when creating project

### DIFF
--- a/src/js/project/PlotDesign.js
+++ b/src/js/project/PlotDesign.js
@@ -244,7 +244,7 @@ export class PlotDesign extends React.Component {
     render() {
         const {plotDistribution, plotShape} = this.context;
         const totalPlots = this.props.getTotalPlots();
-        const plotUnits = plotShape === "circle" ? "Diameter (m)" : "Width (m)";
+        const plotUnits = plotShape === "circle" ? "Plot diameter (m)" : "Plot width (m)";
 
         const plotOptions = {
             random: {


### PR DESCRIPTION
### Purpose
Adds "Plot" to width / diameter when creating project to reduce confusion

### Related Issues
Fix #1071
