### PR TITLE
Dashboard Total Plots (Fix #1212)

### DIFF
--- a/src/js/institutionDashboard.js
+++ b/src/js/institutionDashboard.js
@@ -35,7 +35,7 @@ class InstitutionDashboard extends React.Component {
                     details.push({
                         id: proj.id,
                         name: proj.name,
-                        numPlots: proj.numPlots,
+                        numPlots: data.unanalyzedPlots + data.analyzedPlots,
                         unanalyzedPlots: data.unanalyzedPlots,
                         analyzedPlots: data.analyzedPlots,
                         flaggedPlots: data.flaggedPlots,


### PR DESCRIPTION
### Purpose
`numProjects` was removed from the `get-institution-projects` endpoint, so it was not displaying. For the time being, sum analyzed and unanalyzed plots to get total plots.

### Related Issues
Fix #1212
