### PR TITLE
CEO-150 Fix flag plots without samples for members

### DIFF
--- a/src/js/collection.js
+++ b/src/js/collection.js
@@ -970,6 +970,8 @@ class SideBar extends React.Component {
         if (this.props.answerMode !== "question") {
             alert("You must be in question mode to save the collection.");
             return false;
+        } else if (this.props.currentPlot.flagged) {
+            return true;
         } else if (this.props.isProjectAdmin) {
             if (!(noneAnswered || allAnswered)) {
                 alert("Admins can only save the plot if all questions are answered or the answers are cleared.");

--- a/src/js/collection.js
+++ b/src/js/collection.js
@@ -965,8 +965,7 @@ class SideBar extends React.Component {
     checkCanSave = () => {
         const noneAnswered = this.props.surveyQuestions.every(sq => safeLength(sq.answered) === 0);
         const hasSamples = safeLength(this.props.currentPlot.samples) > 0;
-        const allAnswered = this.props.currentPlot.flagged
-            || this.props.surveyQuestions.every(sq => safeLength(sq.visible) === safeLength(sq.answered));
+        const allAnswered = this.props.surveyQuestions.every(sq => safeLength(sq.visible) === safeLength(sq.answered));
         if (this.props.answerMode !== "question") {
             alert("You must be in question mode to save the collection.");
             return false;

--- a/src/sql/functions/member.sql
+++ b/src/sql/functions/member.sql
@@ -77,7 +77,7 @@ CREATE OR REPLACE FUNCTION add_user(_email text, _password text, _reset_key text
 $$ LANGUAGE SQL;
 
 -- Get information for single user
-CREATE OR REPLACE FUNCTION get_user_by_mail(_email text)
+CREATE OR REPLACE FUNCTION get_user_by_email(_email text)
  RETURNS table (
     user_id          integer,
     administrator    boolean,


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Fix bug where an institution member cannot flag a plot that does not have samples.

## Related Issues
Closes CEO-150

## Testing
<!-- Create a BDD style test script -->
1. Given I am an institution member, When I flag a plot with a reason, Then the plot is flagged.
