### PR TITLE
Change duplicate imagery title

### DIFF
--- a/src/sql/changes/update_2021-05-26_imagery_UK.sql
+++ b/src/sql/changes/update_2021-05-26_imagery_UK.sql
@@ -1,0 +1,19 @@
+-- Set imagery with repeating names to (#)
+UPDATE imagery i
+SET title = new_title
+FROM
+(
+    SELECT i.imagery_uid, i.title || ' (' || ROW_NUMBER() OVER(PARTITION BY i.institution_rid) || ')' as new_title
+    FROM imagery i
+    INNER JOIN
+    (
+        SELECT institution_rid, title, count(imagery_uid), max(imagery_uid)
+        FROM imagery
+        WHERE archived = false
+        GROUP BY institution_rid, title
+        HAVING count(imagery_uid) > 1
+    ) aa
+    ON aa.institution_rid = i.institution_rid
+        AND aa.title = i.title
+) zz
+where zz.imagery_uid = i.imagery_uid


### PR DESCRIPTION
## Purpose
We no longer allow duplicate imagery names.  Go back to older institutions and update the imagery title.

## Related Issues
Closes CEO-28


