### PR TITLE
Remove utf tag from csv

### DIFF
--- a/src/clj/collect_earth_online/db/projects.clj
+++ b/src/clj/collect_earth_online/db/projects.clj
@@ -367,6 +367,7 @@
                     (str/split hr #",")
                     (mapv #(-> %
                                (str/upper-case)
+                               (str/replace "\uFEFF" "")
                                (str/replace #"-| " "_")
                                (str/replace #"^(X|LONGITUDE|LONG|CENTER_X)$" "LON")
                                (str/replace #"^(Y|LATITUDE|CENTER_Y)$" "LAT"))


### PR DESCRIPTION
## Purpose
CVS files dont load correctly if they contain a UTF-8 tag.

## Testing
This file should load correctly for a new project.
[ceo-recheck-2021-07-13.csv](https://github.com/openforis/collect-earth-online/files/6816949/ceo-recheck-2021-07-13.csv)


