### PR TITLE
AOI Map - Hold CMD for Mac OS

### DIFF
--- a/src/js/project/AOIMap.js
+++ b/src/js/project/AOIMap.js
@@ -1,6 +1,7 @@
 import React from "react";
 
 import {mercator} from "../utils/mercator";
+import {detectMacOS} from "../utils/generalUtils";
 
 export default class AOIMap extends React.Component {
     constructor(props) {
@@ -115,7 +116,7 @@ export default class AOIMap extends React.Component {
             <div id="project-map" style={{height: "25rem", width: "100%"}}>
                 {this.props.canDrag && (
                     <div className="col small text-center mb-2">
-                        Hold CTRL and click-and-drag a bounding box on the map
+                        {`Hold ${detectMacOS() ? "CMD ⌘" : "CTRL"} and click-and-drag a bounding box on the map`}
                     </div>
                 )}
             </div>

--- a/src/js/utils/generalUtils.js
+++ b/src/js/utils/generalUtils.js
@@ -157,3 +157,8 @@ export function invertColor(hex) {
 export function pluralize(number, single, plural) {
     return (number === 1) ? single : plural;
 }
+
+export function detectMacOS() {
+    const macRegex = /(Mac OS X|MacPPC|MacIntel|Mac_PowerPC|Macintosh)/;
+    return macRegex.test(window.navigator.userAgent);
+}

--- a/src/js/utils/generalUtils.js
+++ b/src/js/utils/generalUtils.js
@@ -159,6 +159,6 @@ export function pluralize(number, single, plural) {
 }
 
 export function detectMacOS() {
-    const macRegex = /(Mac OS X|MacPPC|MacIntel|Mac_PowerPC|Macintosh)/;
+    const macRegex = /Mac/i;
     return macRegex.test(window.navigator.userAgent);
 }


### PR DESCRIPTION
### Purpose
When a User is on a Mac, the AOI Map screen instructs the user to "Hold CMD to select an Area of Interest"

### Related Issues
Fix #1096
