### PR TITLE
CEO-177 Fix show error on empty answers

### DIFF
--- a/src/js/components/SurveyCollection.js
+++ b/src/js/components/SurveyCollection.js
@@ -665,7 +665,8 @@ class AnswerInput extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            newInput: ""
+            newInput: "",
+            touched: false
         };
     }
 
@@ -697,39 +698,49 @@ class AnswerInput extends React.Component {
 
     render() {
         const {surveyNode, surveyNode: {answers, dataType}, validateAndSetCurrentValue} = this.props;
-        const {newInput} = this.state;
+        const {touched, newInput} = this.state;
         return answers[0]
             ? (
-                <div className="d-inline-flex">
-                    <div className="pr-2 pt-2">
-                        <div
-                            className="circle"
-                            style={{
-                                backgroundColor: answers[0].color,
-                                border: "1px solid"
-                            }}
+                <>
+                    <div className="d-inline-flex">
+                        <div className="pr-2 pt-2">
+                            <div
+                                className="circle"
+                                style={{
+                                    backgroundColor: answers[0].color,
+                                    border: "1px solid"
+                                }}
+                            />
+                        </div>
+                        <input
+                            className="form-control mr-2"
+                            id={answers[0].answer + "_" + answers[0].id}
+                            name={answers[0].answer + "_" + answers[0].id}
+                            onBlur={() => this.setState({touched: true})}
+                            onChange={e => this.updateInputValue(dataType === "number"
+                                ? Number(e.target.value)
+                                : e.target.value)}
+                            placeholder={answers[0].answer}
+                            type={dataType}
+                            value={newInput}
+                        />
+                        <input
+                            className="text-center btn btn-outline-lightgreen btn-sm"
+                            disabled={newInput === "" || newInput === null}
+                            id="save-input"
+                            name="save-input"
+                            onClick={() => validateAndSetCurrentValue(surveyNode, answers[0].id, newInput)}
+                            type="button"
+                            value="Save"
                         />
                     </div>
-                    <input
-                        className="form-control mr-2"
-                        id={answers[0].answer + "_" + answers[0].id}
-                        name={answers[0].answer + "_" + answers[0].id}
-                        onChange={e => this.updateInputValue(dataType === "number"
-                            ? Number(e.target.value)
-                            : e.target.value)}
-                        placeholder={answers[0].answer}
-                        type={dataType}
-                        value={newInput}
-                    />
-                    <input
-                        className="text-center btn btn-outline-lightgreen btn-sm"
-                        id="save-input"
-                        name="save-input"
-                        onClick={() => validateAndSetCurrentValue(surveyNode, answers[0].id, newInput)}
-                        type="button"
-                        value="Save"
-                    />
-                </div>
+                    <div
+                        className="invalid-feedback"
+                        style={{display: touched && (newInput === "" || newInput === null) ? "block" : "none"}}
+                    >
+                        Answer must not be empty.
+                    </div>
+                </>
             ) : null;
     }
 }


### PR DESCRIPTION

## Purpose
<!-- Description of what has been added/changed -->
Prevent a user from saving a blank answer for text or number input questions. Shows an error dialogue and disables the save button.

## Related Issues
Closes CEO-177

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `CEO-### #review <comment>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
<!-- Create a BDD style test script -->
1. Given I a visitor, When I am collecting, And I attempt to save an empty input answer, Then I am presented with an error.

## Screenshots
<!-- Add a screen shot when UI changes are included -->
Text input:
<img width="362" alt="Screen Shot 2021-07-27 at 3 54 40 PM" src="https://user-images.githubusercontent.com/1829313/127219004-7f03a2b0-a634-4484-914c-769fbae663be.png">

Number input:
<img width="362" alt="Screen Shot 2021-07-27 at 3 55 18 PM" src="https://user-images.githubusercontent.com/1829313/127219087-f3303513-8e70-453f-b970-a34e802324b8.png">

