### PR TITLE
unavailable image asset fix and available bands refresh button

### DIFF
--- a/src/js/widgetLayoutEditor.js
+++ b/src/js/widgetLayoutEditor.js
@@ -287,8 +287,8 @@ class WidgetLayoutEditor extends React.PureComponent {
         if (value !== "") {
             const postObject = {
                 path: "getAvailableBands",
+                ...(isCollection ? {imageCollection: value} : {image: value}),
             };
-            if (isCollection) postObject["imageCollection"] = value; else postObject["image"] = value;
             fetch("/geo-dash/gateway-request", {
                 method: "POST",
                 headers: {

--- a/src/js/widgetLayoutEditor.js
+++ b/src/js/widgetLayoutEditor.js
@@ -1289,21 +1289,15 @@ class WidgetLayoutEditor extends React.PureComponent {
             </div>
         ) : "");
 
-    getAvailableBandsControl = isCollection => <React.Fragment>
-        <div style={{display: "flex", justifyContent: "space-between", alignItems: "center"}}>
-            <label>Available Bands</label>
-            <button type="button" className="btn btn-sm btn-secondary mb-1" onClick={() => this.getBandsFromGateway(false, isCollection)}>Refresh</button>
-        </div>
-        <label>{this.state.availableBands || "Click on refresh to see the Available Bands."}</label>
-    </React.Fragment>;
-
-    getAvailableBandsControlDual = isCollection => <React.Fragment>
-        <div style={{display: "flex", justifyContent: "space-between", alignItems: "center"}}>
-            <label>Available Bands</label>
-            <button type="button" className="btn btn-sm btn-secondary mb-1" onClick={() => this.getBandsFromGateway(true, isCollection)}>Refresh</button>
-        </div>
-        <label>{this.state.availableBandsDual || "Click on refresh to see the Available Bands."}</label>
-    </React.Fragment>;
+    getAvailableBandsControl = (isDual, isCollection) => (
+        <>
+            <div style={{display: "flex", justifyContent: "space-between", alignItems: "center"}}>
+                <label>Available Bands</label>
+                <button className="btn btn-sm btn-secondary mb-1" onClick={() => this.getBandsFromGateway(isDual, isCollection)} type="button">Refresh</button>
+            </div>
+            <label>{this.state.availableBands || "Click on refresh to see the Available Bands."}</label>
+        </>
+    );
 
     getDataForm = () => {
         if (this.state.selectedWidgetType === "ImageElevation") {
@@ -1382,24 +1376,26 @@ class WidgetLayoutEditor extends React.PureComponent {
                 ? ["GEE Image Asset", "LANDSAT/LC8_L1T_TOA/LC81290502015036LGN00"]
                 : ["GEE Collection Image Asset", "LANDSAT/LC8_L1T_TOA"];
             const isCollection = this.state.selectedWidgetType === "imageCollectionAsset";
-            return <React.Fragment>
-                {this.getTitleBlock()}
-                <div className="form-group">
-                    <label htmlFor="imageCollection">{label}</label>
-                    <input
-                        type="text"
-                        name="imageCollection"
-                        id="imageCollection"
-                        placeholder={placeholder}
-                        value={this.state.imageCollection}
-                        className="form-control"
-                        onChange={this.onImageCollectionChange}
-                    />
-                </div>
-                {this.getAvailableBandsControl(isCollection)}
-                {this.getImageParamsBlock()}
-                {this.getInstitutionImageryInfo()}
-            </React.Fragment>;
+            return (
+                <>
+                    {this.getTitleBlock()}
+                    <div className="form-group">
+                        <label htmlFor="imageCollection">{label}</label>
+                        <input
+                            className="form-control"
+                            id="imageCollection"
+                            name="imageCollection"
+                            onChange={this.onImageCollectionChange}
+                            placeholder={placeholder}
+                            type="text"
+                            value={this.state.imageCollection}
+                        />
+                    </div>
+                    {this.getAvailableBandsControl(false, isCollection)}
+                    {this.getImageParamsBlock()}
+                    {this.getInstitutionImageryInfo()}
+                </>
+            );
         } else if (this.state.selectedDataType === "-1") {
             return "";
         } else if (["LANDSAT5", "LANDSAT7", "LANDSAT8", "Sentinel2"].includes(this.state.selectedDataType) && this.state.wizardStep === 1) {
@@ -1411,7 +1407,7 @@ class WidgetLayoutEditor extends React.PureComponent {
                     {this.getDateRangeControl()}
                     {this.getDualImageCollectionTimeSpanOption()}
                     {this.getDualLayerDateRangeControl()}
-                    {this.getAvailableBandsControl(true)}
+                    {this.getAvailableBandsControl(false, true)}
                     <div className="form-group">
                         <label htmlFor="widgetBands">Bands</label>
                         <input
@@ -1487,7 +1483,7 @@ class WidgetLayoutEditor extends React.PureComponent {
                             value={this.state.endDateDual}
                         />
                     </div>
-                    {this.getAvailableBandsControlDual(true)}
+                    {this.getAvailableBandsControl(true, true)}
                     <div className="form-group">
                         <label htmlFor="widgetBands">Bands</label>
                         <input
@@ -1545,11 +1541,12 @@ class WidgetLayoutEditor extends React.PureComponent {
         } else if (((this.state.selectedDataType === "imageCollectionAsset" || this.state.selectedDataType === "imageAsset")
                         && this.state.selectedWidgetType === "DualImageCollection")
                         && this.state.wizardStep === 1) {
-                const [label, placeholder] = this.state.selectedDataType === "imageAsset"
-                    ? ["GEE Image Asset", "LANDSAT/LC8_L1T_TOA/LC81290502015036LGN00"]
-                    : ["GEE Collection Image Asset", "LANDSAT/LC8_L1T_TOA"];
-                const isCollection = this.state.selectedDataType === "imageCollectionAsset";
-                return <>
+            const [label, placeholder] = this.state.selectedDataType === "imageAsset"
+                ? ["GEE Image Asset", "LANDSAT/LC8_L1T_TOA/LC81290502015036LGN00"]
+                : ["GEE Collection Image Asset", "LANDSAT/LC8_L1T_TOA"];
+            const isCollection = this.state.selectedDataType === "imageCollectionAsset";
+            return (
+                <>
                     {this.getTitleBlock()}
                     <div className="form-group">
                         <label htmlFor="imageCollection">{label}</label>
@@ -1563,7 +1560,7 @@ class WidgetLayoutEditor extends React.PureComponent {
                             value={this.state.imageCollection}
                         />
                     </div>
-                    {this.getAvailableBandsControl(isCollection)}
+                    {this.getAvailableBandsControl(false, isCollection)}
                     <div className="form-group">
                         <label htmlFor="imageParams">Image Parameters (json format)</label>
                         <textarea
@@ -1577,28 +1574,30 @@ class WidgetLayoutEditor extends React.PureComponent {
                     </div>
                     {this.getInstitutionImageryInfo()}
                     {this.getNextStepButton()}
-                </>;
+                </>
+            );
         } else if (((this.state.selectedDataTypeDual === "imageCollectionAsset" || this.state.selectedDataTypeDual === "imageAsset")
                         && this.state.selectedWidgetType === "DualImageCollection")
                         && this.state.wizardStep === 2) {
-                const [label, placeholder] = this.state.selectedDataTypeDual === "imageAsset"
-                    ? ["GEE Image Asset", "LANDSAT/LC8_L1T_TOA/LC81290502015036LGN00"]
-                    : ["GEE Collection Image Asset", "LANDSAT/LC8_L1T_TOA"];
-                const isCollection = this.state.selectedDataTypeDual === "imageCollectionAsset";
-                return <>
+            const [label, placeholder] = this.state.selectedDataTypeDual === "imageAsset"
+                ? ["GEE Image Asset", "LANDSAT/LC8_L1T_TOA/LC81290502015036LGN00"]
+                : ["GEE Collection Image Asset", "LANDSAT/LC8_L1T_TOA"];
+            const isCollection = this.state.selectedDataTypeDual === "imageCollectionAsset";
+            return (
+                <>
                     <div className="form-group">
                         <label htmlFor="imageCollection">{label}</label>
                         <input
                             className="form-control"
                             id="imageCollection"
                             name="imageCollection"
-                            type="text"
                             onChange={this.onImageCollectionChangeDual}
                             placeholder={placeholder}
+                            type="text"
                             value={this.state.imageCollectionDual}
                         />
                     </div>
-                    {this.getAvailableBandsControlDual(isCollection)}
+                    {this.getAvailableBandsControl(true, isCollection)}
                     <div className="form-group">
                         <label htmlFor="imageParams">Image Parameters (json format)</label>
                         <textarea
@@ -1619,7 +1618,8 @@ class WidgetLayoutEditor extends React.PureComponent {
                     >
                         &lArr; Step 1
                     </button>
-                </>;
+                </>
+            );
         } else if ((this.state.selectedWidgetType === "ImageCollection"
                         || this.state.selectedWidgetType === "DualImageCollection")
                         && this.state.selectedDataType === "Custom"
@@ -1639,7 +1639,7 @@ class WidgetLayoutEditor extends React.PureComponent {
                             value={this.state.imageCollection}
                         />
                     </div>
-                    {this.getAvailableBandsControl(true)}
+                    {this.getAvailableBandsControl(false, true)}
                     <div className="form-group">
                         <label htmlFor="imageParams">Image Parameters (json format)</label>
                         <textarea
@@ -1676,7 +1676,7 @@ class WidgetLayoutEditor extends React.PureComponent {
                             value={this.state.imageCollectionDual}
                         />
                     </div>
-                    {this.getAvailableBandsControlDual(true)}
+                    {this.getAvailableBandsControl(true, true)}
                     <div className="form-group">
                         <label htmlFor="imageParams">Image Parameters (json format)</label>
                         <textarea
@@ -1817,7 +1817,7 @@ class WidgetLayoutEditor extends React.PureComponent {
                             value={this.state.imageCollection}
                         />
                     </div>
-                    {this.getAvailableBandsControl(true)}
+                    {this.getAvailableBandsControl(false, true)}
                     <div className="form-group">
                         <label htmlFor="graphBand">Band to graph</label>
                         <input

--- a/src/js/widgetLayoutEditor.js
+++ b/src/js/widgetLayoutEditor.js
@@ -1295,7 +1295,10 @@ class WidgetLayoutEditor extends React.PureComponent {
                 <label>Available Bands</label>
                 <button className="btn btn-sm btn-secondary mb-1" onClick={() => this.getBandsFromGateway(isDual, isCollection)} type="button">Refresh</button>
             </div>
-            <label>{this.state.availableBands || "Click on refresh to see the Available Bands."}</label>
+            <label>{isDual
+                ? this.state.availableBandsDual || "Click on refresh to see the Available Bands."
+                : this.state.availableBands || "Click on refresh to see the Available Bands."}
+            </label>
         </>
     );
 

--- a/src/js/widgetLayoutEditor.js
+++ b/src/js/widgetLayoutEditor.js
@@ -1396,7 +1396,7 @@ class WidgetLayoutEditor extends React.PureComponent {
                         onChange={this.onImageCollectionChange}
                     />
                 </div>
-                {this.getAvailableBandsControl(false, isCollection)}
+                {this.getAvailableBandsControl(isCollection)}
                 {this.getImageParamsBlock()}
                 {this.getInstitutionImageryInfo()}
             </React.Fragment>;


### PR DESCRIPTION
fix #1189

Available Bands was an hidden row, now it is always visible.

GeoDash didn't know the difference between an Image Asset or an Image Collection Asset, this caused errors when it requested for the Available Bands.

Instead of performing an http request to GEEG at onChange time, now the user have to click on the Refresh button to get the available bands for a specific Image Asset or Image Collection Asset.