### PR TITLE
Update window names

### DIFF
--- a/src/js/collection.js
+++ b/src/js/collection.js
@@ -517,7 +517,7 @@ class Collection extends React.Component {
                     + `&aoi=${encodeURIComponent(`[${mercator.getViewExtent(mapConfig)}]`)}`
                     + `&daterange=&bcenter=${currentPlot.center}`
                     + `&bradius=${plotRadius}`,
-                    "_geo-dash");
+                    `_geo-dash_${this.props.projectId}`);
     };
 
     createPlotKML = () => {

--- a/src/js/project/ManageProject.js
+++ b/src/js/project/ManageProject.js
@@ -245,8 +245,7 @@ class ProjectManagement extends React.Component {
                             onClick={() => window.open(
                                 "/widget-layout-editor?editable=true&" // TODO, drop unused 'editable'
                                     + `institutionId=${this.context.institution}`
-                                    + `&projectId=${this.context.id}`,
-                                "_geo-dash"
+                                    + `&projectId=${this.context.id}`
                             )}
                             type="button"
                             value="Configure Geo-Dash"


### PR DESCRIPTION
## Purpose
Allow widget editor to open independently of the geo-dash.

Only windows that are trying to be repeatedly used need names.  The only case we have in CEO for that is the geo-dash during collection.

## Related Issues
Closes CEO-146

## Submission Checklist
- [ X] Commits include the JIRA issue and the `#review` hashtag (e.g. `CEO-### #review <comment>`)
- [X ] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
1. As admin, when the widget editor is open, I can collect on the same project without the geo-dash taking over the window.
