### PR TITLE
CEO-150 Fix flagging plots without samples

### DIFF
--- a/src/js/collection.js
+++ b/src/js/collection.js
@@ -989,6 +989,8 @@ class SideBar extends React.Component {
         if (this.props.answerMode !== "question") {
             alert("You must be in question mode to save the collection.");
             return false;
+        } else if (this.props.currentPlot.flagged) {
+            return true;
         } else if (this.props.isProjectAdmin) {
             if (!(noneAnswered || allAnswered)) {
                 alert("Admins can only save the plot if all questions are answered or the answers are cleared.");


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Fix bug where an institution member cannot flag a plot that does not have samples.

## Related Issues
Closes CEO-150

## Testing
<!-- Create a BDD style test script -->
1. Given I am an institution member, When I flag a plot with a reason, Then the plot is flagged.
