### PR TITLE
reset question tree to begining so new drawn points show

### DIFF
--- a/src/js/collection.js
+++ b/src/js/collection.js
@@ -828,6 +828,7 @@ class Collection extends React.Component {
                 this.featuresToDrawLayer(drawTool);
             } else {
                 this.featuresToSampleLayer();
+                this.setSelectedQuestion(this.state.currentProject.surveyQuestions[0]);
             }
             this.setState({answerMode: newMode});
         }


### PR DESCRIPTION
## Purpose
Fix UI issue.  When user is not on first question, and draws a new feature, going back to the questions make it look like the new feature is gone.

## Related Issues
Closes CEO-148

## Testing
1. When collecting with user drawn samples, and answered all questions, and draw a new feature, and go back to answer mode, then the new feature is still drawn.


