### PR TITLE
Clean up widgets

### DIFF
--- a/src/css/geo-dash.css
+++ b/src/css/geo-dash.css
@@ -394,43 +394,18 @@ input:checked+.switchslider:before {
 /*
  * Placeholder dashboard ideas
  */
-.placeholders.row, .placeholdersOld.row {
-    margin-right: auto;
-    margin-left: auto;
-}
-.placeholdersOld{
-    margin-bottom: 30px;
-    text-align: center;
-}
-.placeholdersOld .placeholder{
-    height: 362px;
-}
-.placeholdersOld .minmapwidget {
-    height: calc(100% - 125px);
-}
-
-.placeholdersOld .graphwidget{
-    height:250px;
-}
 .placeholders {
     margin-bottom: 30px;
     text-align: center;
     display: grid;
-    /*grid-gap: 10px;*/
     grid-template-columns: 8.33% 8.33% 8.33% 8.33% 8.33% 8.33% 8.33% 8.33% 8.33% 8.33% 8.33% 8.33%;
-    /* background-color: #fff;
-     color: #444;*/
 }
 
-.placeholders h4, .placeholdersOld h4 {
+.placeholders h4 {
     margin-bottom: 0;
 }
-
 .placeholder {
     margin-bottom: 20px;
-}
-.placeholder.c1{
-
 }
 .placeholder img {
     display: inline-block;

--- a/src/js/geoDash.js
+++ b/src/js/geoDash.js
@@ -308,57 +308,17 @@ class Widget extends React.Component {
 
     generateGridRow = (y, h) => (y + 1) + " / span " + h;
 
-    getColumnClass = c => (c.includes("span 12")
-        ? " fullcolumnspan"
-        : c.includes("span 9")
-            ? " columnSpan9"
-            : c.includes("span 6")
-                ? " columnSpan6"
-                : " columnSpan3");
-
-    getRowClass = r => (r.includes("span 2")
-        ? " rowSpan2"
-        : r.includes("span 3")
-            ? " rowSpan3"
-            : " rowSpan1");
-
-    getClassNames = (fullState, c, r) => (fullState
-        ? "placeholder fullwidget"
-        : "placeholder" + this.getColumnClass(c) + this.getRowClass(r));
-
-    getWidgetHtml = (widget, onSliderChange, onSwipeChange) => {
-        if (widget.gridcolumn || widget.layout) {
-            return (
-                <div
-                    className={this.getClassNames(
-                        widget.isFull,
-                        widget.gridcolumn || "",
-                        widget.gridrow || (widget.layout && "span " + widget.layout.h) || ""
-                    )}
-                    style={{
-                        gridColumn:widget.gridcolumn != null
-                            ? widget.gridcolumn
-                            : this.generateGridColumn(widget.layout.x, widget.layout.w),
-                        gridRow:widget.gridrow != null
-                            ? widget.gridrow
-                            : this.generateGridRow(widget.layout.y, widget.layout.h)
-                    }}
-                >
-                    {this.getCommonWidgetLayout(widget, onSliderChange, onSwipeChange)}
-                </div>
-            );
-        } else {
-            return (
-                <div
-                    className={widget.isFull
-                        ? "fullwidget columnSpan3 rowSpan1 placeholder"
-                        : "columnSpan3 rowSpan1 placeholder"}
-                >
-                    {this.getCommonWidgetLayout(widget, onSliderChange, onSwipeChange)}
-                </div>
-            );
-        }
-    };
+    getWidgetHtml = (widget, onSliderChange, onSwipeChange) => (
+        <div
+            className={`placeholder columnSpan3 rowSpan${widget.layout.h} ${widget.isFull && "fullwidget"}`}
+            style={{
+                gridColumn: this.generateGridColumn(widget.layout.x, widget.layout.w),
+                gridRow: this.generateGridRow(widget.layout.y, widget.layout.h)
+            }}
+        >
+            {this.getCommonWidgetLayout(widget, onSliderChange, onSwipeChange)}
+        </div>
+    );
 
     getCommonWidgetLayout = (widget, onSliderChange, onSwipeChange) => (
         <div className="panel panel-default" id={"widget_" + widget.id}>

--- a/src/sql/changes/update_2021-06-06_simplify_widgets.sql
+++ b/src/sql/changes/update_2021-06-06_simplify_widgets.sql
@@ -1,0 +1,60 @@
+ALTER table project_widgets ADD COLUMN widget_bk jsonb;
+
+UPDATE project_widgets p
+SET widget = nw.new_widget
+FROM (SELECT widget_uid,
+    widget || jsonb_build_object(
+        'id', row_number() over( partition by project_rid order by widget->'id')::int - 1
+    ) AS new_widget
+FROM project_widgets
+ORDER BY project_rid, widget->'id') AS nw
+WHERE p.widget_uid = nw.widget_uid;
+
+UPDATE project_widgets
+SET widget = jsonb_set(widget, '{"layout"}', jsonb_build_object(
+    'x', split_part(widget->>'gridcolumn', ' ', 1)::int - 1,
+    'w', CASE WHEN split_part(widget->>'gridcolumn', ' ', 4) <> ''
+            THEN split_part(widget->>'gridcolumn', ' ', 4)::int
+        WHEN split_part(widget->>'gridcolumn', ' ', 3) <> ''
+            THEN split_part(widget->>'gridcolumn', ' ', 3)::int
+        ELSE 3
+        END,
+    'y', split_part(widget->>'gridrow', ' ', 1)::int - 1,
+    'h', CASE WHEN split_part(widget->>'gridrow', ' ', 4) <> ''
+            THEN split_part(widget->>'gridrow', ' ', 4)::int
+        ELSE 1
+        END,
+    'i', widget->>'id'
+))
+WHERE widget->'gridcolumn' is NOT NULL;
+
+UPDATE project_widgets
+SET widget = jsonb_set(widget, '{"layout"}', jsonb_build_object(
+    'x', 0,
+    'w', CASE WHEN widget->>'width' <> ''
+            THEN (widget->>'width')::int
+        ELSE 3
+        END,
+    'y', (widget->>'id')::int,
+    'h', 1,
+    'i', widget->>'id'
+))
+WHERE widget->'gridcolumn' is NULL
+    AND widget->'layout' is NULL
+    AND widget->'width' is NOT NULL;
+
+UPDATE project_widgets
+SET widget = widget - 'width' - 'position' - 'gridcolumn' - 'gridrow'
+WHERE widget->'layout' is NOT NULL;
+
+-- Check all widget
+SELECT widget
+FROM project_widgets
+WHERE widget->'layout' IS NULL
+    OR widget->'layout'->'y' IS NULL
+    OR widget->'layout'->'i' IS NULL
+    OR jsonb_typeof(widget->'layout'->'i') <> 'string'
+    OR widget->'gridcolumn' IS NOT NULL
+    OR widget->'gridrow' IS NOT NULL
+    OR widget->'width' IS NOT NULL
+    OR widget->'position' IS NOT NULL;

--- a/src/sql/functions/project.sql
+++ b/src/sql/functions/project.sql
@@ -162,7 +162,7 @@ CREATE OR REPLACE FUNCTION get_project_widgets_by_project_id(_project_id integer
     project_title    text
  ) AS $$
 
-    SELECT pw.*, p.name
+    SELECT widget_uid, project_uid, dashboard_id, widget, p.name
     FROM project_widgets pw
     INNER JOIN projects p
         ON project_uid = project_rid


### PR DESCRIPTION
## Purpose

** Conform widget layout json

Widgets are always an array so there is no longer a need to check.
- See geodash.clj line 20

No widgets with a layout have a:
```
-- missing y
select widget->'layout' from project_widgets
where widget->'layout' is not null 
	and widget->'layout'->'y' is null

-- i that is not already a string
select jsonb_typeof(widget->'layout'->'i') from project_widgets
  where widget->'layout' is not null 
  	and jsonb_typeof(widget->'layout'->'i') <> 'string'
```

Widgets with layouts are cleaned to ensure no left over width or position fields

Widgets with grid row are converted to widgets with layouts

Widgets with width are put one on each row

** Bug fixes
updateAllServerWidgets was called before dashId was set in state so none of the old widgets -> new widgets were save if no other changes were made. updateAllServerWidgets is no longer needed because all of the DB widgets are the same

generateLayout was working on accident as it was called before any widgets were in state, then overwritten.  It was also causing the app to send /update-widget more than once

Use a more specific change comparison because layout adds more fields we don't need in the widget layout settings.  This means all widgets get updated again the first time one changes.

gridcolumn -> layout missed some permutations of the gridcolumn tag.

some widgets had duplicate id / i values, or out of sync id -> i.

## Related Issues
Closes CEO-40