### PR TITLE
Format Survey Rules

### DIFF
--- a/src/js/components/SurveyQuestionRules.js
+++ b/src/js/components/SurveyQuestionRules.js
@@ -1,7 +1,78 @@
 import React from "react";
 
 import SvgIcon from "./SvgIcon";
-import {pluralize} from "../utils/generalUtils";
+import {pluralize, truncate} from "../utils/generalUtils";
+
+/**
+ * Helper Components
+ */
+function Badge({children}) {
+    return (
+        <div className="badge badge-light">
+            {children}
+        </div>
+    );
+}
+
+function Pre({children}) {
+    return (
+        <pre style={{display: "inline"}}>
+            {children}
+        </pre>
+    );
+}
+
+function EqualToSumRule({questionsText, validSum}) {
+    const truncjoin = qs => qs.map(q => truncate(q, 15)).join(", ");
+    return (
+        <div className="mb-3">
+            <strong>Sum of Answers</strong>
+            <br/>
+            Answers to <i>{truncjoin(questionsText)}</i> should sum up to <Pre>{validSum}.</Pre>
+        </div>
+    );
+}
+
+function IncompatibleRule({answerText1, answerText2, questionText1, questionText2}) {
+    return (
+        <div className="mb-3">
+            <strong>Incompatible Answers</strong>
+            <br/>
+            Answer <Badge>{answerText1}</Badge> from <i>{truncate(questionText1, 15)}</i> is
+            incompatible with <Badge>{answerText2}</Badge> from <i>{truncate(questionText2, 15)}</i>
+        </div>
+    );
+}
+
+function MatchingSumsRule({questionSetText1, questionSetText2}) {
+    const truncjoin = qs => qs.map(q => truncate(q, 15)).join(", ");
+    return (
+        <div className="mb-3">
+            <strong>Matching Sums</strong>
+            <br/>
+            Sum of <i>{truncjoin(questionSetText1)}</i> should be equal to sum of <i>{truncjoin(questionSetText2)}</i>
+        </div>
+    );
+}
+
+function MinMaxRule({questionsText, min, max}) {
+    return (
+        <div className="mb-3">
+            <strong>Min/Max Values</strong>
+            <br/>
+            Answer to <i>{truncate(questionsText, 15)}</i> should be between: <Pre>{min}</Pre> and <Pre>{max}.</Pre>
+        </div>
+    );
+}
+
+function RegexRule({questionsText, regex}) {
+    return (
+        <div className="mb-3">
+            <strong>Text Match</strong><br/>
+            Answer to <i>{truncate(questionsText, 15)}</i> should match the pattern: <Pre>{regex}</Pre>
+        </div>
+    );
+}
 
 export default class SurveyQuestionRules extends React.Component {
     constructor(props) {
@@ -15,15 +86,15 @@ export default class SurveyQuestionRules extends React.Component {
             || (rule.questions && rule.questions.includes(id))
             || (rule.questionSetIds1 && (rule.questionSetIds1.includes(id) || rule.questionSetIds2.includes(id)))
             || (rule.question1 && (rule.question1 === id || rule.question2 === id)))
-        .map((r, uid) => (r.questionId
+        .map(r => (r.questionId
             ? r.regex
-                ? <li key={uid}>{`Rule: ${r.ruleType} | Question '${r.questionsText}' should match the pattern: ${r.regex}.`}</li>
-                : <li key={uid}>{`Rule: ${r.ruleType} | Question '${r.questionsText}' should be between: ${r.min} and ${r.max}.`}</li>
+                ? <RegexRule key={r.id} {...r}/>
+                : <MinMaxRule key={r.id} {...r}/>
             : r.questions
-                ? <li key={uid}>{`Rule: ${r.ruleType} | Questions '${r.questionsText}' should sum up to ${r.validSum}`}</li>
+                ? <EqualToSumRule key={r.id} {...r}/>
                 : r.questionSetIds1
-                    ? <li key={uid}>{`Rule: ${r.ruleType} | Sum of '${r.questionSetText1}' should be equal to sum of '${r.questionSetText2}'.`}</li>
-                    : <li key={uid}>{`Rule: ${r.ruleType} | 'Question 1: ${r.questionText1}, Answer 1: ${r.answerText1}' is not compatible with 'Question 2: ${r.questionText2}, Answer 2: ${r.answerText2}'.`}</li>));
+                    ? <MatchingSumsRule key={r.id} {...r}/>
+                    : <IncompatibleRule key={r.id} {...r}/>));
 
     render() {
         const {showModal} = this.state;
@@ -71,7 +142,7 @@ export default class SurveyQuestionRules extends React.Component {
                                       </button>
                                   </div>
                                   <div className="modal-body text-left">
-                                      <ul>{rules}</ul>
+                                      {rules}
                                   </div>
                                   <div className="modal-footer">
                                       <button

--- a/src/js/components/SurveyQuestionRules.js
+++ b/src/js/components/SurveyQuestionRules.js
@@ -1,12 +1,11 @@
 import React from "react";
 
-import _ from "lodash";
 import SvgIcon from "./SvgIcon";
 import {pluralize, truncate} from "../utils/generalUtils";
 
 /**
  * Helper Components
- */
+ **/
 function truncjoin(qs) {
     return qs.map(q => truncate(q, 15)).join(", ");
 }
@@ -21,13 +20,14 @@ function Badge({text}) {
 }
 
 function Question({text}) {
+    const textIsArray = Array.isArray(text);
     return (
         <i className="tooltip_wrapper" style={{color: "black"}}>
-            &quot;{(_.isArray(text) ? truncjoin(text) : truncate(text, 15))}&quot;
-            {(_.isArray(text) || text.length >= 15)
+            &quot;{(textIsArray ? truncjoin(text) : truncate(text, 15))}&quot;
+            {(textIsArray || text.length >= 15)
                 && (
                     <span className="tooltip_content" style={{"font-size": "0.8rem"}}>
-                        {_.isArray(text) ? text.join(", ") : text}
+                        {textIsArray ? text.join(", ") : text}
                     </span>
                 )}
         </i>

--- a/src/js/components/SurveyQuestionRules.js
+++ b/src/js/components/SurveyQuestionRules.js
@@ -38,8 +38,8 @@ function IncompatibleRule({answerText1, answerText2, questionText1, questionText
         <div className="mb-3">
             <strong>Incompatible Answers</strong>
             <br/>
-            Answer <Badge>{answerText1}</Badge> from <i>{truncate(questionText1, 15)}</i> is
-            incompatible with <Badge>{answerText2}</Badge> from <i>{truncate(questionText2, 15)}</i>
+            Answer <Badge>{truncate(answerText1, 10)}</Badge> from <i>{truncate(questionText1, 15)}</i> is
+            incompatible with <Badge>{truncate(answerText2, 10)}</Badge> from <i>{truncate(questionText2, 15)}</i>
         </div>
     );
 }

--- a/src/js/components/SurveyQuestionRules.js
+++ b/src/js/components/SurveyQuestionRules.js
@@ -1,75 +1,85 @@
 import React from "react";
 
+import _ from "lodash";
 import SvgIcon from "./SvgIcon";
 import {pluralize, truncate} from "../utils/generalUtils";
 
 /**
  * Helper Components
  */
-function Badge({children}) {
+function truncjoin(qs) {
+    return qs.map(q => truncate(q, 15)).join(", ");
+}
+
+function Badge({text}) {
     return (
-        <div className="badge badge-light">
-            {children}
+        <div className="badge badge-light tooltip_wrapper" style={{color: "black"}}>
+            {truncate(text, 10)}
+            {text.length > 10 && (<div className="tooltip_content">{text}</div>)}
         </div>
     );
 }
 
-function Pre({children}) {
+function Question({text}) {
     return (
-        <pre style={{display: "inline"}}>
-            {children}
-        </pre>
+        <i className="tooltip_wrapper" style={{color: "black"}}>
+            &quot;{(_.isArray(text) ? truncjoin(text) : truncate(text, 15))}&quot;
+            {(_.isArray(text) || text.length >= 15)
+                && (
+                    <span className="tooltip_content" style={{"font-size": "0.8rem"}}>
+                        {_.isArray(text) ? text.join(", ") : text}
+                    </span>
+                )}
+        </i>
     );
 }
 
 function EqualToSumRule({questionsText, validSum}) {
-    const truncjoin = qs => qs.map(q => truncate(q, 15)).join(", ");
     return (
-        <div className="mb-3">
-            <strong>Sum of Answers</strong>
-            <br/>
-            Answers to <i>{truncjoin(questionsText)}</i> should sum up to <Pre>{validSum}.</Pre>
+        <div className="d-flex flex-column mb-3">
+            <div><strong>Sum of Answers</strong></div>
+            <div>Answers to <Question text={questionsText}/> should sum up to {validSum}.</div>
         </div>
     );
 }
 
 function IncompatibleRule({answerText1, answerText2, questionText1, questionText2}) {
     return (
-        <div className="mb-3">
-            <strong>Incompatible Answers</strong>
-            <br/>
-            Answer <Badge>{truncate(answerText1, 10)}</Badge> from <i>{truncate(questionText1, 15)}</i> is
-            incompatible with <Badge>{truncate(answerText2, 10)}</Badge> from <i>{truncate(questionText2, 15)}</i>
+        <div className="d-flex flex-column mb-3">
+            <div><strong>Incompatible Answers</strong></div>
+            <div>
+                Answer <Badge text={answerText1}/> from <Question text={questionText1}/> is
+                incompatible with <Badge text={answerText2}/> from <Question text={questionText2}/>
+            </div>
         </div>
     );
 }
 
 function MatchingSumsRule({questionSetText1, questionSetText2}) {
-    const truncjoin = qs => qs.map(q => truncate(q, 15)).join(", ");
     return (
-        <div className="mb-3">
-            <strong>Matching Sums</strong>
-            <br/>
-            Sum of <i>{truncjoin(questionSetText1)}</i> should be equal to sum of <i>{truncjoin(questionSetText2)}</i>
+        <div className="d-flex flex-column mb-3">
+            <div><strong>Matching Sums</strong></div>
+            <div>
+                Sum of <Question text={questionSetText1}/> should be equal to sum of <Question text={questionSetText2}/>
+            </div>
         </div>
     );
 }
 
 function MinMaxRule({questionsText, min, max}) {
     return (
-        <div className="mb-3">
-            <strong>Min/Max Values</strong>
-            <br/>
-            Answer to <i>{truncate(questionsText, 15)}</i> should be between: <Pre>{min}</Pre> and <Pre>{max}.</Pre>
+        <div className="d-flex flex-column mb-3">
+            <div><strong>Min/Max Values</strong></div>
+            <div>Answer to <Question text={questionsText}/> should be between: {min} and {max}.</div>
         </div>
     );
 }
 
 function RegexRule({questionsText, regex}) {
     return (
-        <div className="mb-3">
-            <strong>Text Match</strong><br/>
-            Answer to <i>{truncate(questionsText, 15)}</i> should match the pattern: <Pre>{regex}</Pre>
+        <div className="d-flex flex-column mb-3">
+            <div><strong>Text Match</strong></div>
+            <div>Answer to <Question text={questionsText}/> should match the pattern: <pre style={{display: "inline"}}>{regex}</pre></div>
         </div>
     );
 }

--- a/src/js/utils/generalUtils.js
+++ b/src/js/utils/generalUtils.js
@@ -158,6 +158,16 @@ export function pluralize(number, single, plural) {
     return (number === 1) ? single : plural;
 }
 
+/**
+ * Returns text truncated to max value with an ellipses.
+ * @param {string} text
+ * @param {number} max
+ * @returns {string}
+ **/
+export function truncate(text, max) {
+    return text.length > max ? `${text.substring(0, max)}...` : text;
+}
+
 export function detectMacOS() {
     const macRegex = /Mac/i;
     return macRegex.test(window.navigator.userAgent);


### PR DESCRIPTION
### Purpose
Now that we have more space for rules inside of the Rules Modal, optimize the format for each rule.

### Steps
- Add truncate(text, max) fn
- Create components for each rule type
- Re-word the rules to refer to Answers
- Truncate long questions
- Italicize questions and and place in quotes
- Put RegEx constrain in `<pre>` tag
- Put answers in Badges

### Related Issues
Fix #1182

### Screenshots
Incompatible Answers
![Screen Shot 2021-04-26 at 11 21 01 AM](https://user-images.githubusercontent.com/1829313/116131643-7cd11000-a681-11eb-845c-41ee6667f891.png)

Text Match (Regex)
![Screen Shot 2021-04-26 at 11 21 14 AM](https://user-images.githubusercontent.com/1829313/116131663-8490b480-a681-11eb-964f-cb9741e3e2e2.png)

Exact Sums, Min/Max, and Matching Sums
![Screen Shot 2021-04-26 at 11 21 48 AM](https://user-images.githubusercontent.com/1829313/116131722-98d4b180-a681-11eb-9884-1886d9e64602.png)

(NEW) Tooltips for Long Answers
![Screen Shot 2021-05-14 at 1 15 00 PM](https://user-images.githubusercontent.com/1829313/118324055-649d2580-b4b6-11eb-86c5-b31e81db2351.png)
