### PR TITLE
Eliminate the use of separate tables for external data.

### DIFF
--- a/src/clj/collect_earth_online/db/projects.clj
+++ b/src/clj/collect_earth_online/db/projects.clj
@@ -23,6 +23,15 @@
 (def path-env (System/getenv "PATH"))
 
 ;;;
+;;; Helper function
+;;;
+
+(defn- remove-vector-items [coll & items]
+  (->> coll
+       (remove (set items))
+       (vec)))
+
+;;;
 ;;; Auth functions
 ;;;
 
@@ -457,15 +466,15 @@
                                (update r :visible_id tc/val->int)
                                (dissoc r :lon :lat)))
                            (rest rows))]
-      (if (and (contains? header-keys :lon)
-               (contains? header-keys :lon))
-        [(dissoc header-keys :lon :lat) body]
+      (if (and (some #(= % :lon) header-keys)
+               (some #(= % :lat) header-keys))
+        [(remove-vector-items header-keys [:lon :lat]) body]
         (init-throw (str "The provided "
                          design-type
                          " CSV file must contain a LAT and LON column."))))))
 
 (defmethod get-file-data :default [distribution _ _ _]
-  (throw (str "No such distribution (" distribution ") defined for ollect-earth-online.db.projects/get-file-data")))
+  (throw (str "No such distribution (" distribution ") defined for collect-earth-online.db.projects/get-file-data")))
 
 (defn- check-headers [headers primary-key design-type]
   (let [header-diff     (set/difference (set primary-key) (set headers))
@@ -1008,11 +1017,6 @@
   (when pg-time
     (.format (SimpleDateFormat. "YYYY-MM-dd HH:mm")
              pg-time)))
-
-(defn- remove-vector-items [coll & items]
-  (->> coll
-       (remove (set items))
-       (vec)))
 
 ;;;
 ;;; Dump aggregate

--- a/src/clj/collect_earth_online/db/projects.clj
+++ b/src/clj/collect_earth_online/db/projects.clj
@@ -555,11 +555,11 @@
           (as-> plot-centers pc
             (map (fn [[lon lat]]
                    {:project_rid project-id
-                    :center      (make-wkt-point lon lat)})
+                    :sample_geom (make-wkt-point lon lat)})
                  pc)
             (insert-rows! "plots"
                           pc
-                          :fields     [:project_rid :center]
+                          :fields     [:project_rid :sample_geom]
                           :custom-row "(?, ST_GeomFromText(?, 4326))")))
         (create-project-samples! project-id
                                  sample-distribution

--- a/src/clj/collect_earth_online/utils/type_conversion.clj
+++ b/src/clj/collect_earth_online/utils/type_conversion.clj
@@ -94,3 +94,9 @@
   (doto (PGobject.)
     (.setType "uuid")
     (.setValue str)))
+
+;; TODO use general form for the above two
+(defn str->pg [str pg-type]
+  (doto (PGobject.)
+    (.setType pg-type)
+    (.setValue str)))

--- a/src/js/collection.js
+++ b/src/js/collection.js
@@ -419,16 +419,18 @@ class Collection extends React.Component {
         mercator.removeLayerById(mapConfig, "currentPlot");
         mercator.removeLayerById(mapConfig, "currentSamples");
         mercator.removeLayerById(mapConfig, "drawLayer");
-        mercator.addVectorLayer(mapConfig,
-                                "currentPlot",
-                                mercator.geometryToVectorSource(
-                                    currentPlot.geom
-                                        ? mercator.parseGeoJson(currentPlot.geom, true)
-                                        : mercator.getPlotPolygon(currentPlot.center,
-                                                                  currentProject.plotSize,
-                                                                  currentProject.plotShape)
-                                ),
-                                mercator.ceoMapStyles("geom", "yellow"));
+        mercator.addVectorLayer(
+            mapConfig,
+            "currentPlot",
+            mercator.geometryToVectorSource(
+                currentPlot.plotGeom.includes("Point")
+                    ? mercator.getPlotPolygon(currentPlot.plotGeom,
+                                              currentProject.plotSize,
+                                              currentProject.plotShape)
+                    : mercator.parseGeoJson(currentPlot.plotGeom, true)
+            ),
+            mercator.ceoMapStyles("geom", "yellow")
+        );
 
         this.zoomToPlot();
     };
@@ -504,6 +506,7 @@ class Collection extends React.Component {
     };
 
     showGeoDash = () => {
+        // FIXME
         const {currentPlot, mapConfig, currentProject} = this.state;
         const plotRadius = currentProject.plotSize
             ? currentProject.plotSize / 2.0
@@ -511,11 +514,11 @@ class Collection extends React.Component {
         window.open("/geo-dash?"
                     + `institutionId=${this.state.currentProject.institution}`
                     + `&projectId=${this.props.projectId}`
-                    + `&visiblePlotId=${isNumber(currentPlot.plotId) ? currentPlot.plotId : currentPlot.id}`
+                    + `&visiblePlotId=${currentPlot.visibleId}`
                     + `&plotId=${currentPlot.id}`
-                    + `&plotShape=${encodeURIComponent((currentPlot.geom ? "polygon" : currentProject.plotShape))}`
+                    + `&plotShape=${(currentPlot.plotGeom.includes("Point") ? currentProject.plotShape : "polygon")}`
                     + `&aoi=${encodeURIComponent(`[${mercator.getViewExtent(mapConfig)}]`)}`
-                    + `&daterange=&bcenter=${currentPlot.center}`
+                    + `&bcenter=${currentPlot.center}`
                     + `&bradius=${plotRadius}`,
                     `_geo-dash_${this.props.projectId}`);
     };
@@ -531,9 +534,8 @@ class Collection extends React.Component {
 
     navToFirstPlot = () => this.getNextPlotData(-10000000);
 
-    getPlotId = () => (isNumber(this.state.currentPlot.plotId)
-        ? this.state.currentPlot.plotId
-        : this.state.currentPlot.id);
+    // TODO, consider edge cases. Consider using plot_id to navigate.
+    getPlotId = () => this.state.currentPlot.visibleId;
 
     navToNextPlot = () => this.getNextPlotData(this.getPlotId());
 

--- a/src/js/components/SurveyQuestionRules.js
+++ b/src/js/components/SurveyQuestionRules.js
@@ -26,7 +26,7 @@ function Question({text}) {
             &quot;{(textIsArray ? truncjoin(text) : truncate(text, 15))}&quot;
             {(textIsArray || text.length >= 15)
                 && (
-                    <span className="tooltip_content" style={{"font-size": "0.8rem"}}>
+                    <span className="tooltip_content" style={{"fontSize": "0.8rem"}}>
                         {textIsArray ? text.join(", ") : text}
                     </span>
                 )}

--- a/src/js/geoDash.js
+++ b/src/js/geoDash.js
@@ -108,9 +108,7 @@ class Geodash extends React.Component {
             return fetch(`/get-plot-sample-geom?plotId=${plotId}`)
                 .then(response => (response.ok ? response.json() : Promise.reject(response)))
                 .then(plotJsonObject => {
-                    const sampleGeoms = (plotJsonObject.samples || []).map(e => e.sampleGeom);
-                    console.log(sampleGeoms);
-                    const features = [plotJsonObject.plotGeom].concat(sampleGeoms)
+                    const features = [plotJsonObject.plotGeom, ...(plotJsonObject.sampleGeoms || [])]
                         .filter(e => e)
                         .map(geom => new Feature({geometry: mercator.parseGeoJson(geom, true)}));
                     return Promise.resolve(new Vector({features}));

--- a/src/js/geoDash.js
+++ b/src/js/geoDash.js
@@ -108,8 +108,9 @@ class Geodash extends React.Component {
             return fetch(`/get-plot-sample-geom?plotId=${plotId}`)
                 .then(response => (response.ok ? response.json() : Promise.reject(response)))
                 .then(plotJsonObject => {
-                    const sampleGeom = (plotJsonObject.samples || []).map(e => e.geom);
-                    const features = [plotJsonObject.geom].concat(sampleGeom)
+                    const sampleGeoms = (plotJsonObject.samples || []).map(e => e.sampleGeom);
+                    console.log(sampleGeoms);
+                    const features = [plotJsonObject.plotGeom].concat(sampleGeoms)
                         .filter(e => e)
                         .map(geom => new Feature({geometry: mercator.parseGeoJson(geom, true)}));
                     return Promise.resolve(new Vector({features}));
@@ -132,7 +133,7 @@ class Geodash extends React.Component {
         } else if (plotShape === "circle") {
             return Promise.resolve(new Vector({
                 features: [new Feature(new Circle(
-                    projTransform(JSON.parse(center).coordinates, "EPSG:4326", "EPSG:3857"), radius * 1
+                    projTransform(JSON.parse(center).coordinates, "EPSG:4326", "EPSG:3857"), radius
                 ))]
             }));
         } else {

--- a/src/js/simpleCollection.js
+++ b/src/js/simpleCollection.js
@@ -303,10 +303,10 @@ class SimpleCollection extends React.Component {
         this.setState({currentImagery, imageryAttribution: currentImagery.attribution});
     };
 
-    getPlotData = plotId => this.processModal(
-        `${this.state.localeText.gettingPlot} ${plotId}`,
+    getPlotData = visibleId => this.processModal(
+        `${this.state.localeText.gettingPlot} ${visibleId}`,
         () => fetch("/get-plot-by-id?" + getQueryString({
-            plotId,
+            visibleId,
             projectId: this.props.projectId,
             navigationMode: this.state.navigationMode
         }))
@@ -315,7 +315,7 @@ class SimpleCollection extends React.Component {
                 if (data === "done") {
                     alert(this.state.localeText.navPlot);
                 } else if (data === "not-found") {
-                    alert(this.state.localeText.plotNotFound.replace("{0}", plotId));
+                    alert(this.state.localeText.plotNotFound.replace("{0}", visibleId));
                 } else {
                     this.setState({
                         currentPlot: data,
@@ -331,17 +331,17 @@ class SimpleCollection extends React.Component {
             })
     );
 
-    getNextPlotData = plotId => this.processModal(
-        plotId >= 0 ? this.state.localeText.gettingNextPlot : this.state.localeText.gettingFirstPlot,
+    getNextPlotData = visibleId => this.processModal(
+        visibleId >= 0 ? this.state.localeText.gettingNextPlot : this.state.localeText.gettingFirstPlot,
         () => fetch("/get-next-plot?" + getQueryString({
-            plotId,
+            visibleId,
             projectId: this.props.projectId,
             navigationMode: this.state.navigationMode
         }))
             .then(response => (response.ok ? response.json() : Promise.reject(response)))
             .then(data => {
                 if (data === "done") {
-                    if (plotId === -1) {
+                    if (visibleId === -1) {
                         alert(this.state.navigationMode === "unanalyzed"
                             ? this.state.localeText.navNextUn
                             : this.state.localeText.navNextAn);
@@ -353,7 +353,7 @@ class SimpleCollection extends React.Component {
                     this.setState({
                         currentPlot: data,
                         ...this.newPlotValues(data),
-                        prevPlotButtonDisabled: plotId === -1
+                        prevPlotButtonDisabled: visibleId === -1
                     });
                 }
             })
@@ -363,10 +363,10 @@ class SimpleCollection extends React.Component {
             })
     );
 
-    getPrevPlotData = plotId => this.processModal(
+    getPrevPlotData = visibleId => this.processModal(
         this.state.localeText.gettingPrevPlot,
         () => fetch("/get-prev-plot?" + getQueryString({
-            plotId,
+            visibleId,
             projectId: this.props.projectId,
             navigationMode: this.state.navigationMode
         }))
@@ -394,7 +394,7 @@ class SimpleCollection extends React.Component {
     resetPlotValues = () => this.setState(this.newPlotValues(this.state.currentPlot, false));
 
     newPlotValues = (newPlot, copyValues = true) => ({
-        newPlotInput: isNumber(newPlot.plotId) ? newPlot.plotId : newPlot.id,
+        newPlotInput: isNumber(newPlot.visibleId) ? newPlot.visibleId : newPlot.id,
         userSamples: newPlot.samples
             ? newPlot.samples.reduce((acc, cur) =>
                 ({...acc, [cur.id]: copyValues ? (cur.savedAnswers || {}) : {}}), {})
@@ -427,11 +427,11 @@ class SimpleCollection extends React.Component {
             mapConfig,
             "currentPlot",
             mercator.geometryToVectorSource(
-                currentPlot.geom
-                    ? mercator.parseGeoJson(currentPlot.geom, true)
-                    : mercator.getPlotPolygon(currentPlot.center,
+                currentPlot.plotGeom.includes("Point")
+                    ? mercator.getPlotPolygon(currentPlot.plotGeom,
                                               currentProject.plotSize,
                                               currentProject.plotShape)
+                    : mercator.parseGeoJson(currentPlot.plotGeom, true)
             ),
             mercator.ceoMapStyles("geom", "yellow")
         );
@@ -469,13 +469,9 @@ class SimpleCollection extends React.Component {
 
     navToFirstPlot = () => this.getNextPlotData(-10000000);
 
-    getPlotId = () => (isNumber(this.state.currentPlot.plotId)
-        ? this.state.currentPlot.plotId
-        : this.state.currentPlot.id);
+    navToNextPlot = () => this.getNextPlotData(this.state.currentPlot.visibleId);
 
-    navToNextPlot = () => this.getNextPlotData(this.getPlotId());
-
-    navToPrevPlot = () => this.getPrevPlotData(this.getPlotId());
+    navToPrevPlot = () => this.getPrevPlotData(this.state.currentPlot.visibleId);
 
     navToPlot = newPlot => {
         if (!isNaN(newPlot)) {
@@ -702,8 +698,6 @@ class SimpleCollection extends React.Component {
 
     render() {
         const {imageryAttribution} = this.state;
-        const plotId = this.getPlotId();
-
         const infoStyle = {
             position: "absolute",
             top: "0px",
@@ -796,9 +790,9 @@ class SimpleCollection extends React.Component {
                                 navToPlot={this.navToPlot}
                                 navToPrevPlot={this.navToPrevPlot}
                                 nextPlotButtonDisabled={this.state.nextPlotButtonDisabled}
-                                plotId={plotId}
                                 prevPlotButtonDisabled={this.state.prevPlotButtonDisabled}
                                 setNavigationMode={this.setNavigationMode}
+                                visibleId={this.state.currentPlot.visibleId}
                             />
                             <div className="my-3"/>
                             <ImageryOptions
@@ -817,7 +811,11 @@ class SimpleCollection extends React.Component {
                             {!this.state.isMobile && this.state.KMLFeatures && (
                                 <a
                                     className="btn btn-outline-lightgreen btn-sm btn-block my-2"
-                                    download={"ceo_projectId-" + this.state.currentProject.id + "_plotId-" + plotId + ".kml"}
+                                    download={"ceo_projectId-"
+                                        + this.state.currentProject.id
+                                        + "_plotId-"
+                                        + this.state.currentPlot.visibleId
+                                        + ".kml"}
                                     href={"data:earth.kml+xml application/vnd.google-earth.kmz, "
                                         + encodeURIComponent(this.state.KMLFeatures)}
                                 >
@@ -941,7 +939,7 @@ class PlotNavigation extends React.Component {
     }
 
     componentDidUpdate(prevProps) {
-        if (this.props.plotId !== prevProps.plotId) this.setState({newPlotInput: this.props.plotId});
+        if (this.props.visibleId !== prevProps.visibleId) this.setState({newPlotInput: this.props.visibleId});
     }
 
     updateNewPlotId = value => this.setState({newPlotInput: value});

--- a/src/js/utils/mercator.js
+++ b/src/js/utils/mercator.js
@@ -1178,7 +1178,7 @@ mercator.samplesToVectorSource = samples => {
     const features = samples.map(
         sample => new Feature({
             sampleId: sample.id,
-            geometry: mercator.parseGeoJson(sample.geom || sample.sampleGeom, true)
+            geometry: mercator.parseGeoJson(sample.sampleGeom, true)
         })
     );
     return new VectorSource({features});

--- a/src/sql/changes/clean-old-data.sql
+++ b/src/sql/changes/clean-old-data.sql
@@ -1,30 +1,5 @@
 -- Validate and then move to functions where it can run every time the server is re-deployed
 
--- Clean up any orphaned tables
-DO $$
- DECLARE
-    _sql text;
- BEGIN
-    SELECT INTO _sql
-        string_agg(format('DROP TABLE ext_tables.%s;', table_name), E'\n')
-    FROM (
-        SELECT table_name,
-            (SELECT project_uid FROM projects WHERE plots_ext_table = table_name) as p,
-            (SELECT project_uid FROM projects WHERE samples_ext_table = table_name) as s
-        FROM information_schema.tables
-        WHERE table_schema='ext_tables'
-            AND table_type='BASE TABLE'
-    ) a
-    WHERE p is null and s is null;
-
-    IF _sql IS NOT NULL THEN
-        EXECUTE _sql;
-    ELSE
-        RAISE NOTICE 'No orphaned tables found.';
-    END IF;
- END
-$$ LANGUAGE plpgsql;
-
 -- Archive malformed projects
 SELECT (SELECT archive_project(project_uid))
 FROM projects

--- a/src/sql/changes/update_2021-06-28_retire_ext_tables.sql
+++ b/src/sql/changes/update_2021-06-28_retire_ext_tables.sql
@@ -1,0 +1,256 @@
+-- Add new columns
+ALTER TABLE plots ADD COLUMN plot_geom geometry(geometry,4326);
+ALTER TABLE plots ADD COLUMN visible_id integer;
+ALTER TABLE plots ADD COLUMN ext_plot_info jsonb;
+ALTER TABLE samples ADD COLUMN visible_id integer;
+ALTER TABLE samples ADD COLUMN ext_sample_info jsonb;
+
+-- Migrate data
+CREATE OR REPLACE FUNCTION merge_ext_plots(_project_id integer)
+ RETURNS void AS $$
+
+ DECLARE
+    i1 integer;
+    i2 integer;
+    _plots_ext_table text;
+ BEGIN
+    SELECT plots_ext_table INTO _plots_ext_table FROM projects WHERE project_uid = _project_id;
+    IF _plots_ext_table IS NULL OR _plots_ext_table = '' THEN RETURN; END IF;
+
+    EXECUTE 'SELECT * FROM information_schema.columns
+                WHERE table_name = ''' || _plots_ext_table || '''
+                AND (column_name = ''lon'' OR column_name = ''lat'')
+                AND data_type = ''double precision''';
+    GET DIAGNOSTICS i1 = ROW_COUNT;
+    IF i1 = 2 THEN EXECUTE
+        'ALTER table ext_tables.' || _plots_ext_table || ' ADD COLUMN IF NOT EXISTS plotid integer;
+
+        UPDATE plots p
+        SET plot_geom = a.plot_geom,
+            visible_id = a.plotid,
+            ext_plot_info = a.row
+        FROM (
+            SELECT plot_uid,
+                plotid::integer as plotid,
+                ST_SetSRID(ST_MakePoint(lon, lat), 4326) as plot_geom,
+                row_to_json(xxx)::jsonb - ''lat'' - ''lon'' - ''gid'' - ''plotid'' as row
+            FROM plots p
+            INNER JOIN ext_tables.' || _plots_ext_table || ' xxx
+               ON ext_id = gid
+            WHERE project_rid = ' || _project_id
+        || ') a
+        WHERE p.plot_uid = a.plot_uid';
+    END IF;
+
+    EXECUTE 'SELECT * FROM information_schema.columns
+                WHERE table_name = ''' || _plots_ext_table || '''
+                AND column_name = ''geom''';
+    GET DIAGNOSTICS i2 = ROW_COUNT;
+    IF i2 = 1 THEN EXECUTE
+        'ALTER table ext_tables.' || _plots_ext_table || ' ADD COLUMN IF NOT EXISTS plotid integer;
+
+        UPDATE plots p
+        SET plot_geom = a.plot_geom,
+            visible_id = a.plotid,
+            ext_plot_info = a.row
+        FROM (
+            SELECT plot_uid,
+                plotid::integer as plotid,
+                ST_Force2D(geom) as plot_geom,
+                row_to_json(xxx)::jsonb - ''geom'' - ''gid'' - ''plotid'' as row
+            FROM plots p
+            INNER JOIN ext_tables.' || _plots_ext_table || ' xxx
+               ON ext_id = gid
+            WHERE project_rid = ' || _project_id
+        || ') a
+        WHERE p.plot_uid = a.plot_uid';
+    END IF;
+ END
+
+$$ LANGUAGE PLPGSQL;
+
+DO $$
+
+ DECLARE
+    pid RECORD;
+ BEGIN
+    FOR pid IN SELECT * FROM projects WHERE plots_ext_table IS NOT NULL
+    LOOP
+        PERFORM merge_ext_plots(pid.project_uid);
+    END LOOP;
+ END
+
+$$ LANGUAGE PLPGSQL;
+
+CREATE OR REPLACE FUNCTION merge_ext_samples(_project_id integer)
+ RETURNS void AS $$
+
+ DECLARE
+    i1 integer;
+    i2 integer;
+    _samples_ext_table text;
+ BEGIN
+    SELECT samples_ext_table INTO _samples_ext_table FROM projects WHERE project_uid = _project_id;
+    IF _samples_ext_table IS NULL OR _samples_ext_table = '' THEN RETURN; END IF;
+
+    EXECUTE 'SELECT * FROM information_schema.columns
+                WHERE table_name = ''' || _samples_ext_table || '''
+                AND (column_name = ''lon'' OR column_name = ''lat'')
+                AND data_type = ''double precision''';
+    GET DIAGNOSTICS i1 = ROW_COUNT;
+    IF i1 = 2 THEN EXECUTE
+        'ALTER table ext_tables.' || _samples_ext_table || ' ADD COLUMN IF NOT EXISTS sampleid integer;
+
+        UPDATE samples p
+        SET sample_geom = a.sample_geom,
+            visible_id = a.sampleid,
+            ext_sample_info = a.row
+        FROM (
+            SELECT sample_uid,
+                sampleid::integer as sampleid,
+                ST_SetSRID(ST_MakePoint(lon, lat), 4326) as sample_geom,
+                row_to_json(xxx)::jsonb - ''lat'' - ''lon'' - ''gid'' - ''plotid'' - ''sampleid'' as row
+            FROM plots
+            INNER JOIN samples s
+                ON plot_uid = plot_rid
+            INNER JOIN ext_tables.' || _samples_ext_table || ' xxx
+               ON s.ext_id = gid
+            WHERE project_rid = ' || _project_id
+        || ') a
+        WHERE p.sample_uid = a.sample_uid';
+    END IF;
+
+    EXECUTE 'SELECT * FROM information_schema.columns
+                WHERE table_name = ''' || _samples_ext_table || '''
+                AND column_name = ''geom''';
+    GET DIAGNOSTICS i2 = ROW_COUNT;
+    IF i2 = 1 THEN EXECUTE
+        'ALTER table ext_tables.' || _samples_ext_table || ' ADD COLUMN IF NOT EXISTS sampleid integer;
+
+        UPDATE samples p
+        SET sample_geom = a.sample_geom,
+            visible_id = a.sampleid,
+            ext_sample_info = a.row
+        FROM (
+            SELECT sample_uid,
+                sampleid::integer as sampleid,
+                ST_Force2D(geom) as sample_geom,
+                row_to_json(xxx)::jsonb - ''geom'' - ''gid'' - ''plotid'' - ''sampleid'' as row
+            FROM plots
+            INNER JOIN samples s
+                ON plot_uid = plot_rid
+            INNER JOIN ext_tables.' || _samples_ext_table || ' xxx
+               ON s.ext_id = gid
+            WHERE project_rid = ' || _project_id
+        || ') a
+        WHERE p.sample_uid = a.sample_uid';
+    END IF;
+ END
+
+$$ LANGUAGE PLPGSQL;
+
+DO $$
+
+ DECLARE
+    pid RECORD;
+ BEGIN
+    FOR pid IN SELECT * FROM projects WHERE samples_ext_table IS NOT NULL
+    LOOP
+        PERFORM merge_ext_samples(pid.project_uid);
+    END LOOP;
+ END
+
+$$ LANGUAGE PLPGSQL;
+
+-- Fill in missing
+UPDATE plots
+SET plot_geom = center
+WHERE plot_geom IS NULL;
+
+-- FIXME, use row over query to update visible ids.
+UPDATE plots p
+SET visible_id = row_num
+FROM (
+    SELECT plot_uid,
+    row_number() OVER(PARTITION BY project_rid ORDER BY plot_uid)::int AS row_num
+    FROM plots
+    WHERE visible_id IS NULL
+    ORDER BY project_rid, plot_uid
+) AS np
+WHERE p.plot_uid = np.plot_uid;
+
+
+CREATE TABLE temp_samp (
+    sample_uid    integer,
+    vis_id        integer
+);
+
+INSERT INTO temp_samp
+SELECT sample_uid,
+    row_number() OVER(PARTITION BY project_rid ORDER BY sample_uid)::int AS row_num
+FROM plots
+INNER JOIN samples s
+    ON plot_uid = plot_rid
+WHERE s.visible_id IS NULL;
+
+CREATE INDEX su ON temp_samp (sample_uid);
+
+UPDATE samples p
+SET visible_id = vis_id
+FROM temp_samp t
+WHERE p.sample_uid = t.sample_uid;
+
+DROP TABLE temp_samp;
+
+-- Drop old column
+ALTER TABLE plots DROP COLUMN center;
+ALTER TABLE plots DROP COLUMN ext_id;
+ALTER TABLE samples DROP COLUMN ext_id;
+ALTER TABLE projects DROP COLUMN plots_ext_table;
+ALTER TABLE projects DROP COLUMN samples_ext_table;
+
+DO $$
+
+ DECLARE
+    pid RECORD;
+ BEGIN
+    FOR pid IN SELECT * FROM projects LIMIT 10000
+    LOOP
+        EXECUTE
+        'DROP TABLE IF EXISTS ext_tables.project_' || pid.project_uid || '_plots_csv;'
+        'DROP TABLE IF EXISTS ext_tables.project_' || pid.project_uid || '_plots_shp;'
+        'DROP TABLE IF EXISTS ext_tables.project_' || pid.project_uid || '_samples_csv;'
+        'DROP TABLE IF EXISTS ext_tables.project_' || pid.project_uid || '_samples_shp;';
+    END LOOP;
+ END
+
+$$ LANGUAGE PLPGSQL;
+
+DO $$
+
+ DECLARE
+    pid RECORD;
+ BEGIN
+    FOR pid IN SELECT * FROM projects
+    LOOP
+        EXECUTE
+        'DROP TABLE IF EXISTS ext_tables.project_' || pid.project_uid || '_plots_csv;'
+        'DROP TABLE IF EXISTS ext_tables.project_' || pid.project_uid || '_plots_shp;'
+        'DROP TABLE IF EXISTS ext_tables.project_' || pid.project_uid || '_samples_csv;'
+        'DROP TABLE IF EXISTS ext_tables.project_' || pid.project_uid || '_samples_shp;';
+    END LOOP;
+ END
+
+$$ LANGUAGE PLPGSQL;
+
+DROP schema ext_tables CASCADE;
+
+VACUUM FULL;
+
+-- Verify migration
+SELECT project_uid, plots_ext_table, count(1), count(ext_plot_info)
+FROM projects
+INNER JOIN plots
+    ON project_uid = project_rid
+    AND plots_ext_table is not null
+GROUP BY project_uid

--- a/src/sql/create_db.sql
+++ b/src/sql/create_db.sql
@@ -5,5 +5,3 @@ CREATE DATABASE ceo WITH OWNER ceo;
 \c ceo
 CREATE EXTENSION postgis;
 CREATE EXTENSION pgcrypto;
--- Schema for external tables
-CREATE SCHEMA ext_tables AUTHORIZATION ceo;

--- a/src/sql/dev_data/dev_data.sql
+++ b/src/sql/dev_data/dev_data.sql
@@ -26,7 +26,7 @@ VALUES
 
 SELECT setval(pg_get_serial_sequence('institution_users', 'inst_user_uid'), (SELECT MAX(inst_user_uid) FROM institution_users) + 1);
 
--- Adds an intitutiom imagery
+-- Adds an institution imagery
 INSERT INTO imagery
     (institution_rid, visibility, title, attribution, extent, source_config)
 VALUES
@@ -85,63 +85,63 @@ VALUES
 
 -- Add 4 plots
 INSERT INTO plots
-    (plot_uid, project_rid, center)
+    (plot_uid, project_rid, plot_geom, visible_id)
 VALUES
-    (1, 1, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[102.999640127073,22.0468074686287]}'), 4326)),
-    (2, 1, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[98.5680216776391,12.3793535946933]}'), 4326)),
-    (3, 1, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[106.718471401115,13.7459074361384]}'), 4326));
+    (1, 1, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[102.999640127073,22.0468074686287]}'), 4326), 1),
+    (2, 1, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[98.5680216776391,12.3793535946933]}'), 4326), 2),
+    (3, 1, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[106.718471401115,13.7459074361384]}'), 4326), 3);
 
 SELECT setval(pg_get_serial_sequence('plots', 'plot_uid'), (SELECT MAX(plot_uid) FROM plots) + 1);
 
 -- Add 10 samples per 3 plots
 INSERT INTO samples
-    (plot_rid, sample_geom)
+    (plot_rid, sample_geom, visible_id)
 VALUES
-    (1, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[103.000003879452,22.0468975929135]}'), 4326)),
-    (1, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[102.999659597506,22.0468036237562]}'), 4326)),
-    (1, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[102.999501703938,22.0467991514296]}'), 4326)),
-    (1, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[102.998949185863,22.0466248615901]}'), 4326)),
-    (1, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[102.99966198978,22.0466084221078]}'), 4326)),
-    (1, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[102.999566464554,22.0463120389197]}'), 4326)),
-    (1, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[102.999740489714,22.0468942725417]}'), 4326)),
-    (1, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[102.999223221942,22.0465117917509]}'), 4326)),
-    (1, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[102.999452134532,22.0466484482659]}'), 4326)),
-    (1, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[102.999890834681,22.0467964915768]}'), 4326)),
-    (1, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[103.000254645522,22.04669295608]}'), 4326)),
-    (1, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[102.999719482979,22.0465994297173]}'), 4326)),
-    (1, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[102.999139315219,22.0466135869806]}'), 4326)),
-    (1, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[102.999807083116,22.0466539723281]}'), 4326)),
-    (1, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[102.999723982592,22.0474907559667]}'), 4326)),
-    (2, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[98.5680208639992,12.3792772955153]}'), 4326)),
-    (2, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[98.5681408052842,12.378997629299]}'), 4326)),
-    (2, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[98.5674893527881,12.3791403221257]}'), 4326)),
-    (2, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[98.5676406856725,12.3790404496009]}'), 4326)),
-    (2, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[98.5680795299306,12.3792172223556]}'), 4326)),
-    (2, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[98.5685366624246,12.3787821289617]}'), 4326)),
-    (2, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[98.5680099128529,12.3795410368552]}'), 4326)),
-    (2, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[98.5681464703452,12.3792672309771]}'), 4326)),
-    (2, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[98.5673981032599,12.3791330862771]}'), 4326)),
-    (2, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[98.5688706092875,12.3796102435328]}'), 4326)),
-    (2, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[98.5684360084512,12.3792116012074]}'), 4326)),
-    (2, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[98.5681511311399,12.3795313477436]}'), 4326)),
-    (2, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[98.5673749749785,12.3789225927278]}'), 4326)),
-    (2, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[98.5679345010481,12.3795452545641]}'), 4326)),
-    (2, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[98.5677401971136,12.3791719391359]}'), 4326)),
-    (3, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[106.719017040138,13.7464939415532]}'), 4326)),
-    (3, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[106.718555513054,13.7463215099279]}'), 4326)),
-    (3, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[106.7185236659,13.7464061467244]}'), 4326)),
-    (3, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[106.718791845779,13.7464815711221]}'), 4326)),
-    (3, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[106.718712185681,13.7457456666488]}'), 4326)),
-    (3, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[106.717733763325,13.7459559669583]}'), 4326)),
-    (3, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[106.718182494124,13.7456356732466]}'), 4326)),
-    (3, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[106.718202305812,13.7457602170494]}'), 4326)),
-    (3, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[106.718580714415,13.7457414612821]}'), 4326)),
-    (3, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[106.718156929973,13.7455628153881]}'), 4326)),
-    (3, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[106.718658109221,13.74519156337]}'), 4326)),
-    (3, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[106.717683299127,13.7458568865769]}'), 4326)),
-    (3, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[106.718498811146,13.7459316835242]}'), 4326)),
-    (3, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[106.718562527415,13.7452788216232]}'), 4326)),
-    (3, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[106.717809924561,13.7458799404487]}'), 4326));
+    (1, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[103.000003879452,22.0468975929135]}'), 4326), 1),
+    (1, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[102.999659597506,22.0468036237562]}'), 4326), 2),
+    (1, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[102.999501703938,22.0467991514296]}'), 4326), 3),
+    (1, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[102.998949185863,22.0466248615901]}'), 4326), 4),
+    (1, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[102.99966198978,22.0466084221078]}'), 4326)), 5,
+    (1, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[102.999566464554,22.0463120389197]}'), 4326), 6),
+    (1, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[102.999740489714,22.0468942725417]}'), 4326), 7),
+    (1, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[102.999223221942,22.0465117917509]}'), 4326), 8),
+    (1, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[102.999452134532,22.0466484482659]}'), 4326), 9),
+    (1, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[102.999890834681,22.0467964915768]}'), 4326), 10),
+    (1, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[103.000254645522,22.04669295608]}'), 4326), 11),
+    (1, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[102.999719482979,22.0465994297173]}'), 4326), 12),
+    (1, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[102.999139315219,22.0466135869806]}'), 4326), 13),
+    (1, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[102.999807083116,22.0466539723281]}'), 4326), 14),
+    (1, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[102.999723982592,22.0474907559667]}'), 4326), 15),
+    (2, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[98.5680208639992,12.3792772955153]}'), 4326), 16),
+    (2, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[98.5681408052842,12.378997629299]}'), 4326), 17),
+    (2, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[98.5674893527881,12.3791403221257]}'), 4326), 18),
+    (2, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[98.5676406856725,12.3790404496009]}'), 4326), 19),
+    (2, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[98.5680795299306,12.3792172223556]}'), 4326), 20),
+    (2, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[98.5685366624246,12.3787821289617]}'), 4326), 21),
+    (2, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[98.5680099128529,12.3795410368552]}'), 4326), 22),
+    (2, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[98.5681464703452,12.3792672309771]}'), 4326), 23),
+    (2, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[98.5673981032599,12.3791330862771]}'), 4326), 24),
+    (2, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[98.5688706092875,12.3796102435328]}'), 4326), 25),
+    (2, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[98.5684360084512,12.3792116012074]}'), 4326), 26),
+    (2, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[98.5681511311399,12.3795313477436]}'), 4326), 27),
+    (2, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[98.5673749749785,12.3789225927278]}'), 4326), 28),
+    (2, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[98.5679345010481,12.3795452545641]}'), 4326), 29),
+    (2, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[98.5677401971136,12.3791719391359]}'), 4326), 30),
+    (3, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[106.719017040138,13.7464939415532]}'), 4326), 31),
+    (3, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[106.718555513054,13.7463215099279]}'), 4326), 32),
+    (3, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[106.7185236659,13.7464061467244]}'), 4326), 33),
+    (3, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[106.718791845779,13.7464815711221]}'), 4326), 34),
+    (3, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[106.718712185681,13.7457456666488]}'), 4326), 35),
+    (3, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[106.717733763325,13.7459559669583]}'), 4326), 36),
+    (3, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[106.718182494124,13.7456356732466]}'), 4326), 37),
+    (3, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[106.718202305812,13.7457602170494]}'), 4326), 38),
+    (3, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[106.718580714415,13.7457414612821]}'), 4326), 39),
+    (3, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[106.718156929973,13.7455628153881]}'), 4326), 40),
+    (3, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[106.718658109221,13.74519156337]}'), 4326), 41),
+    (3, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[106.717683299127,13.7458568865769]}'), 4326), 42),
+    (3, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[106.718498811146,13.7459316835242]}'), 4326), 43),
+    (3, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[106.718562527415,13.7452788216232]}'), 4326), 44),
+    (3, ST_SetSRID(ST_GeomFromGeoJSON('{"type":"Point","coordinates":[106.717809924561,13.7458799404487]}'), 4326), 45);
 
 -- Add 2 widgets
 INSERT INTO project_widgets

--- a/src/sql/functions/project.sql
+++ b/src/sql/functions/project.sql
@@ -1237,7 +1237,7 @@ CREATE OR REPLACE FUNCTION dump_project_plot_data(_project_id integer)
     samples                    text,
     common_securewatch_date    text,
     total_securewatch_dates    integer,
-    ext_plot_data              jsonb
+    ext_plot_info              jsonb
  ) AS $$
 
     SELECT plot_uid,
@@ -1293,14 +1293,14 @@ CREATE OR REPLACE FUNCTION dump_project_sample_data(_project_id integer)
         imagery_attributes    text,
         sample_geom           text,
         saved_answers         jsonb,
-        ext_plot_data         jsonb,
-        ext_sample_data       jsonb
+        ext_plot_info         jsonb,
+        ext_sample_info       jsonb
  ) AS $$
 
     SELECT plot_uid,
         sample_uid,
-        CASE WHEN ST_GeometryType(sample_geom) = 'ST_Point' THEN ST_X(sample_geom) ELSE -1 END AS lon,
-        CASE WHEN ST_GeometryType(sample_geom) = 'ST_Point' THEN ST_Y(sample_geom) ELSE -1 END AS lat,
+        ST_X(ST_Centroid(sample_geom)) AS lon,
+        ST_Y(ST_Centroid(sample_geom)) AS lat,
         email,
         flagged,
         collection_time,

--- a/src/sql/functions/project.sql
+++ b/src/sql/functions/project.sql
@@ -2,130 +2,6 @@
 -- REQUIRES: clear
 
 --
---  READ EXTERNAL FILE FUNCTIONS
---
-
--- Select known columns from a shp or csv file
-CREATE OR REPLACE FUNCTION select_partial_table_by_name(_table_name text)
- RETURNS table (
-    ext_id    integer,
-    plotId    integer,
-    center    geometry,
-    geom      geometry
- ) AS $$
-
- DECLARE
-    i integer;
- BEGIN
-    IF _table_name IS NULL OR _table_name = '' THEN RETURN; END IF;
-    EXECUTE 'SELECT * FROM information_schema.columns
-                WHERE table_name = ''' || _table_name || ''' AND column_name = ''geom''';
-    GET DIAGNOSTICS i = ROW_COUNT;
-    IF i = 0
-    THEN
-        RETURN QUERY EXECUTE
-            'SELECT gid, plotid::integer, ST_SetSRID(ST_MakePoint(lon, lat), 4326), ST_Centroid(NULL) as geom FROM ext_tables.' || _table_name;
-    ELSE
-        RETURN QUERY EXECUTE
-            'SELECT gid, plotid::integer, ST_Centroid(ST_Force2D(geom)), ST_Force2D(geom) FROM ext_tables.' || _table_name;
-    END IF;
- END
-
-$$ LANGUAGE PLPGSQL;
-
--- Converts all columns (including unknown) to a single json column for processing
-CREATE OR REPLACE FUNCTION select_json_table_by_name(_table_name text)
- RETURNS table (
-    ext_id      integer,
-    rem_data    jsonb
- ) AS $$
-
- DECLARE
-    i integer;
- BEGIN
-    IF _table_name IS NULL OR _table_name = '' THEN RETURN; END IF;
-
-    RETURN QUERY EXECUTE 'SELECT gid, row_to_json(p)::jsonb FROM ext_tables.' || _table_name || ' as p';
- END
-
-$$ LANGUAGE PLPGSQL;
-
--- Select known columns from a shp or csv file
-CREATE OR REPLACE FUNCTION select_partial_sample_table_by_name(_table_name text)
- RETURNS table (
-    ext_id      integer,
-    plotId      integer,
-    sampleId    integer,
-    center      geometry,
-    geom        geometry
- ) AS $$
-
- DECLARE
-    i integer;
- BEGIN
-    IF _table_name IS NULL OR _table_name = '' THEN RETURN; END IF;
-    EXECUTE 'SELECT * FROM information_schema.columns
-                    WHERE table_name = ''' || _table_name || ''' AND column_name = ''geom''';
-    GET DIAGNOSTICS i = ROW_COUNT;
-    IF i = 0
-    THEN
-        RETURN QUERY EXECUTE
-            'SELECT gid, plotId::integer, sampleId::integer, ST_SetSRID(ST_MakePoint(lon, lat), 4326), ST_Centroid(NULL) as geom FROM ext_tables.' || _table_name;
-    ELSE
-        RETURN QUERY EXECUTE
-            'SELECT gid, plotId::integer, sampleId::integer, ST_Centroid(ST_Force2D(geom)), ST_Force2D(geom) FROM ext_tables.' || _table_name;
-    END IF;
- END
-
-$$ LANGUAGE PLPGSQL;
-
--- Returns all headers without prior knowledge
-CREATE OR REPLACE FUNCTION get_plot_headers(_project_id integer)
- RETURNS table (column_names text) AS $$
-
- DECLARE
-    _plots_ext_table text;
- BEGIN
-    SELECT plots_ext_table INTO _plots_ext_table FROM projects WHERE project_uid = _project_id;
-
-    IF _plots_ext_table IS NOT NULL THEN
-        RETURN QUERY EXECUTE
-        'SELECT column_name::text FROM information_schema.columns
-            WHERE table_name = ''' || _plots_ext_table || '''';
-    END IF;
- END
-
-$$ LANGUAGE PLPGSQL;
-
--- Returns all headers without prior knowledge
-CREATE OR REPLACE FUNCTION get_sample_headers(_project_id integer)
- RETURNS table (column_names text) AS $$
-
- DECLARE
-    _samples_ext_table text;
- BEGIN
-    SELECT samples_ext_table INTO _samples_ext_table FROM projects WHERE project_uid = _project_id;
-
-    IF _samples_ext_table IS NOT NULL THEN
-        RETURN QUERY EXECUTE
-        'SELECT column_name::text FROM information_schema.columns
-        WHERE table_name = ''' || _samples_ext_table || '''';
-    END IF;
- END
-
-$$ LANGUAGE PLPGSQL;
-
--- Create empty table before loading external data
-CREATE OR REPLACE FUNCTION create_new_table(_table_name text, _cols text)
- RETURNS void AS $$
-
- BEGIN
-    EXECUTE 'CREATE TABLE ext_tables.' || _table_name || '(' || _cols || ')';
- END
-
-$$ LANGUAGE PLPGSQL;
-
---
 --  WIDGET FUNCTIONS
 --
 
@@ -363,39 +239,6 @@ CREATE OR REPLACE FUNCTION update_project(
 
 $$ LANGUAGE SQL;
 
-CREATE OR REPLACE FUNCTION delete_project_tables(_project_id integer)
- RETURNS void AS $$
-
- BEGIN
-
-    UPDATE projects
-    SET samples_ext_table = null,
-        plots_ext_table = null
-    WHERE project_uid = _project_id;
-
-    EXECUTE
-    'DROP TABLE IF EXISTS ext_tables.project_' || _project_id || '_plots_csv;'
-    'DROP TABLE IF EXISTS ext_tables.project_' || _project_id || '_plots_shp;'
-    'DROP TABLE IF EXISTS ext_tables.project_' || _project_id || '_samples_csv;'
-    'DROP TABLE IF EXISTS ext_tables.project_' || _project_id || '_samples_shp;';
- END
-
-$$ LANGUAGE PLPGSQL;
-
-CREATE OR REPLACE FUNCTION delete_project_sample_table(_project_id integer)
- RETURNS void AS $$
-
- BEGIN
-
-    UPDATE projects SET samples_ext_table = null WHERE project_uid = _project_id;
-
-    EXECUTE
-    'DROP TABLE IF EXISTS ext_tables.project_' || _project_id || '_samples_csv;'
-    'DROP TABLE IF EXISTS ext_tables.project_' || _project_id || '_samples_shp;';
- END
-
-$$ LANGUAGE PLPGSQL;
-
 -- Update counts after plots are created
 CREATE OR REPLACE FUNCTION update_project_counts(_project_id integer)
  RETURNS void AS $$
@@ -429,6 +272,7 @@ $$ LANGUAGE SQL;
 --  CLEAN UP FUNCTIONS
 
 -- Delete duplicates after loading
+-- FIXME, can this be done in clj? We should probably be rejecting duplicate data
 CREATE OR REPLACE FUNCTION delete_duplicates(_table_name text, _on_cols text)
  RETURNS void AS $$
 
@@ -451,242 +295,56 @@ CREATE OR REPLACE FUNCTION delete_duplicates(_table_name text, _on_cols text)
 $$ LANGUAGE PLPGSQL;
 
 -- Calculates boundary from for csv data
-CREATE OR REPLACE FUNCTION csv_boundary(_project_id integer, _m_buffer real)
+-- FIXME, for shapes call with buffer 0
+CREATE OR REPLACE FUNCTION set_boundary(_project_id integer, _m_buffer real)
  RETURNS void AS $$
 
     UPDATE projects SET boundary = b
     FROM (
-        SELECT ST_Envelope(ST_Buffer(ST_SetSRID(ST_Extent(center) , 4326)::geography , _m_buffer)::geometry) as b
-        FROM select_partial_table_by_name((
-            SELECT plots_ext_table
-            FROM projects
-            WHERE project_uid = _project_id
-    ))) bb
-    WHERE project_uid = _project_id
-
-$$ LANGUAGE SQL;
-
--- Calculates boundary from shp file using geometry. Padding not needed.
-CREATE OR REPLACE FUNCTION shp_boundary(_project_id integer)
- RETURNS void AS $$
-
-    UPDATE projects SET boundary = b
-    FROM (
-        SELECT ST_SetSRID(ST_Extent(geom), 4326) AS b
-        FROM select_partial_table_by_name((
-            SELECT plots_ext_table
-            FROM projects
-            WHERE project_uid = _project_id
-    ))) bb
-    WHERE project_uid = _project_id
-
-$$ LANGUAGE SQL;
-
--- Runs a few functions after data has been uploaded
-CREATE OR REPLACE FUNCTION cleanup_project_tables(_project_id integer, _m_buffer real)
- RETURNS void AS $$
-
-    DECLARE
-        _plots_ext_table text;
-        _samples_ext_table text;
-    BEGIN
-        SELECT plots_ext_table INTO _plots_ext_table FROM projects WHERE project_uid = _project_id;
-        SELECT samples_ext_table INTO _samples_ext_table FROM projects WHERE project_uid = _project_id;
-
-        IF _plots_ext_table SIMILAR TO '%(_csv)' THEN
-            PERFORM csv_boundary(_project_id, _m_buffer);
-        ELSIF _plots_ext_table SIMILAR TO '%(_shp)' THEN
-            PERFORM shp_boundary(_project_id);
-        END IF;
-
-        -- TODO consider rejecting files with duplicate data
-        PERFORM delete_duplicates(_plots_ext_table, 'plotid');
-        PERFORM delete_duplicates(_samples_ext_table, 'plotid, sampleid');
-    END
-
-$$ LANGUAGE PLPGSQL;
-
--- Add plots from file
-CREATE OR REPLACE FUNCTION add_file_plots(_project_id integer)
- RETURNS table (
-    plot_uid    integer,
-    plotid      integer,
-    lon         double precision,
-    lat         double precision
- ) AS $$
-
-    WITH plot_tbl AS (
-        SELECT * FROM select_partial_table_by_name((
-            SELECT plots_ext_table
-            FROM projects
-            WHERE project_uid = _project_id
-    ))), plotrows AS (
-        INSERT INTO plots (project_rid, center, ext_id)
-        SELECT _project_id, center, ext_id
-        FROM plot_tbl
-        RETURNING plot_uid, ext_id, center
-    )
-
-    SELECT plot_uid, plotid, ST_X(plotrows.center), ST_Y(plotrows.center)
-    FROM plotrows
-    INNER JOIN plot_tbl
-        ON plotrows.ext_id = plot_tbl.ext_id
-
-$$ LANGUAGE SQL;
-
--- Add samples from file assuming plot data will also come from a file
-CREATE OR REPLACE FUNCTION samples_from_plots_with_files(_project_id integer)
- RETURNS integer AS $$
-
-    WITH sample_tbl AS (
-        SELECT * FROM select_partial_table_by_name((
-            SELECT samples_ext_table
-            FROM projects
-            WHERE project_uid = _project_id
-        )) as st
-        INNER JOIN add_file_plots(_project_id) asp
-            ON asp.plotId = st.plotId
-    ), samplerows AS (
-        INSERT INTO samples (plot_rid, sample_geom, ext_id)
-        SELECT plot_uid, center as sample_geom, ext_id
-        FROM sample_tbl
-        RETURNING sample_uid, ext_id, sample_geom
-    )
-
-    SELECT COUNT(*)::integer
-    FROM samplerows
-    INNER JOIN sample_tbl
-        ON samplerows.ext_id = sample_tbl.ext_id
-
-$$ LANGUAGE SQL;
-
-CREATE OR REPLACE FUNCTION samples_from_ext_tables(_project_id integer)
- RETURNS integer AS $$
-
-    WITH plots_tbl AS (
-        SELECT plotId, plot_uid
-        FROM select_partial_table_by_name((
-            SELECT plots_ext_table
-            FROM projects
-            WHERE project_uid = _project_id
-        )) asp
-        INNER JOIN plots p
-            ON p.ext_id = asp.ext_id
+        SELECT ST_Envelope(ST_Buffer(ST_SetSRID(ST_Extent(plot_geom) , 4326)::geography , _m_buffer)::geometry) as b
+        FROM plots
         WHERE project_rid = _project_id
-    ), sample_tbl AS (
-        SELECT * FROM select_partial_table_by_name((
-            SELECT samples_ext_table
-            FROM projects
-            WHERE project_uid = _project_id
-        )) as st
-        INNER JOIN plots_tbl pt
-            ON pt.plotId = st.plotId
-    ), samplerows AS (
-        INSERT INTO samples (plot_rid, sample_geom, ext_id)
-        SELECT plot_uid, center as sample_geom, ext_id
-        FROM sample_tbl
-        RETURNING sample_uid, ext_id, sample_geom
-    )
-
-    SELECT COUNT(*)::integer
-    FROM samplerows
-    INNER JOIN sample_tbl
-        ON samplerows.ext_id = sample_tbl.ext_id
+    ) bb
+    WHERE project_uid = _project_id
 
 $$ LANGUAGE SQL;
 
--- Update tables for external data after project is created
-CREATE OR REPLACE FUNCTION update_project_tables(
-    _project_id           integer,
-    _plots_ext_table      text,
-    _samples_ext_table    text
- ) RETURNS void AS $$
-
-    UPDATE projects
-    SET plots_ext_table = _plots_ext_table,
-        samples_ext_table = _samples_ext_table
-    WHERE project_uid = _project_id;
-
-$$ LANGUAGE SQL;
-
--- Update sample table for external data after project is created
-CREATE OR REPLACE FUNCTION update_project_sample_table(
-    _project_id           integer,
-    _samples_ext_table    text
- ) RETURNS void AS $$
-
-    UPDATE projects
-    SET samples_ext_table = _samples_ext_table
-    WHERE project_uid = _project_id;
-
-$$ LANGUAGE SQL;
-
--- TEMPLATE RELATED
-
--- Copy the tables related to file data if they exist and update the projects table
-CREATE OR REPLACE FUNCTION copy_file_tables(_old_project_uid integer, _new_project_uid integer)
- RETURNS VOID AS $$
-
- DECLARE
-    _plots_ext_table text;
-    _samples_ext_table text;
-    _plots_ext_table_new text;
-    _samples_ext_table_new text;
- BEGIN
-    SELECT plots_ext_table INTO _plots_ext_table FROM projects WHERE project_uid = _old_project_uid;
-    SELECT samples_ext_table INTO _samples_ext_table FROM projects WHERE project_uid = _old_project_uid;
-
-    IF _plots_ext_table IS NOT NULL AND _plots_ext_table <> '' THEN
-        EXECUTE
-            'SELECT regexp_replace(''' || _plots_ext_table || ''', ''(\d+)'', ''' || _new_project_uid || ''')'
-                INTO _plots_ext_table_new;
-        EXECUTE 'CREATE TABLE ext_tables.' || _plots_ext_table_new || ' AS SELECT * FROM ext_tables.' || _plots_ext_table;
-        EXECUTE 'UPDATE projects SET plots_ext_table = ''' || _plots_ext_table_new || ''' WHERE project_uid = ' || _new_project_uid;
-    END IF;
-    IF _samples_ext_table IS NOT NULL AND _samples_ext_table <> '' THEN
-        EXECUTE 'SELECT regexp_replace(''' || _samples_ext_table || ''', ''(\d+)'', ''' || _new_project_uid || ''')'
-            INTO _samples_ext_table_new;
-        EXECUTE 'CREATE TABLE ext_tables.' || _samples_ext_table_new || ' AS SELECT * FROM ext_tables.' || _samples_ext_table;
-        EXECUTE 'UPDATE projects SET samples_ext_table = ''' || _samples_ext_table_new || ''' WHERE project_uid = ' || _new_project_uid;
-    END IF;
- END
-
-$$ LANGUAGE PLPGSQL;
+-- FIXME, call the above two functions from clojure instead of a stored procedure
 
 -- Copy plot data and sample data
-CREATE OR REPLACE FUNCTION copy_project_plots_samples(_old_project_uid integer, _new_project_uid integer)
- RETURNS integer AS $$
+-- CREATE OR REPLACE FUNCTION copy_project_plots_samples(_old_project_uid integer, _new_project_uid integer)
+--  RETURNS integer AS $$
 
-    WITH project_plots AS (
-        SELECT center, ext_id, plot_uid as plid_old, row_number() OVER(order by plot_uid) as rowid
-        FROM projects p
-        INNER JOIN plots pl
-            ON project_rid = project_uid
-            AND project_rid = _old_project_uid
-    ), inserting AS (
-        INSERT INTO plots (project_rid, center, ext_id)
-        SELECT _new_project_uid, center, ext_id
-        FROM project_plots
-        RETURNING plot_uid as plid
-    ), new_ordered AS (
-        SELECT plid, row_number() OVER(order by plid) as rowid FROM inserting
-    ), combined AS (
-        SELECT * from new_ordered inner join project_plots USING (rowid)
-    ), inserting_samples AS (
-        INSERT INTO samples (plot_rid, sample_geom, ext_id)
-        SELECT plid, sample_geom, ext_id
-        FROM (
-            SELECT plid, sample_geom, s.ext_id
-            FROM combined c
-            INNER JOIN samples s
-                ON c.plid_old = s.plot_rid
-        ) B
-        RETURNING sample_uid
-    )
+--     WITH project_plots AS (
+--         SELECT center, ext_id, plot_uid as plid_old, row_number() OVER(order by plot_uid) as rowid
+--         FROM projects p
+--         INNER JOIN plots pl
+--             ON project_rid = project_uid
+--             AND project_rid = _old_project_uid
+--     ), inserting AS (
+--         INSERT INTO plots (project_rid, center, ext_id)
+--         SELECT _new_project_uid, center, ext_id
+--         FROM project_plots
+--         RETURNING plot_uid as plid
+--     ), new_ordered AS (
+--         SELECT plid, row_number() OVER(order by plid) as rowid FROM inserting
+--     ), combined AS (
+--         SELECT * from new_ordered inner join project_plots USING (rowid)
+--     ), inserting_samples AS (
+--         INSERT INTO samples (plot_rid, sample_geom, ext_id)
+--         SELECT plid, sample_geom, ext_id
+--         FROM (
+--             SELECT plid, sample_geom, s.ext_id
+--             FROM combined c
+--             INNER JOIN samples s
+--                 ON c.plid_old = s.plot_rid
+--         ) B
+--         RETURNING sample_uid
+--     )
 
-    SELECT COUNT(1)::int FROM inserting_samples
+--     SELECT COUNT(1)::int FROM inserting_samples
 
-$$ LANGUAGE SQL;
+-- $$ LANGUAGE SQL;
 
 -- Copy other project fields that may not have been correctly passed from UI
 CREATE OR REPLACE FUNCTION copy_project_plots_stats(_old_project_uid integer, _new_project_uid integer)
@@ -718,10 +376,9 @@ $$ LANGUAGE SQL;
 
 -- Combines individual functions needed to copy all plot and sample information
 CREATE OR REPLACE FUNCTION copy_template_plots(_old_project_uid integer, _new_project_uid integer)
- RETURNS VOID AS $$
+ RETURNS void AS $$
 
-    SELECT * FROM copy_project_plots_samples(_old_project_uid, _new_project_uid);
-    SELECT * FROM copy_file_tables(_old_project_uid, _new_project_uid);
+    -- SELECT * FROM copy_project_plots_samples(_old_project_uid, _new_project_uid);
     SELECT * FROM copy_project_plots_stats(_old_project_uid, _new_project_uid);
 
 $$ LANGUAGE SQL;
@@ -729,54 +386,20 @@ $$ LANGUAGE SQL;
 -- VALIDATIONS
 
 -- Check if a project was created where plots have no samples
--- This only checks plots with external data. It asssumes that auto generated samples generate correctly
+-- This only checks plots with external data. It assumes that auto generated samples generate correctly
 CREATE OR REPLACE FUNCTION plots_missing_samples(_project_id integer)
- RETURNS table (plot_id integer) AS $$
+ RETURNS table (visible_id integer) AS $$
 
-    WITH plot_tbl AS (
-        SELECT * FROM select_partial_table_by_name((
-            SELECT plots_ext_table
-            FROM projects
-            WHERE project_uid = _project_id
-    )))
-
-    SELECT plotid
+    SELECT pl.visible_id
     FROM projects p
     INNER JOIN plots pl
         ON pl.project_rid = project_uid
-    INNER JOIN plot_tbl
-        ON pl.ext_id = plot_tbl.ext_id
     LEFT JOIN samples s
         ON plot_uid = s.plot_rid
     WHERE project_uid = _project_id
         AND sample_uid IS NULL
 
 $$ LANGUAGE SQL;
-
--- Return table sizes for shp and csv to check against limits
-CREATE OR REPLACE FUNCTION ext_table_count(_project_id integer, _plots_ext_table text, _samples_ext_table text)
- RETURNS table (plot_count integer, sample_count integer) AS $$
-
-    DECLARE
-        _plots_count integer;
-        _samples_count integer;
-    BEGIN
-        IF _plots_ext_table = '' OR _plots_ext_table IS NULL THEN
-            _plots_count = 0;
-        ELSE
-            EXECUTE 'SELECT COUNT(1)::int FROM ext_tables.' || _plots_ext_table INTO _plots_count;
-        END IF;
-
-        IF _samples_ext_table = '' OR _samples_ext_table IS NULL THEN
-            _samples_count = 0;
-        ELSE
-            EXECUTE 'SELECT COUNT(1)::int FROM ext_tables.' || _samples_ext_table INTO _samples_count;
-        END IF;
-
-        RETURN QUERY SELECT _plots_count, _samples_count;
-    END
-
-$$ LANGUAGE PLPGSQL;
 
 --
 -- USING PROJECT FUNCTIONS
@@ -1158,7 +781,7 @@ CREATE OR REPLACE FUNCTION select_limited_project_plots(_project_id integer, _ma
  ) AS $$
 
     SELECT plot_uid,
-        ST_AsGeoJSON(center) as center,
+        ST_AsGeoJSON(ST_Centroid(plot_geom)) as center,
         CASE WHEN flagged IS NULL THEN FALSE ELSE flagged END,
         CASE WHEN user_plot_uid IS NULL THEN 0 ELSE 1 END
     FROM plots
@@ -1173,18 +796,8 @@ $$ LANGUAGE SQL;
 CREATE OR REPLACE FUNCTION select_plot_geom(_plot_id integer)
  RETURNS text AS $$
 
-    WITH tablenames AS (
-        SELECT plots_ext_table
-        FROM projects
-        WHERE project_uid = (SELECT project_rid FROM plots WHERE plot_uid = _plot_id)
-    ), plots_file_data AS (
-        SELECT * FROM select_partial_table_by_name((SELECT plots_ext_table FROM tablenames))
-    )
-
-    SELECT ST_AsGeoJSON(geom)
+    SELECT ST_AsGeoJSON(plot_geom)
     FROM plots p
-    LEFT JOIN plots_file_data pfd
-        ON p.ext_id = pfd.ext_id
     WHERE p.plot_uid = _plot_id
 
 $$ LANGUAGE SQL;
@@ -1198,51 +811,34 @@ CREATE OR REPLACE FUNCTION select_project_collection_plots(_project_id integer)
     flagged            boolean,
     flagged_reason     text,
     confidence         integer,
-    plotId             integer,
-    geom               text,
+    visible_id         integer,
+    plot_geom          text,
     extra_plot_info    jsonb
  ) AS $$
 
-    WITH file_data AS (
-        SELECT *, a.ext_id as this_ext_id
-        FROM select_partial_table_by_name((
-            SELECT plots_ext_table
-            FROM projects
-            WHERE project_uid = _project_id
-        )) a
-        INNER JOIN select_json_table_by_name((
-            SELECT plots_ext_table
-            FROM projects
-            WHERE project_uid = _project_id
-        )) b
-        ON a.ext_id = b.ext_id
-    )
-
     SELECT plot_uid,
-        ST_AsGeoJSON(pl.center) as center,
+        ST_AsGeoJSON(ST_Centroid(plot_geom)) as center,
         user_rid,
         flagged,
         flagged_reason,
         confidence,
-        (CASE WHEN fd.plotId IS NULL THEN plot_uid ELSE fd.plotId END) as plotId,
-        ST_AsGeoJSON(fd.geom) as geom,
-        fd.rem_data
+        visible_id,
+        ST_AsGeoJSON(plot_geom),
+        ext_plot_info
     FROM plots pl
     LEFT JOIN user_plots
         ON plot_uid = plot_rid
-    LEFT JOIN file_data fd
-        ON pl.ext_id = fd.this_ext_id
     WHERE project_rid = _project_id
 
 $$ LANGUAGE SQL;
 
--- Returns next plot by id
-CREATE OR REPLACE FUNCTION plot_exists(_project_id integer, _plot_id integer)
+-- Check if plot exists by visible_id
+CREATE OR REPLACE FUNCTION plot_exists(_project_id integer, _visible_id integer)
  RETURNS boolean AS $$
 
-    SELECT count(plotId) > 0
+    SELECT count(visible_id) > 0
     FROM select_project_collection_plots(_project_id) as spp
-    WHERE plotId = _plot_id
+    WHERE visible_id = _visible_id
 
 $$ LANGUAGE SQL;
 
@@ -1255,13 +851,13 @@ CREATE TYPE collection_return AS (
     flagged            boolean,
     flagged_reason     text,
     confidence         integer,
-    plotId             integer,
-    geom               text,
+    visible_id         integer,
+    plot_geom          text,
     extra_plot_info    jsonb
 );
 
 -- Returns next unanalyzed plot
-CREATE OR REPLACE FUNCTION select_next_unassigned_plot(_project_id integer, _plot_id integer)
+CREATE OR REPLACE FUNCTION select_next_unassigned_plot(_project_id integer, _visible_id integer)
  RETURNS setOf collection_return AS $$
 
     SELECT plot_id,
@@ -1269,17 +865,17 @@ CREATE OR REPLACE FUNCTION select_next_unassigned_plot(_project_id integer, _plo
         flagged,
         flagged_reason,
         confidence,
-        plotId,
-        geom,
+        visible_id,
+        plot_geom,
         extra_plot_info
     FROM select_project_collection_plots(_project_id)
     LEFT JOIN plot_locks pl
         ON plot_id = pl.plot_rid
-    WHERE plotId > _plot_id
+    WHERE visible_id > _visible_id
         AND user_id IS NULL
         AND (pl.lock_end IS NULL
             OR localtimestamp > pl.lock_end)
-    ORDER BY plotId ASC
+    ORDER BY visible_id ASC
     LIMIT 1
 
 $$ LANGUAGE SQL;
@@ -1287,7 +883,7 @@ $$ LANGUAGE SQL;
 -- Returns next user analyzed plot
 CREATE OR REPLACE FUNCTION select_next_user_plot(
     _project_id    integer,
-    _plot_id       integer,
+    _visible_id    integer,
     _user_id       integer,
     _review_all    boolean
  ) RETURNS setOf collection_return AS $$
@@ -1297,20 +893,20 @@ CREATE OR REPLACE FUNCTION select_next_user_plot(
         flagged,
         flagged_reason,
         confidence,
-        plotId,
-        geom,
+        visible_id,
+        plot_geom,
         extra_plot_info
     FROM select_project_collection_plots(_project_id)
-    WHERE plotId > _plot_id
+    WHERE visible_id > _visible_id
         AND ((_review_all AND user_id IS NOT NULL)
              OR user_id = _user_id)
-    ORDER BY plotId ASC
+    ORDER BY visible_id ASC
     LIMIT 1
 
 $$ LANGUAGE SQL;
 
 -- Returns prev unanalyzed plot
-CREATE OR REPLACE FUNCTION select_prev_unassigned_plot(_project_id integer, _plot_id integer)
+CREATE OR REPLACE FUNCTION select_prev_unassigned_plot(_project_id integer, _visible_id integer)
  RETURNS setOf collection_return AS $$
 
     SELECT plot_id,
@@ -1318,17 +914,17 @@ CREATE OR REPLACE FUNCTION select_prev_unassigned_plot(_project_id integer, _plo
         flagged,
         flagged_reason,
         confidence,
-        plotId,
-        geom,
+        visible_id,
+        plot_geom,
         extra_plot_info
     FROM select_project_collection_plots(_project_id)
     LEFT JOIN plot_locks pl
         ON plot_id = pl.plot_rid
-    WHERE plotId < _plot_id
+    WHERE visible_id < _visible_id
         AND user_id IS NULL
         AND (pl.lock_end IS NULL
             OR localtimestamp > pl.lock_end)
-    ORDER BY plotId DESC
+    ORDER BY visible_id DESC
     LIMIT 1
 
 $$ LANGUAGE SQL;
@@ -1336,7 +932,7 @@ $$ LANGUAGE SQL;
 -- Returns prev user analyzed plot
 CREATE OR REPLACE FUNCTION select_prev_user_plot(
     _project_id    integer,
-    _plot_id       integer,
+    _visible_id    integer,
     _user_id       integer,
     _review_all    boolean
  ) RETURNS setOf collection_return AS $$
@@ -1346,20 +942,20 @@ CREATE OR REPLACE FUNCTION select_prev_user_plot(
         flagged,
         flagged_reason,
         confidence,
-        plotId,
-        geom,
+        visible_id,
+        plot_geom,
         extra_plot_info
     FROM select_project_collection_plots(_project_id) as spp
-    WHERE plotId < _plot_id
+    WHERE visible_id < _visible_id
         AND ((_review_all AND user_id IS NOT NULL)
              OR user_id = _user_id)
-    ORDER BY plotId DESC
+    ORDER BY visible_id DESC
     LIMIT 1
 
 $$ LANGUAGE SQL;
 
 -- Returns unanalyzed plots by plot id
-CREATE OR REPLACE FUNCTION select_by_id_unassigned_plot(_project_id integer, _plot_id integer)
+CREATE OR REPLACE FUNCTION select_by_id_unassigned_plot(_project_id integer, _visible_id integer)
  RETURNS setOf collection_return AS $$
 
     SELECT plot_id,
@@ -1367,13 +963,13 @@ CREATE OR REPLACE FUNCTION select_by_id_unassigned_plot(_project_id integer, _pl
         flagged,
         flagged_reason,
         confidence,
-        plotId,
-        geom,
+        visible_id,
+        plot_geom,
         extra_plot_info
     FROM select_project_collection_plots(_project_id) as spp
     LEFT JOIN plot_locks pl
         ON plot_id = pl.plot_rid
-    WHERE plotId = _plot_id
+    WHERE visible_id = _visible_id
         AND user_id IS NULL
         AND (pl.lock_end IS NULL
             OR localtimestamp > pl.lock_end)
@@ -1383,7 +979,7 @@ $$ LANGUAGE SQL;
 -- Returns user analyzed plots by plot id
 CREATE OR REPLACE FUNCTION select_by_id_user_plot(
     _project_id    integer,
-    _plot_id       integer,
+    _visible_id    integer,
     _user_id       integer,
     _review_all    boolean
  ) RETURNS setOf collection_return AS $$
@@ -1393,11 +989,11 @@ CREATE OR REPLACE FUNCTION select_by_id_user_plot(
         flagged,
         flagged_reason,
         confidence,
-        plotId,
-        geom,
+        visible_id,
+        plot_geom,
         extra_plot_info
     FROM select_project_collection_plots(_project_id)
-    WHERE plotId = _plot_id
+    WHERE visible_id = _visible_id
         AND ((_review_all AND user_id IS NOT NULL)
              OR user_id = _user_id)
 
@@ -1452,61 +1048,29 @@ CREATE OR REPLACE FUNCTION create_project_plot_sample(_plot_id integer, _sample_
 $$ LANGUAGE SQL;
 
 -- Select samples. GEOM comes from shp file table.
-CREATE OR REPLACE FUNCTION select_plot_samples(_plot_id integer, _project_id integer)
+CREATE OR REPLACE FUNCTION select_plot_samples(_plot_id integer)
  RETURNS table (
-    sample_id             integer,
-    sample_geom           text,
-    ext_id                integer,
-    plotId                integer,
-    sampleId              integer,
-    geom                  text,
-    saved_answers         jsonb,
-    imagery_id            integer,
-    imagery_attributes    jsonb
+    sample_id        integer,
+    sample_geom      text,
+    saved_answers    jsonb
  ) AS $$
-
-    WITH tablename AS (
-        SELECT samples_ext_table
-        FROM projects
-        WHERE project_uid = _project_id
-    ), file_data AS (
-        SELECT * FROM select_partial_sample_table_by_name((SELECT samples_ext_table FROM tablename))
-    )
 
     SELECT sample_uid,
         ST_AsGeoJSON(sample_geom) as sample_geom,
-        fd.ext_id,
-        fd.sampleId,
-        fd.sampleId,
-        ST_AsGeoJSON(fd.geom) as geom,
-        (CASE WHEN sv.saved_answers IS NULL THEN '{}' ELSE sv.saved_answers END),
-        sv.imagery_rid,
-        sv.imagery_attributes
+        (CASE WHEN sv.saved_answers IS NULL THEN '{}' ELSE sv.saved_answers END)
     FROM samples
     LEFT JOIN sample_values sv
         ON sample_uid = sv.sample_rid
-    LEFT JOIN file_data fd
-        ON samples.ext_id = fd.ext_id
     WHERE samples.plot_rid = _plot_id
 
 $$ LANGUAGE SQL;
 
 -- Select sample geoms. GEOM comes from shp file table, if it exists, otherwise return sample_geom.
 CREATE OR REPLACE FUNCTION select_plot_sample_geoms(_plot_id integer)
- RETURNS table (geom text) AS $$
+ RETURNS table (sample_geom text) AS $$
 
-    WITH tablename AS (
-        SELECT samples_ext_table
-        FROM projects
-        WHERE project_uid = (SELECT project_rid FROM plots WHERE plot_uid = _plot_id)
-    ), file_data AS (
-        SELECT * FROM select_partial_sample_table_by_name((SELECT samples_ext_table FROM tablename))
-    )
-
-    SELECT CASE WHEN fd.geom IS NULL THEN ST_AsGeoJSON(sample_geom) ELSE ST_AsGeoJSON(fd.geom) END
+    SELECT ST_AsGeoJSON(sample_geom)
     FROM samples s
-    LEFT JOIN file_data fd
-        ON s.ext_id = fd.ext_id
     WHERE s.plot_rid = _plot_id
 
 $$ LANGUAGE SQL;
@@ -1667,8 +1231,8 @@ CREATE OR REPLACE FUNCTION get_plot_centers_by_project(_project_id integer)
  ) AS $$
 
     SELECT plot_uid,
-        ST_X(center) AS lon,
-        ST_Y(center) AS lat
+        ST_X(ST_Centroid(plot_geom)) AS lon,
+        ST_Y(ST_Centroid(plot_geom)) AS lat
     FROM plots
     WHERE project_rid = _project_id
 
@@ -1679,6 +1243,7 @@ $$ LANGUAGE SQL;
 --
 
 -- Returns project aggregate data
+-- TODO, return WKT geom
 CREATE OR REPLACE FUNCTION dump_project_plot_data(_project_id integer)
  RETURNS table (
     plot_id                    integer,
@@ -1698,17 +1263,9 @@ CREATE OR REPLACE FUNCTION dump_project_plot_data(_project_id integer)
     ext_plot_data              jsonb
  ) AS $$
 
-    WITH plots_file_data AS (
-        SELECT * FROM select_json_table_by_name((
-            SELECT plots_ext_table
-            FROM projects
-            WHERE project_uid = _project_id
-        ))
-    )
-
     SELECT plot_uid,
-        ST_X(center) AS lon,
-        ST_Y(center) AS lat,
+        ST_X(ST_Centroid(plot_geom)) AS lon,
+        ST_Y(ST_Centroid(plot_geom)) AS lat,
         plot_shape,
         plot_size,
         email,
@@ -1726,7 +1283,7 @@ CREATE OR REPLACE FUNCTION dump_project_plot_data(_project_id integer)
         )) AS samples,
         MODE() WITHIN GROUP (ORDER BY imagery_attributes->>'imagerySecureWatchDate') AS common_securewatch_date,
         COUNT(DISTINCT(imagery_attributes->>'imagerySecureWatchDate'))::int AS total_securewatch_dates,
-        rem_data
+        ext_plot_info
     FROM projects p
     INNER JOIN plots pl
         ON project_uid = pl.project_rid
@@ -1738,10 +1295,8 @@ CREATE OR REPLACE FUNCTION dump_project_plot_data(_project_id integer)
         ON sv.sample_rid = s.sample_uid
     LEFT JOIN users u
         ON u.user_uid = up.user_rid
-    LEFT JOIN plots_file_data pfd
-        ON pl.ext_id = pfd.ext_id
     WHERE project_rid = _project_id
-    GROUP BY project_uid, plot_uid, user_plot_uid, email, rem_data
+    GROUP BY project_uid, plot_uid, user_plot_uid, email, ext_plot_info
     ORDER BY plot_uid
 
 $$ LANGUAGE SQL;
@@ -1765,16 +1320,6 @@ CREATE OR REPLACE FUNCTION dump_project_sample_data(_project_id integer)
         ext_sample_data       jsonb
  ) AS $$
 
-    WITH tablenames AS (
-        SELECT plots_ext_table, samples_ext_table
-        FROM projects
-        WHERE project_uid = _project_id
-    ), plots_file_data AS (
-        SELECT * FROM select_json_table_by_name((SELECT plots_ext_table FROM tablenames))
-    ), samples_file_data AS (
-        SELECT * FROM select_json_table_by_name((SELECT samples_ext_table FROM tablenames))
-    )
-
     SELECT plot_uid,
         sample_uid,
         CASE WHEN ST_GeometryType(sample_geom) = 'ST_Point' THEN ST_X(sample_geom) ELSE -1 END AS lon,
@@ -1787,8 +1332,8 @@ CREATE OR REPLACE FUNCTION dump_project_sample_data(_project_id integer)
         imagery_attributes::text,
         ST_AsText(sample_geom),
         saved_answers,
-        pfd.rem_data,
-        sfd.rem_data
+        ext_plot_info,
+        ext_sample_info
     FROM plots pl
     INNER JOIN samples s
         ON s.plot_rid = pl.plot_uid
@@ -1800,10 +1345,6 @@ CREATE OR REPLACE FUNCTION dump_project_sample_data(_project_id integer)
         ON imagery_uid = sv.imagery_rid
     LEFT JOIN users u
         ON u.user_uid = up.user_rid
-    LEFT JOIN plots_file_data pfd
-        ON pl.ext_id = pfd.ext_id
-    LEFT JOIN samples_file_data sfd
-        ON s.ext_id = sfd.ext_id
     WHERE pl.project_rid = _project_id
     ORDER BY plot_uid, sample_uid
 

--- a/src/sql/tables/all.sql
+++ b/src/sql/tables/all.sql
@@ -146,7 +146,7 @@ CREATE TABLE samples (
     plot_rid           integer NOT NULL REFERENCES plots (plot_uid) ON DELETE CASCADE ON UPDATE CASCADE,
     sample_geom        geometry(geometry,4326),
     visible_id         integer,
-    ext_sample_data    jsonb
+    ext_sample_info    jsonb
 );
 
 -- Stores information about a plot as data is collected, including the user who collected it

--- a/src/sql/tables/all.sql
+++ b/src/sql/tables/all.sql
@@ -124,11 +124,11 @@ CREATE TABLE packet_users (
 --                   |plots -> many user_plots -> many sample_values <- samples|
 --                                       ^- users|
 CREATE TABLE plots (
-    plot_uid        SERIAL PRIMARY KEY,
-    project_rid     integer NOT NULL REFERENCES projects (project_uid) ON DELETE CASCADE ON UPDATE CASCADE,
-    plot_geom       geometry(geometry,4326),
-    visible_id      integer,
-    ext_plot_info   jsonb
+    plot_uid           SERIAL PRIMARY KEY,
+    project_rid        integer NOT NULL REFERENCES projects (project_uid) ON DELETE CASCADE ON UPDATE CASCADE,
+    plot_geom          geometry(geometry,4326),
+    visible_id         integer,
+    extra_plot_info    jsonb
 );
 
 CREATE TABLE packet_plots (
@@ -142,11 +142,11 @@ CREATE TABLE packet_plots (
 --                   |plots -> many user_plots -> many sample_values <- samples|
 --                                       ^- users|
 CREATE TABLE samples (
-    sample_uid         SERIAL PRIMARY KEY,
-    plot_rid           integer NOT NULL REFERENCES plots (plot_uid) ON DELETE CASCADE ON UPDATE CASCADE,
-    sample_geom        geometry(geometry,4326),
-    visible_id         integer,
-    ext_sample_info    jsonb
+    sample_uid           SERIAL PRIMARY KEY,
+    plot_rid             integer NOT NULL REFERENCES plots (plot_uid) ON DELETE CASCADE ON UPDATE CASCADE,
+    sample_geom          geometry(geometry,4326),
+    visible_id           integer,
+    extra_sample_info    jsonb
 );
 
 -- Stores information about a plot as data is collected, including the user who collected it

--- a/src/sql/tables/all.sql
+++ b/src/sql/tables/all.sql
@@ -77,8 +77,6 @@ CREATE TABLE projects (
     sample_resolution      real,
     survey_questions       jsonb,
     survey_rules           jsonb,
-    plots_ext_table        text,
-    samples_ext_table      text,
     created_date           date,
     published_date         date,
     closed_date            date,
@@ -126,10 +124,11 @@ CREATE TABLE packet_users (
 --                   |plots -> many user_plots -> many sample_values <- samples|
 --                                       ^- users|
 CREATE TABLE plots (
-    plot_uid       SERIAL PRIMARY KEY,
-    project_rid    integer NOT NULL REFERENCES projects (project_uid) ON DELETE CASCADE ON UPDATE CASCADE,
-    center         geometry(Point,4326),
-    ext_id         integer
+    plot_uid        SERIAL PRIMARY KEY,
+    project_rid     integer NOT NULL REFERENCES projects (project_uid) ON DELETE CASCADE ON UPDATE CASCADE,
+    plot_geom       geometry(geometry,4326),
+    visible_id      integer,
+    ext_plot_info   jsonb
 );
 
 CREATE TABLE packet_plots (
@@ -143,10 +142,11 @@ CREATE TABLE packet_plots (
 --                   |plots -> many user_plots -> many sample_values <- samples|
 --                                       ^- users|
 CREATE TABLE samples (
-    sample_uid     SERIAL PRIMARY KEY,
-    plot_rid       integer NOT NULL REFERENCES plots (plot_uid) ON DELETE CASCADE ON UPDATE CASCADE,
-    sample_geom    geometry(geometry,4326),
-    ext_id         integer
+    sample_uid         SERIAL PRIMARY KEY,
+    plot_rid           integer NOT NULL REFERENCES plots (plot_uid) ON DELETE CASCADE ON UPDATE CASCADE,
+    sample_geom        geometry(geometry,4326),
+    visible_id         integer,
+    ext_sample_data    jsonb
 );
 
 -- Stores information about a plot as data is collected, including the user who collected it


### PR DESCRIPTION
## Purpose
Eliminate the use of separate tables for external data.

- For plots, reuse the logic we added for samples to allow user drawn.  That is that we dont need to store a center and a geom since center is a geom.  We can then just check for geom type.

- In this code, I use "generators" for each type of plot or sample, and and then uses bulk insert to copy the data to PG.  This should be more flexible moving forward. 
    - Invalid external files fail before being imported into the DB
    - The generators are quicker and potentially reusable for previewing the project in design.
    - Eliminates redundant "recreate-samples"
 
- The DB PK and the visible plot id are now distinguished with obviously different var names.  All plots have a "visible_id".  If none is provided (ie a shapefile 'plotid'), then the number is generated sequentially.
    - A plot ID of 100K+ is not very valuable for users to see
    - All plot types navigate the same
    - Potential to have more flexible ordering, like "scramble" for the grid layout.

- This makes the DB 10% larger, but reduces the backup and restore time by 5x

## Related Issues
Closes CEO-37 CEO-38

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `CEO-### #review <comment>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
All creating, collecting, and downloading of project data needs to be tested.

