### PR TITLE
Make proxying optional

### DIFF
--- a/src/clj/collect_earth_online/db/imagery.clj
+++ b/src/clj/collect_earth_online/db/imagery.clj
@@ -5,12 +5,13 @@
             [collect-earth-online.views :refer [data-response]]))
 
 (defn- clean-source [source-config]
-  (if (#{"GeoServer" "SecureWatch" "Planet"} (:type source-config))
-    (dissoc source-config [:geoserverParams :accessToken])
-    source-config))
+  (let [image-type (:type source-config)]
+    (cond-> source-config
+      (#{"GeoServer" "SecureWatch"} image-type) (dissoc source-config :geoserverParams)
+      (#{"Planet" "PlanetNICFI"}    image-type) (dissoc source-config :accessToken))))
 
 (defn- prepare-imagery [imagery inst-admin?]
-  (mapv (fn [{:keys [imagery_id institution_id visibility title attribution extent source_config]}]
+  (mapv (fn [{:keys [imagery_id institution_id visibility title attribution extent is_proxied source_config]}]
           (let [source-config (tc/jsonb->clj source_config)]
             {:id           imagery_id
              :institution  institution_id ; FIXME, legacy variable name, update to institutionId
@@ -18,7 +19,10 @@
              :title        title
              :attribution  attribution
              :extent       (tc/jsonb->clj extent)
-             :sourceConfig (if inst-admin? source-config (clean-source source-config))}))
+             :isProxied    is_proxied
+             :sourceConfig (if (or inst-admin? (not is_proxied))
+                             source-config
+                             (clean-source source-config))}))
         imagery))
 
 (defn get-institution-imagery [{:keys [params]}]
@@ -51,6 +55,7 @@
         imagery-title        (:imageryTitle params)
         imagery-attribution  (:imageryAttribution params)
         source-config        (tc/clj->jsonb (:sourceConfig params))
+        is-proxied?          (tc/val->bool (:isProxied params))
         add-to-all-projects? (tc/val->bool (:addToAllProjects params) true)]
     (if (sql-primitive (call-sql "imagery_name_taken" institution-id imagery-title -1))
       (data-response "The title you have chosen is already taken.")
@@ -60,6 +65,7 @@
                                                     imagery-title
                                                     imagery-attribution
                                                     nil
+                                                    is-proxied?
                                                     source-config))]
         (when add-to-all-projects?
           (call-sql "add_imagery_to_all_institution_projects" new-imagery-id))
@@ -70,6 +76,7 @@
         imagery-title        (:imageryTitle params)
         imagery-attribution  (:imageryAttribution params)
         source-config        (tc/clj->jsonb (:sourceConfig params))
+        is-proxied?          (tc/val->bool (:isProxied params))
         add-to-all-projects? (tc/val->bool (:addToAllProjects params) true)
         institution-id       (tc/val->int (:institutionId params))]
     (if (sql-primitive (call-sql "imagery_name_taken" institution-id imagery-title imagery-id))
@@ -79,6 +86,7 @@
                   imagery-id
                   imagery-title
                   imagery-attribution
+                  is-proxied?
                   source-config)
         (when add-to-all-projects?
           (call-sql "add_imagery_to_all_institution_projects" imagery-id))

--- a/src/js/geoDash.js
+++ b/src/js/geoDash.js
@@ -545,10 +545,10 @@ class MapWidget extends React.Component {
         const {projPairAOI, widget} = this.props;
         let {projAOI} = this.props;
 
-        const {sourceConfig, id, attribution} = this.props.imageryList.find(imagery =>
+        const {sourceConfig, id, attribution, isProxied} = this.props.imageryList.find(imagery =>
             imagery.id === widget.basemapId) || this.props.imageryList[0];
         const basemapLayer = new TileLayer({
-            source: mercator.createSource(sourceConfig, id, attribution)
+            source: mercator.createSource(sourceConfig, id, attribution, isProxied)
         });
         const plotSampleLayer = new VectorLayer({
             source: this.props.vectorSource,

--- a/src/js/imagery/imageryOptions.js
+++ b/src/js/imagery/imageryOptions.js
@@ -38,11 +38,14 @@ const isValidJSON = str => {
 };
 
 export const imageryOptions = [
+    // Note optionalProxy is for optionally proxied imagery. optionalProxy = false && defaultProxy = true are always proxied.
     // Default type is text, default parent is none, a referenced parent must be entered as a json string
     // Parameters can be defined one level deep. {paramParent: {paramChild: "", fields: "", fromJsonStr: ""}}
     {
         type: "GeoServer",
         label: "WMS Imagery",
+        optionalProxy: true,
+        defaultProxy: false,
         params: [
             {
                 key: "geoserverUrl",
@@ -84,6 +87,8 @@ export const imageryOptions = [
     {
         type: "xyz",
         label: "XYZ Imagery",
+        optionalProxy: false,
+        defaultProxy: false,
         params: [{
             key: "url",
             display: "XYZ URL",
@@ -97,6 +102,8 @@ export const imageryOptions = [
     {
         type: "BingMaps",
         label: "Bing Maps",
+        optionalProxy: false,
+        defaultProxy: false,
         params: [
             {
                 key: "imageryId",
@@ -114,6 +121,8 @@ export const imageryOptions = [
     {
         type: "Planet",
         label: "Planet Monthly",
+        optionalProxy: false,
+        defaultProxy: true,
         params: [
             {
                 key: "year",
@@ -134,6 +143,8 @@ export const imageryOptions = [
     {
         type: "PlanetDaily",
         label: "Planet Daily",
+        optionalProxy: false,
+        defaultProxy: false,
         params: [
             {key: "accessToken", display: "Access Token"},
             {key: "startDate", display: "Start Date", type: "date"},
@@ -145,6 +156,8 @@ export const imageryOptions = [
     {
         type: "PlanetNICFI",
         label: "Planet NICFI",
+        optionalProxy: false,
+        defaultProxy: false,
         params: [
             {key: "accessToken", display: "Access Token"},
             {
@@ -170,6 +183,8 @@ export const imageryOptions = [
     },
     {
         type: "SecureWatch",
+        optionalProxy: true,
+        defaultProxy: true,
         params: [
             {
                 key: "baseUrl",
@@ -199,6 +214,8 @@ export const imageryOptions = [
     {
         type: "Sentinel1",
         label: "Sentinel 1",
+        optionalProxy: false,
+        defaultProxy: false,
         params: [
             {
                 key: "year",
@@ -250,6 +267,8 @@ export const imageryOptions = [
     {
         type: "Sentinel2",
         label: "Sentinel 2",
+        optionalProxy: false,
+        defaultProxy: false,
         params: [
             {
                 key: "year",
@@ -315,6 +334,8 @@ export const imageryOptions = [
     {
         type: "GEEImage",
         label: "GEE Image Asset",
+        optionalProxy: false,
+        defaultProxy: false,
         params: [
             {
                 key: "imageId",
@@ -333,6 +354,8 @@ export const imageryOptions = [
     {
         type: "GEEImageCollection",
         label: "GEE ImageCollection Asset",
+        optionalProxy: false,
+        defaultProxy: false,
         params: [
             {
                 key: "collectionId",
@@ -364,6 +387,8 @@ export const imageryOptions = [
     {
         type: "MapBoxRaster",
         label: "Mapbox Raster",
+        optionalProxy: false,
+        defaultProxy: false,
         params: [
             {key: "layerName", display: "Layer Name"},
             {key: "accessToken", display: "Access Token"}
@@ -373,6 +398,8 @@ export const imageryOptions = [
     {
         type: "MapBoxStatic",
         label: "Mapbox Static",
+        optionalProxy: false,
+        defaultProxy: false,
         params: [
             {key: "userName", display: "User Name"},
             {key: "mapStyleId", display: "Map Style Id"},
@@ -383,6 +410,8 @@ export const imageryOptions = [
     {
         type: "OSM",
         label: "Open Street Map",
+        optionalProxy: false,
+        defaultProxy: false,
         params: []
     }
 ];

--- a/src/js/imagery/imageryOptions.js
+++ b/src/js/imagery/imageryOptions.js
@@ -121,7 +121,7 @@ export const imageryOptions = [
     {
         type: "Planet",
         label: "Planet Monthly",
-        optionalProxy: false,
+        optionalProxy: true,
         defaultProxy: true,
         params: [
             {

--- a/src/js/reviewInstitution.js
+++ b/src/js/reviewInstitution.js
@@ -705,13 +705,15 @@ class NewImagery extends React.Component {
 
     formCheck = (title, checked, callback) => (
         <div key={title} className="mb-2">
-            <input
-                checked={checked}
-                className="mr-2"
-                onChange={callback}
-                type="checkbox"
-            />
-            <label>{title}</label>
+            <label>
+                <input
+                    checked={checked}
+                    className="mr-2"
+                    onChange={callback}
+                    type="checkbox"
+                />
+                {title}
+            </label>
         </div>
     );
 

--- a/src/js/utils/mercator.js
+++ b/src/js/utils/mercator.js
@@ -220,7 +220,7 @@ mercator.createSource = (sourceConfig,
                 params: {imageryId},
                 attributions: attribution
             });
-        } if (sourceConfig.type === "Planet") {
+        } else if (sourceConfig.type === "Planet") {
             return new XYZ({
                 url: `/get-tile?imageryId=${imageryId}`
                     + `&z={z}&x={x}&y={y}&tile={0-3}&month=${sourceConfig.month}`

--- a/src/sql/changes/update_2021-06-08_no_proxy.sql
+++ b/src/sql/changes/update_2021-06-08_no_proxy.sql
@@ -1,0 +1,24 @@
+ALTER TABLE imagery ADD COLUMN is_proxied boolean DEFAULT FALSE;
+
+-- Existing always proxied
+UPDATE imagery
+SET is_proxied = TRUE
+WHERE source_config->>'type' = 'SecureWatch'
+    OR source_config->>'type' = 'Planet';
+
+-- Existing sometimes proxied
+UPDATE imagery
+SET is_proxied = TRUE
+WHERE source_config->>'type' = 'GeoServer'
+    AND source_config->'geoserverParams'->'CONNECTID' IS NOT NULL;
+
+-- FIXME, making these proxied is a future PR
+-- -- NICFI needs to be proxied
+-- UPDATE imagery
+-- SET is_proxied = TRUE
+-- WHERE source_config->>'type' = 'PlanetNICFI';
+
+-- -- PlanetDaily needs to be proxied
+-- UPDATE imagery
+-- SET is_proxied = TRUE
+-- WHERE source_config->>'type' = 'PlanetDaily';

--- a/src/sql/tables/all.sql
+++ b/src/sql/tables/all.sql
@@ -54,7 +54,8 @@ CREATE TABLE imagery (
     source_config      jsonb,
     archived           boolean DEFAULT FALSE,
     created_date       date DEFAULT NOW(),
-    archived_date      date
+    archived_date      date,
+    is_proxied         boolean DEFAULT FALSE
 );
 
 -- Stores information about projects


### PR DESCRIPTION
## Purpose
Make proxying optional for the existing proxiable imagery types.

## Related Issues
Closes CEO-72

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `CEO-### #review <comment>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
1. When creating / editing imagery, and select "proxy imagery", then the imagery is saved with that option.
2. When loading a wms source that is not proxied, then the url for the map tiles is not /get-tile
3. When loading a wms source that is proxied, then the url for the map tiles is /get-tile



