### PR TITLE
fixed geodash Local Storage storageName issue

### DIFF
--- a/src/js/geoDash.js
+++ b/src/js/geoDash.js
@@ -834,17 +834,20 @@ class MapWidget extends React.Component {
         }
     }
 
-    checkForCache = (postObject, widget, isSecond) => (localStorage.getItem(postObject.ImageAsset + JSON.stringify(postObject.visParams))
-        ? this.createTileServerFromCache(postObject.ImageAsset + JSON.stringify(postObject.visParams), widget.id, isSecond)
-        : localStorage.getItem(postObject.ImageCollectionAsset + JSON.stringify(postObject.visParams))
-            ? this.createTileServerFromCache(postObject.ImageCollectionAsset + JSON.stringify(postObject.visParams), widget.id, isSecond)
-            : postObject.index && localStorage.getItem(postObject.index + postObject.dateFrom + postObject.dateTo)
-                ? this.createTileServerFromCache(postObject.index + postObject.dateFrom + postObject.dateTo, widget.id, isSecond)
-                : postObject.path && localStorage.getItem(postObject.path + postObject.dateFrom + postObject.dateTo)
-                    ? this.createTileServerFromCache(postObject.path + postObject.dateFrom + postObject.dateTo, widget.id, isSecond)
-                    : localStorage.getItem(JSON.stringify(postObject))
-                        ? this.createTileServerFromCache(JSON.stringify(postObject), widget.id, isSecond)
-                        : true);
+    checkForCache = (postObject, widget, isSecond) => {
+        const visParams = JSON.stringify(postObject.visParams);
+        return (localStorage.getItem(postObject.ImageAsset + visParams)
+            ? this.createTileServerFromCache(postObject.ImageAsset + visParams, widget.id, isSecond)
+            : localStorage.getItem(postObject.ImageCollectionAsset + visParams)
+                ? this.createTileServerFromCache(postObject.ImageCollectionAsset + visParams, widget.id, isSecond)
+                : postObject.index && localStorage.getItem(postObject.index + visParams + postObject.dateFrom + postObject.dateTo)
+                    ? this.createTileServerFromCache(postObject.index + visParams + postObject.dateFrom + postObject.dateTo, widget.id, isSecond)
+                    : postObject.path && localStorage.getItem(postObject.path + visParams + postObject.dateFrom + postObject.dateTo)
+                        ? this.createTileServerFromCache(postObject.path + visParams + postObject.dateFrom + postObject.dateTo, widget.id, isSecond)
+                        : localStorage.getItem(JSON.stringify(postObject))
+                            ? this.createTileServerFromCache(JSON.stringify(postObject), widget.id, isSecond)
+                            : true);
+    };
 
     fetchMapInfo = (postObject, url, widget, dualImageObject) => {
         if (postObject.path === "getDegraditionTileUrl" && url.trim() === "") {
@@ -868,14 +871,15 @@ class MapWidget extends React.Component {
             .then(data => {
                 if (data && data.hasOwnProperty("url")) {
                     data.lastGatewayUpdate = new Date();
-                    if (postObject.ImageAsset && JSON.stringify(postObject.visParams)) {
-                        localStorage.setItem(postObject.ImageAsset + JSON.stringify(postObject.visParams), JSON.stringify(data));
-                    } else if (postObject.ImageCollectionAsset && JSON.stringify(postObject.visParams)) {
-                        localStorage.setItem(postObject.ImageCollectionAsset + JSON.stringify(postObject.visParams), JSON.stringify(data));
-                    } else if (postObject.index && postObject.dateFrom + postObject.dateTo) {
-                        localStorage.setItem(postObject.index + postObject.dateFrom + postObject.dateTo, JSON.stringify(data));
-                    } else if (postObject.path && postObject.dateFrom + postObject.dateTo) {
-                        localStorage.setItem(postObject.path + postObject.dateFrom + postObject.dateTo, JSON.stringify(data));
+                    const visParams = JSON.stringify(postObject.visParams);
+                    if (postObject.ImageAsset && visParams) {
+                        localStorage.setItem(postObject.ImageAsset + visParams, JSON.stringify(data));
+                    } else if (postObject.ImageCollectionAsset && visParams) {
+                        localStorage.setItem(postObject.ImageCollectionAsset + visParams, JSON.stringify(data));
+                    } else if (postObject.index && visParams + postObject.dateFrom + postObject.dateTo) {
+                        localStorage.setItem(postObject.index + visParams + postObject.dateFrom + postObject.dateTo, JSON.stringify(data));
+                    } else if (postObject.path && visParams + postObject.dateFrom + postObject.dateTo) {
+                        localStorage.setItem(postObject.path + visParams + postObject.dateFrom + postObject.dateTo, JSON.stringify(data));
                     } else {
                         localStorage.setItem(JSON.stringify(postObject), JSON.stringify(data));
                     }
@@ -904,12 +908,13 @@ class MapWidget extends React.Component {
                             .then(data => {
                                 if (data.hasOwnProperty("url")) {
                                     data.lastGatewayUpdate = new Date();
-                                    if (postObject.ImageAsset && JSON.stringify(postObject.visParams)) {
-                                        localStorage.setItem(postObject.ImageAsset + JSON.stringify(postObject.visParams), JSON.stringify(data));
-                                    } else if (postObject.ImageCollectionAsset && JSON.stringify(postObject.visParams)) {
-                                        localStorage.setItem(postObject.ImageCollectionAsset + JSON.stringify(postObject.visParams), JSON.stringify(data));
-                                    } else if (postObject.index && postObject.dateFrom + postObject.dateTo) {
-                                        localStorage.setItem(postObject.index + postObject.dateFrom + postObject.dateTo, JSON.stringify(data));
+                                    const visParams = JSON.stringify(postObject.visParams);
+                                    if (postObject.ImageAsset && visParams) {
+                                        localStorage.setItem(postObject.ImageAsset + visParams, JSON.stringify(data));
+                                    } else if (postObject.ImageCollectionAsset && visParams) {
+                                        localStorage.setItem(postObject.ImageCollectionAsset + visParams, JSON.stringify(data));
+                                    } else if (postObject.index && visParams + postObject.dateFrom + postObject.dateTo) {
+                                        localStorage.setItem(postObject.index + visParams + postObject.dateFrom + postObject.dateTo, JSON.stringify(data));
                                     } else {
                                         localStorage.setItem(JSON.stringify(postObject), JSON.stringify(data));
                                     }
@@ -936,12 +941,13 @@ class MapWidget extends React.Component {
                                 .then(data => {
                                     if (data.hasOwnProperty("url")) {
                                         data.lastGatewayUpdate = new Date();
-                                        if (dualImageObject.ImageAsset && JSON.stringify(dualImageObject.visParams)) {
-                                            localStorage.setItem(dualImageObject.ImageAsset + JSON.stringify(dualImageObject.visParams), JSON.stringify(data));
-                                        } else if (dualImageObject.ImageCollectionAsset && JSON.stringify(dualImageObject.visParams)) {
-                                            localStorage.setItem(dualImageObject.ImageCollectionAsset + JSON.stringify(dualImageObject.visParams), JSON.stringify(data));
-                                        } else if (dualImageObject.index && dualImageObject.dateFrom + dualImageObject.dateTo) {
-                                            localStorage.setItem(dualImageObject.index + dualImageObject.dateFrom + dualImageObject.dateTo, JSON.stringify(data));
+                                        const visParams = JSON.stringify(dualImageObject.visParams);
+                                        if (dualImageObject.ImageAsset && visParams) {
+                                            localStorage.setItem(dualImageObject.ImageAsset + visParams, JSON.stringify(data));
+                                        } else if (dualImageObject.ImageCollectionAsset && visParams) {
+                                            localStorage.setItem(dualImageObject.ImageCollectionAsset + visParams, JSON.stringify(data));
+                                        } else if (dualImageObject.index && visParams + dualImageObject.dateFrom + dualImageObject.dateTo) {
+                                            localStorage.setItem(dualImageObject.index + visParams + dualImageObject.dateFrom + dualImageObject.dateTo, JSON.stringify(data));
                                         } else {
                                             localStorage.setItem(JSON.stringify(dualImageObject), JSON.stringify(data));
                                         }


### PR DESCRIPTION
## Purpose
now geodash always includes visual parametrizations object in localstorage keys

## Related Issues
Closes CEO-145

## Submission Checklist
- [ ] Commits include the JIRA issue and the `#review` hashtag (e.g. `CEO-### #review <comment>`)
- [ ] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
<!-- Create a BDD style test script -->
As a User, When collecting using GeoDash, Then widgets with different visual parameters are shown differently.

## Screenshots
<!-- Add a screen shot when UI changes are included -->
![Schermata 2021-06-04 alle 18 03 49](https://user-images.githubusercontent.com/10047945/120871937-c6572980-c562-11eb-8130-aa258634f168.png)

