### PR TITLE
Require new users to verify email

### DIFF
--- a/src/clj/collect_earth_online/routing.clj
+++ b/src/clj/collect_earth_online/routing.clj
@@ -40,6 +40,7 @@
    [:get  "/login"]                          {:handler     (render-page "/login")}
    [:get  "/password-request"]               {:handler     (render-page "/password-request")}
    [:get  "/password-reset"]                 {:handler     (render-page "/password-reset")}
+   [:get  "/verify-email"]                   {:handler     (render-page "/verify-email")}
    [:get  "/project-dashboard"]              {:handler     (render-page "/project-dashboard")
                                               :auth-type   :admin
                                               :auth-action :redirect}
@@ -73,6 +74,7 @@
                                               :auth-action :block}
    [:post "/password-request"]               {:handler     users/password-request}
    [:post "/password-reset"]                 {:handler     users/password-reset}
+   [:post "/verify-email"]                   {:handler     users/verify-email}
    [:post "/register"]                       {:handler     users/register}
    ;; Projects API
    [:get  "/dump-project-aggregate-data"]    {:handler     projects/dump-project-aggregate-data

--- a/src/js/account.js
+++ b/src/js/account.js
@@ -3,7 +3,6 @@ import ReactDOM from "react-dom";
 
 import {FormLayout, SectionBlock, StatsCell, StatsRow} from "./components/FormComponents";
 import {NavigationBar} from "./components/PageComponents";
-import {getQueryString} from "./utils/generalUtils";
 
 function Account(props) {
     const sameAsUser = props.userId === props.accountId;
@@ -114,8 +113,11 @@ class AccountForm extends React.Component {
         fetch("/account",
               {
                   method: "POST",
-                  headers: {"Content-Type": "application/x-www-form-urlencoded"},
-                  body: getQueryString(this.state)
+                  headers: {
+                      "Accept": "application/json",
+                      "Content-Type": "application/json"
+                  },
+                  body: JSON.stringify(this.state)
               })
             .then(response => Promise.all([response.ok, response.json()]))
             .then(data => {

--- a/src/js/login.js
+++ b/src/js/login.js
@@ -1,7 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import {NavigationBar} from "./components/PageComponents";
-import {getQueryString} from "./utils/generalUtils";
 
 class Login extends React.Component {
     constructor(props) {
@@ -16,8 +15,11 @@ class Login extends React.Component {
         fetch("/login",
               {
                   method: "POST",
-                  headers: {"Content-Type": "application/x-www-form-urlencoded"},
-                  body: getQueryString(this.state)
+                  headers: {
+                      "Accept": "application/json",
+                      "Content-Type": "application/json"
+                  },
+                  body: JSON.stringify(this.state)
               })
             .then(response => Promise.all([response.ok, response.json()]))
             .then(data => {

--- a/src/js/passwordRequest.js
+++ b/src/js/passwordRequest.js
@@ -1,7 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import {NavigationBar} from "./components/PageComponents";
-import {getQueryString} from "./utils/generalUtils";
 
 class PasswordRequest extends React.Component {
     constructor(props) {
@@ -16,9 +15,10 @@ class PasswordRequest extends React.Component {
               {
                   method: "POST",
                   headers: {
-                      "Content-Type": "application/x-www-form-urlencoded"
+                      "Accept": "application/json",
+                      "Content-Type": "application/json"
                   },
-                  body: getQueryString(this.state)
+                  body: JSON.stringify(this.state)
               })
             .then(response => Promise.all([response.ok, response.json()]))
             .then(data => {

--- a/src/js/passwordReset.js
+++ b/src/js/passwordReset.js
@@ -1,7 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import {NavigationBar} from "./components/PageComponents";
-import {getQueryString} from "./utils/generalUtils";
 
 class PasswordReset extends React.Component {
     constructor(props) {
@@ -23,9 +22,10 @@ class PasswordReset extends React.Component {
               {
                   method: "POST",
                   headers: {
-                      "Content-Type": "application/x-www-form-urlencoded"
+                      "Accept": "application/json",
+                      "Content-Type": "application/json"
                   },
-                  body: getQueryString(this.state)
+                  body: JSON.stringify(this.state)
               })
             .then(response => Promise.all([response.ok, response.json()]))
             .then(data => {

--- a/src/js/register.js
+++ b/src/js/register.js
@@ -1,7 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import {NavigationBar} from "./components/PageComponents";
-import {getQueryString} from "./utils/generalUtils";
 
 class Register extends React.Component {
     constructor(props) {
@@ -22,14 +21,15 @@ class Register extends React.Component {
                   {
                       method: "POST",
                       headers: {
-                          "Content-Type": "application/x-www-form-urlencoded"
+                          "Accept": "application/json",
+                          "Content-Type": "application/json"
                       },
-                      body: getQueryString(this.state)
+                      body: JSON.stringify(this.state)
                   })
                 .then(response => Promise.all([response.ok, response.json()]))
                 .then(data => {
                     if (data[0] && data[1] === "") {
-                        alert("You have successfully created an account.");
+                        alert("You have successfully created an account.  Please check your email for a link to verify your account.");
                         window.location = "/home";
                     } else {
                         alert(data[1]);

--- a/src/js/verifyEmail.js
+++ b/src/js/verifyEmail.js
@@ -1,0 +1,57 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import {NavigationBar} from "./components/PageComponents";
+
+class VerifyEmail extends React.Component {
+    componentDidMount() {
+        fetch("/verify-email",
+              {
+                  method: "POST",
+                  headers: {
+                      "Accept": "application/json",
+                      "Content-Type": "application/json"
+                  },
+                  body: JSON.stringify({
+                      email: this.props.email,
+                      passwordResetKey: this.props.passwordResetKey
+                  })
+              })
+            .then(response => Promise.all([response.ok, response.json()]))
+            .then(data => {
+                if (data[0] && data[1] === "") {
+                    alert("You have successfully verified your email.");
+                    window.location = "/login";
+                } else {
+                    alert(data[1]);
+                    window.location = "/password-request";
+                }
+            })
+            .catch(err => console.log(err));
+    }
+
+    render() {
+        return (
+            <div className="d-flex justify-content-center">
+                <div className="card card-lightgreen" id="reset-form">
+                    <div className="card-header card-header-lightgreen">Email Verification</div>
+                    <div className="card-body">
+                        <label>Verifying email...</label>
+                    </div>
+                </div>
+            </div>
+
+        );
+    }
+}
+
+export function pageInit(args) {
+    ReactDOM.render(
+        <NavigationBar userId={-1} userName="">
+            <VerifyEmail
+                email={args.email || ""}
+                passwordResetKey={args.passwordResetKey || ""}
+            />
+        </NavigationBar>,
+        document.getElementById("app")
+    );
+}

--- a/src/sql/changes/update_2021-05-26_user_email.sql
+++ b/src/sql/changes/update_2021-05-26_user_email.sql
@@ -1,0 +1,3 @@
+ALTER TABLE users ADD COLUMN verified boolean DEFAULT FALSE;
+
+UPDATE users SET verified = true;

--- a/src/sql/functions/member.sql
+++ b/src/sql/functions/member.sql
@@ -77,7 +77,7 @@ CREATE OR REPLACE FUNCTION add_user(_email text, _password text, _reset_key text
 $$ LANGUAGE SQL;
 
 -- Get information for single user
-CREATE OR REPLACE FUNCTION get_user(_email text)
+CREATE OR REPLACE FUNCTION get_user_by_mail(_email text)
  RETURNS table (
     user_id          integer,
     administrator    boolean,
@@ -90,8 +90,12 @@ CREATE OR REPLACE FUNCTION get_user(_email text)
 
 $$ LANGUAGE SQL;
 
-CREATE OR REPLACE FUNCTION get_user_email(_user_id integer)
- RETURNS text AS $$
+CREATE OR REPLACE FUNCTION get_user_by_id(_user_id integer)
+ RETURNS table (
+    email            text,
+    administrator    boolean,
+    reset_key        text
+ ) AS $$
 
     SELECT email
     FROM users
@@ -239,7 +243,7 @@ CREATE OR REPLACE FUNCTION update_password(_email text, _password text)
 
 $$ LANGUAGE SQL;
 
-CREATE OR REPLACE FUNCTION verify_user(_user_id integer)
+CREATE OR REPLACE FUNCTION user_verified(_user_id integer)
  RETURNS void AS $$
 
     UPDATE users

--- a/src/sql/tables/all.sql
+++ b/src/sql/tables/all.sql
@@ -6,11 +6,12 @@
 
 -- Stores information about users
 CREATE TABLE users (
-    user_uid           SERIAL PRIMARY KEY,
-    email              text NOT NULL UNIQUE,
-    password           varchar(72) NOT NULL,
-    administrator      boolean DEFAULT FALSE,
-    reset_key          text DEFAULT NULL
+    user_uid         SERIAL PRIMARY KEY,
+    email            text NOT NULL UNIQUE,
+    password         varchar(72) NOT NULL,
+    administrator    boolean DEFAULT FALSE,
+    reset_key        text DEFAULT NULL,
+    verified         boolean DEFAULT FALSE
 );
 
 -- Stores information about institutions

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,8 +26,9 @@ module.exports = env => ({
         reviewInstitution    : path.resolve(__dirname, "src/js/reviewInstitution.js"),
         simpleCollection     : path.resolve(__dirname, "src/js/simpleCollection.js"),
         support              : path.resolve(__dirname, "src/js/support.js"),
-        widgetLayoutEditor   : path.resolve(__dirname, "src/js/widgetLayoutEditor.js"),
-        termsOfService       : path.resolve(__dirname, "src/js/termsOfService.js")
+        termsOfService       : path.resolve(__dirname, "src/js/termsOfService.js"),
+        verifyEmail          : path.resolve(__dirname, "src/js/verifyEmail.js"),
+        widgetLayoutEditor   : path.resolve(__dirname, "src/js/widgetLayoutEditor.js")
     },
     output: {
         path: path.resolve(__dirname, outdir),


### PR DESCRIPTION
## Purpose
Require new users to verify email so email notifications go out correctly.  Not seen here is that the smtp settings have been resolved for "no-reply"

## Related Issues
Closes CEO-118 CEO-117

## Testing
1. When a new user registers, then a message will show to notify the user that they need to verify their email
2. When a new user registers, then there is a link to verify their email in the welcome message
3. When a new user registers, and clicks the verify link, they are verified
4. When a new user registers, and tries to log in before verifying, they will not be able to
5. When a new user registers, and tries to login after verifying, they will be able to.
