### PR TITLE
Clean up widget basemap

### DIFF
--- a/src/js/geoDash.js
+++ b/src/js/geoDash.js
@@ -545,7 +545,11 @@ class MapWidget extends React.Component {
         const {projPairAOI, widget} = this.props;
         let {projAOI} = this.props;
 
-        const baseMapLayer = this.getRasterByBasemapConfig(widget.baseMap);
+        const basemapImagery = this.props.imageryList.find(imagery => imagery.id === widget.basemapId)
+                || this.props.imageryList[0];
+        const basemapLayer = TileLayer({
+            source: mercator.createSource(basemapImagery.sourceConfig, basemapImagery.id)
+        });
         const plotSampleLayer = new VectorLayer({
             source: this.props.vectorSource,
             style: new Style({
@@ -560,7 +564,7 @@ class MapWidget extends React.Component {
 
         const mapdiv = "widgetmap_" + widget.id;
         const map = new Map({
-            layers: [baseMapLayer, plotSampleLayer],
+            layers: [basemapLayer, plotSampleLayer],
             target: mapdiv,
             view: new View({
                 center: [0, 0],
@@ -915,20 +919,6 @@ class MapWidget extends React.Component {
             .catch(error => {
                 console.log(error);
             });
-    };
-
-    getRasterByBasemapConfig = basemapConfig => {
-        const basemapId = (basemapConfig || {}).id || basemapConfig;
-        if (!basemapId || basemapId === "osm") {
-            return new TileLayer({source: new OSM()});
-        } else {
-            const basemapIdInt = parseInt(basemapId);
-            const basemapImagery = this.props.imageryList.find(imagery => imagery.id === basemapIdInt)
-                || this.props.imageryList[0];
-            return new TileLayer({
-                source: mercator.createSource(basemapImagery.sourceConfig, basemapImagery.id)
-            });
-        }
     };
 
     getImageParams = widget => {

--- a/src/js/geoDash.js
+++ b/src/js/geoDash.js
@@ -10,7 +10,7 @@ import {buffer as ExtentBuffer} from "ol/extent";
 import {Circle, Polygon, Point} from "ol/geom";
 import {Tile as TileLayer, Vector as VectorLayer} from "ol/layer";
 import {transform as projTransform} from "ol/proj";
-import {OSM, Vector, XYZ} from "ol/source";
+import {Vector, XYZ} from "ol/source";
 import {Style, Stroke} from "ol/style";
 import {getArea as sphereGetArea} from "ol/sphere";
 

--- a/src/js/reviewInstitution.js
+++ b/src/js/reviewInstitution.js
@@ -432,9 +432,8 @@ class ImageryList extends React.Component {
         const toVisibility = currentVisibility === "private" ? "public" : "private";
         if (this.props.userId === 1
                 && confirm(`Do you want to change the visibility from ${currentVisibility} to ${toVisibility}?`
-                    + toVisibility === "private"
-                    ? "  This will remove the imagery from other institutions' projects."
-                    : "")) {
+                    + `${toVisibility === "private"
+                        && "  This will remove the imagery from other institutions' projects."}`)) {
             fetch("/update-imagery-visibility",
                   {
                       method: "POST",

--- a/src/js/widgetLayoutEditor.js
+++ b/src/js/widgetLayoutEditor.js
@@ -487,7 +487,7 @@ class WidgetLayoutEditor extends React.PureComponent {
             });
     };
 
-    onDataBaseMapSelectChanged = event => {
+    onDataBasemapSelectChanged = event => {
         this.setState({widgetBasemap: parseInt(event.target.value)});
     };
 
@@ -795,7 +795,7 @@ class WidgetLayoutEditor extends React.PureComponent {
                                             </option>
                                         </select>
                                     </div>
-                                    {this.getBaseMapSelector()}
+                                    {this.getBasemapSelector()}
                                     {this.getDataTypeSelectionControl()}
                                     {this.getSwipeOpacityDefault()}
                                     {this.getDataForm()}
@@ -907,7 +907,7 @@ class WidgetLayoutEditor extends React.PureComponent {
         </>
     );
 
-    getBaseMapSelector = () => {
+    getBasemapSelector = () => {
         if (["ImageCollection",
              "DualImageCollection",
              "imageAsset",
@@ -931,7 +931,7 @@ class WidgetLayoutEditor extends React.PureComponent {
                         className="form-control"
                         id="widgetIndicesSelect"
                         name="widgetIndicesSelect"
-                        onChange={this.onDataBaseMapSelectChanged}
+                        onChange={this.onDataBasemapSelectChanged}
                         value={this.state.widgetBasemap}
                     >
                         {this.state.imagery && this.state.imagery

--- a/src/js/widgetLayoutEditor.js
+++ b/src/js/widgetLayoutEditor.js
@@ -17,6 +17,7 @@ class WidgetLayoutEditor extends React.PureComponent {
             layout: [],
             widgets: [],
             imagery: [],
+            widgetBasemap: -1,
             selectedProjectId: 0,
             projectList: [],
             projectFilter:"",
@@ -32,7 +33,6 @@ class WidgetLayoutEditor extends React.PureComponent {
             imageParams: "",
             dualLayer: false,
             swipeAsDefault: false,
-            widgetBaseMap: "osm",
             startDate: "",
             endDate: "",
             startDate2: "",
@@ -76,9 +76,7 @@ class WidgetLayoutEditor extends React.PureComponent {
             .then(data => {
                 this.setState({
                     imagery: data,
-                    widgetBaseMap: data.map(o => o.id.toString()).includes(this.state.widgetBaseMap)
-                        ? this.state.widgetBaseMap
-                        : data[0].id
+                    widgetBasemap: data[0].id
                 });
             })
             .catch(response => {
@@ -168,7 +166,6 @@ class WidgetLayoutEditor extends React.PureComponent {
             graphBandDeg: "NDFI",
             graphReducer: "Min",
             imageParams: "",
-            widgetBaseMap: "osm",
             dualLayer: false,
             swipeAsDefault: false,
             startDate:"",
@@ -262,7 +259,6 @@ class WidgetLayoutEditor extends React.PureComponent {
             graphBandDeg: "NDFI",
             graphReducer: "Min",
             imageParams: "",
-            widgetBaseMap: "osm",
             dualLayer: false,
             swipeAsDefault: false,
             startDate:"",
@@ -314,13 +310,13 @@ class WidgetLayoutEditor extends React.PureComponent {
             h: 1,
             minW: 3
         };
-        widget.baseMap = (this.state.imagery.filter(imagery => String(imagery.id) === this.state.widgetBaseMap))[0];
         if (this.state.selectedWidgetType === "DualImageCollection") {
             widget.properties = ["", "", "", "", ""];
             widget.filterType = "";
             widget.visParams = {};
             widget.dualImageCollection = [];
             widget.swipeAsDefault = this.state.swipeAsDefault;
+            widget.basemapId = this.state.widgetBasemap;
             const img1 = {};
             const img2 = {};
             img1.collectionType = "ImageCollection" + this.state.selectedDataType;
@@ -374,11 +370,13 @@ class WidgetLayoutEditor extends React.PureComponent {
             widget.filterType = "";
             widget.visParams = this.state.imageParams === "" ? {} : JSON.parse(this.state.imageParams);
             widget.ImageAsset = this.state.imageCollection;
+            widget.basemapId = this.state.widgetBasemap;
         } else if (this.state.selectedWidgetType === "imageCollectionAsset") {
             widget.properties = ["", "", "", "", ""];
             widget.filterType = "";
             widget.visParams = JSON.parse(this.state.imageParams);
             widget.ImageCollectionAsset = this.state.imageCollection;
+            widget.basemapId = this.state.widgetBasemap;
         } else if (this.state.selectedWidgetType === "DegradationTool") {
             widget.type = "DegradationTool";
             widget.properties = ["DegradationTool", "", "", "", ""];
@@ -386,19 +384,23 @@ class WidgetLayoutEditor extends React.PureComponent {
             widget.startDate = this.state.startDate;
             widget.endDate = this.state.endDate;
             widget.graphBand = this.state.graphBandDeg === "" ? "NDFI" : this.state.graphBandDeg;
-            widget.baseMap = this.state.widgetBaseMap;
+            widget.basemapId = this.state.widgetBasemap;
         } else if (this.state.selectedWidgetType === "polygonCompare") {
             widget.type = "polygonCompare";
             widget.properties = ["featureCollection", "", "", "", ""];
             widget.featureCollection = this.state.featureCollection;
             widget.visParams = this.state.visParams;
             widget.field = this.state.matchField;
-            widget.baseMap = this.state.widgetBaseMap;
+            widget.basemapId = this.state.widgetBasemap;
         } else {
-            const wType = this.state.selectedWidgetType === "TimeSeries" ? this.state.selectedDataType.toLowerCase() + this.state.selectedWidgetType
-                : this.state.selectedWidgetType === "ImageCollection" ? this.state.selectedWidgetType + this.state.selectedDataType
-                    : this.state.selectedWidgetType === "statistics" ? "getStats"
-                        : this.state.selectedWidgetType === "ImageElevation" ? "ImageElevation"
+            const wType = this.state.selectedWidgetType === "TimeSeries"
+                ? this.state.selectedDataType.toLowerCase() + this.state.selectedWidgetType
+                : this.state.selectedWidgetType === "ImageCollection"
+                    ? this.state.selectedWidgetType + this.state.selectedDataType
+                    : this.state.selectedWidgetType === "statistics"
+                        ? "getStats"
+                        : this.state.selectedWidgetType === "ImageElevation"
+                            ? "ImageElevation"
                             : "custom";
             let prop1 = "";
             const properties = [];
@@ -409,6 +411,9 @@ class WidgetLayoutEditor extends React.PureComponent {
                 widget.visParams = this.state.imageParams;
                 widget.graphBand = this.state.graphBand;
                 widget.graphReducer = this.state.graphReducer;
+            }
+            if (["ImageCollection", "ImageElevation"].includes(this.state.selectedWidgetType)) {
+                widget.basemapId = this.state.widgetBasemap;
             }
             properties[0] = wType;
             properties[1] = prop1;
@@ -464,7 +469,6 @@ class WidgetLayoutEditor extends React.PureComponent {
                         graphBandDeg: "NDFI",
                         graphReducer: "Min",
                         imageParams: "",
-                        widgetBaseMap: "osm",
                         dualLayer: false,
                         swipeAsDefault: false,
                         startDate:"",
@@ -484,7 +488,7 @@ class WidgetLayoutEditor extends React.PureComponent {
     };
 
     onDataBaseMapSelectChanged = event => {
-        this.setState({widgetBaseMap: event.target.value});
+        this.setState({widgetBasemap: parseInt(event.target.value)});
     };
 
     onWidgetTitleChange = event => {
@@ -928,7 +932,7 @@ class WidgetLayoutEditor extends React.PureComponent {
                         id="widgetIndicesSelect"
                         name="widgetIndicesSelect"
                         onChange={this.onDataBaseMapSelectChanged}
-                        value={this.state.widgetBaseMap}
+                        value={this.state.widgetBasemap}
                     >
                         {this.state.imagery && this.state.imagery
                             .map(({id, title}) => <option key={id} value={id}>{title}</option>)}

--- a/src/sql/changes/update_2021-06-07_clean_widget_imagery.sql
+++ b/src/sql/changes/update_2021-06-07_clean_widget_imagery.sql
@@ -1,0 +1,42 @@
+-- Convert old object to new imagery id
+UPDATE project_widgets
+SET widget = jsonb_set(widget, '{"baseMap"}', widget->'baseMap'->'id')
+WHERE widget->'baseMap' IS NOT NULL
+    AND jsonb_typeof(widget->'baseMap') = 'object'
+
+-- Set OSM to public OSM layer.
+UPDATE project_widgets
+SET widget =  jsonb_set(widget, '{"baseMap"}', to_jsonb((SELECT select_public_osm())))
+WHERE widget->'baseMap' IS NOT NULL
+    AND widget->>'baseMap' = 'osm'
+
+-- Set all id to integer
+UPDATE project_widgets
+SET widget =  jsonb_set(widget, '{"baseMap"}', (widget->>'baseMap')::jsonb)
+WHERE widget->'baseMap' IS NOT NULL
+    AND jsonb_typeof(widget->'baseMap') = 'string'
+
+-- Convert key
+UPDATE project_widgets
+SET widget =  jsonb_set(widget - 'baseMap', '{"basemapId"}', (widget->>'baseMap')::jsonb)
+WHERE widget->'baseMap' IS NOT NULL
+
+-- Verify conversion
+SELECT widget
+FROM project_widgets
+WHERE (widget->'basemapId' IS NOT NULL
+        AND jsonb_typeof(widget->'basemapId') <> 'number')
+    OR widget->'baseMap' IS NOT NULL
+
+-- Revert archived imagery
+UPDATE project_widgets
+SET widget =  jsonb_set(widget, '{"basemapId"}', to_jsonb((SELECT select_public_osm())))
+WHERE widget_uid IN (
+    SELECT widget_uid
+    FROM project_widgets
+    LEFT JOIN imagery
+        ON (widget->'basemapId')::integer = imagery_uid
+    WHERE widget->'basemapId' IS NOT NULL
+        AND (imagery_uid IS NULL
+            OR archived = TRUE)
+)

--- a/src/sql/changes/update_2021-06-07_clean_widget_imagery.sql
+++ b/src/sql/changes/update_2021-06-07_clean_widget_imagery.sql
@@ -2,33 +2,33 @@
 UPDATE project_widgets
 SET widget = jsonb_set(widget, '{"baseMap"}', widget->'baseMap'->'id')
 WHERE widget->'baseMap' IS NOT NULL
-    AND jsonb_typeof(widget->'baseMap') = 'object'
+    AND jsonb_typeof(widget->'baseMap') = 'object';
 
 -- Set OSM to public OSM layer.
 UPDATE project_widgets
 SET widget =  jsonb_set(widget, '{"baseMap"}', to_jsonb((SELECT select_public_osm())))
 WHERE widget->'baseMap' IS NOT NULL
-    AND widget->>'baseMap' = 'osm'
+    AND widget->>'baseMap' = 'osm';
 
 -- Set all id to integer
 UPDATE project_widgets
 SET widget =  jsonb_set(widget, '{"baseMap"}', (widget->>'baseMap')::jsonb)
 WHERE widget->'baseMap' IS NOT NULL
-    AND jsonb_typeof(widget->'baseMap') = 'string'
+    AND jsonb_typeof(widget->'baseMap') = 'string';
 
 -- Convert key
 UPDATE project_widgets
 SET widget =  jsonb_set(widget - 'baseMap', '{"basemapId"}', (widget->>'baseMap')::jsonb)
-WHERE widget->'baseMap' IS NOT NULL
+WHERE widget->'baseMap' IS NOT NULL;
 
 -- Verify conversion
 SELECT widget
 FROM project_widgets
 WHERE (widget->'basemapId' IS NOT NULL
         AND jsonb_typeof(widget->'basemapId') <> 'number')
-    OR widget->'baseMap' IS NOT NULL
+    OR widget->'baseMap' IS NOT NULL;
 
--- Revert archived imagery
+-- Update archived imagery to OSM
 UPDATE project_widgets
 SET widget =  jsonb_set(widget, '{"basemapId"}', to_jsonb((SELECT select_public_osm())))
 WHERE widget_uid IN (
@@ -39,4 +39,4 @@ WHERE widget_uid IN (
     WHERE widget->'basemapId' IS NOT NULL
         AND (imagery_uid IS NULL
             OR archived = TRUE)
-)
+);

--- a/src/sql/functions/project.sql
+++ b/src/sql/functions/project.sql
@@ -33,7 +33,7 @@ CREATE OR REPLACE FUNCTION select_partial_table_by_name(_table_name text)
 
 $$ LANGUAGE PLPGSQL;
 
--- Converts all columns (including uknown) to a single json column for processing
+-- Converts all columns (including unknown) to a single json column for processing
 CREATE OR REPLACE FUNCTION select_json_table_by_name(_table_name text)
  RETURNS table (
     ext_id      integer,


### PR DESCRIPTION
## Purpose
Clean up widget basemap key so it can be updated when an imagery is removed.

** Conform widget basemap

- Use key basemapId and value as integer

- Explicitly add to widget types that use it

- Use ID for osm layer instead of string

** Bug fixes

- Base map reverts to string "osm" after adding a widget or cancelling.  No need to change widgetBasemap when doing so.

** Behavior change

- We now have an explicit OSM type in CEO.  Users were previously accidently getting OSM if they did not update the base map option.  Moving forward, they will need to explicitly click it. However, the selected base map should stay selected through each widget being added.

## Related Issues
Closes CEO-25

## Testing
1. When I remove a institution imagery, the widget basemap reverts to OSM


