### PR TITLE
CEO-82 Fix Clear Answers/Flag Plot in Survey Question Preview

### DIFF
--- a/src/js/project/SurveyQuestions.js
+++ b/src/js/project/SurveyQuestions.js
@@ -314,6 +314,7 @@ export class SurveyQuestionHelp extends React.Component {
         super(props);
         this.state = {
             answerMode: "question",
+            flaggedReason: "",
             isFlagged: false,
             selectedQuestion: {id: 0, question: "", answers: [], answered: [], visible: [1]},
             userSamples: {1: {}},

--- a/src/js/project/SurveyQuestions.js
+++ b/src/js/project/SurveyQuestions.js
@@ -314,6 +314,7 @@ export class SurveyQuestionHelp extends React.Component {
         super(props);
         this.state = {
             answerMode: "question",
+            isFlagged: false,
             selectedQuestion: {id: 0, question: "", answers: [], answered: [], visible: [1]},
             userSamples: {1: {}},
             unansweredColor: "black",
@@ -416,23 +417,37 @@ export class SurveyQuestionHelp extends React.Component {
         });
     };
 
+    resetAnswers = () => this.setState({
+        isFlagged: false,
+        flaggedReason: "",
+        userSamples: {1: {}}
+    });
+
+    setFlaggedReason = flaggedReason => this.setState({flaggedReason});
+
+    toggleFlagged = () => this.setState({isFlagged: !this.state.isFlagged});
+
     render() {
         return (
             <div className="p-3">
                 <SurveyCollection
                     allowDrawnSamples={this.context.allowDrawnSamples}
                     answerMode={this.state.answerMode}
+                    flagged={this.state.isFlagged}
+                    flaggedReason={this.state.flaggedReason}
                     getSelectedSampleIds={() => [1]}
-                    isFlagged={false}
+                    resetPlotValues={this.resetAnswers}
                     selectedQuestion={this.state.selectedQuestion}
                     selectedSampleId={1}
                     setAnswerMode={mode => this.setState({answerMode: mode})}
                     setCurrentValue={this.setCurrentValue}
+                    setFlaggedReason={this.setFlaggedReason}
                     setSelectedQuestion={newSelectedQuestion => this.setState({selectedQuestion: newSelectedQuestion})}
                     setUnansweredColor={color => this.setState({unansweredColor: color})}
                     surveyQuestions={this.context.surveyQuestions
                         .map(q => ({...q, answered: [], visible: [], ...this.state.visibleAnswered[q.id]}))}
                     surveyRules={this.context.surveyRules}
+                    toggleFlagged={this.toggleFlagged}
                     unansweredColor={this.state.unansweredColor}
                 />
             </div>


### PR DESCRIPTION

## Purpose
<!-- Description of what has been added/changed -->
Enables Flag Plot/Clear Answers in the Question Preview section when creating a project.

## Related Issues
Closes CEO-82

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `CEO-### #review <comment>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
<!-- Create a BDD style test script -->
1. Given I am an admin, When I am creating a project, And I add survey questions, And I answer the test the survey, Then I can "Clear All" answers.
1. Given I am an admin, When I am creating a project, Then I can "Flag Plot" in the test the survey.

## Screenshots
<!-- Add a screen shot when UI changes are included -->
Toggling "Flag Plot": 
![Screen Shot 2021-08-02 at 11 39 40 AM](https://user-images.githubusercontent.com/1829313/127908342-6fbf4c5d-50cf-446b-b5a3-62bf96cd828d.png)
