### PR TITLE
CEO-113 Show help menu on startup for home page

### DIFF
--- a/src/js/components/PageComponents.js
+++ b/src/js/components/PageComponents.js
@@ -146,11 +146,20 @@ export class NavigationBar extends React.Component {
             .catch(error => console.log(error));
     }
 
+    autoShowHelpMenu = page => {
+        const autoShowPages = ["home"];
+        const key = `ceo:${page}:seen`;
+        if (autoShowPages.includes(page) && !localStorage.getItem(key)) {
+            this.setState({showHelpMenu: true});
+            localStorage.setItem(key, true);
+        }
+    };
+
     getHelpSlides = (availableLanguages, page) => {
         fetch(`/locale/${page}/${getLanguage(availableLanguages)}.json`,
               {headers: {"Cache-Control": "no-cache", "Pragma": "no-cache", "Accept": "application/json"}})
             .then(response => (response.ok ? response.json() : Promise.reject(response)))
-            .then(data => this.setState({helpSlides: data, page}))
+            .then(data => { this.setState({helpSlides: data, page}); this.autoShowHelpMenu(page); })
             .catch(error => console.log(page, getLanguage(availableLanguages), error));
     };
 


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Show the help menu when a visitor first goes to the home page.

## Related Issues
Closes CEO-113

## Testing
<!-- Create a BDD style test script -->
1. Given I am a visitor, When I visit the CEO home page for the first time, Then I am shown the help menu screen.
