### PR TITLE
Add 'Additional Imagery' to Imagery selection

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -119,7 +119,7 @@ h1, h2 {
 h1 {font-size: 2rem;}
 h2 {font-size: 1.5rem;}
 h3 {font-size: 1rem;}
-h4 {font-size: 0.5rem;}
+h4 {font-size: 0.8rem;}
 
 /**********/
 /* Colors */

--- a/src/js/project/ImagerySelection.js
+++ b/src/js/project/ImagerySelection.js
@@ -43,8 +43,9 @@ export function ImagerySelection() {
                                     <option key={uid} value={imagery.id}>{imagery.title}</option>)}
                             </select>
                         </div>
+                        <h3>Additional Imagery</h3>
                         <div className="form-group">
-                            <h3>Public Imagery</h3>
+                            <h3 style={{fontSize: "0.8rem"}}>Public Imagery</h3>
                             {renderImageryRow(
                                 institutionImagery.filter(imagery => imagery.visibility === "public"),
                                 imageryId,
@@ -52,7 +53,9 @@ export function ImagerySelection() {
                                 setProjectDetails,
                                 "public"
                             )}
-                            <h3>Private Institution Imagery*</h3>
+                        </div>
+                        <div className="form-group">
+                            <h3 style={{fontSize: "0.8rem"}}>Private Institution Imagery*</h3>
                             {renderImageryRow(
                                 institutionImagery.filter(imagery => imagery.visibility === "private"),
                                 imageryId,

--- a/src/js/project/ImagerySelection.js
+++ b/src/js/project/ImagerySelection.js
@@ -45,7 +45,7 @@ export function ImagerySelection() {
                         </div>
                         <h3>Additional Imagery</h3>
                         <div className="form-group">
-                            <h3 style={{fontSize: "0.8rem"}}>Public Imagery</h3>
+                            <h4>Public Imagery</h4>
                             {renderImageryRow(
                                 institutionImagery.filter(imagery => imagery.visibility === "public"),
                                 imageryId,
@@ -55,7 +55,7 @@ export function ImagerySelection() {
                             )}
                         </div>
                         <div className="form-group">
-                            <h3 style={{fontSize: "0.8rem"}}>Private Institution Imagery*</h3>
+                            <h4>Private Institution Imagery*</h4>
                             {renderImageryRow(
                                 institutionImagery.filter(imagery => imagery.visibility === "private"),
                                 imageryId,


### PR DESCRIPTION
### Purpose
Adds 'Additional Imagery' to separate from the Default Imagery selector. Fixes up the spacing.

### Related Issues
Fix #1070

### Screenshots
<img width="633" alt="Screen Shot 2021-04-16 at 3 15 36 PM" src="https://user-images.githubusercontent.com/1829313/115089203-9a0a1f80-9ec6-11eb-99bb-e34b9f7cd846.png">