### PR TITLE
Save external samples for restoring later

### DIFF
--- a/src/clj/collect_earth_online/db/projects.clj
+++ b/src/clj/collect_earth_online/db/projects.clj
@@ -178,8 +178,7 @@
     (p-insert-rows! "samples" samples)
     (if allow-drawn-samples?
       (when (#{"csv" "shp"} sample-distribution)
-        ;; FIXME, Create a copy of external sample so they can be restored.
-        (log "Restoring external samples for user drawn samples is temporarily broken"))
+        (p-insert-rows! "ext_samples" samples)
       (when-let [bad-plots (seq (map :visible_id (call-sql "plots_missing_samples" project-id)))]
         (pu/init-throw (str "The uploaded plot and sample files do not have correctly overlapping data. "
                             (count bad-plots)
@@ -368,10 +367,8 @@
 
       (#{"csv" "shp"} sample-distribution)
       (do
-        ;; FIXME Add process to restore external samples when allow-drawn-samples? is true.
-        (pu/init-throw "Restoring external samples for user drawn samples is temporarily broken.")
-        #_(call-sql "delete_all_samples_by_project" project-id)
-        #_(call-sql "copy_saved_samples" project-id))
+        (call-sql "delete_all_samples_by_project" project-id)
+        (call-sql "copy_project_ext_samples" project-id))
 
       :else
       (let [plot-shape        (:plot_shape project)

--- a/src/clj/collect_earth_online/db/projects.clj
+++ b/src/clj/collect_earth_online/db/projects.clj
@@ -178,7 +178,7 @@
     (p-insert-rows! "samples" samples)
     (if allow-drawn-samples?
       (when (#{"csv" "shp"} sample-distribution)
-        (p-insert-rows! "ext_samples" samples)
+        (p-insert-rows! "ext_samples" samples))
       (when-let [bad-plots (seq (map :visible_id (call-sql "plots_missing_samples" project-id)))]
         (pu/init-throw (str "The uploaded plot and sample files do not have correctly overlapping data. "
                             (count bad-plots)

--- a/src/clj/collect_earth_online/generators/external_file.clj
+++ b/src/clj/collect_earth_online/generators/external_file.clj
@@ -129,20 +129,26 @@
 (defmethod get-file-data :default [distribution _ _ _]
   (throw (str "No such distribution (" distribution ") defined for collect-earth-online.db.projects/get-file-data")))
 
+(defn- clean-header-text [s design-type]
+  (-> s
+      (name)
+      (str/replace #"visible_" design-type)
+      (str/upper-case)))
+
 (defn- check-headers [headers primary-key design-type]
   (let [header-diff     (set/difference (set primary-key) (set headers))
         invalid-headers (seq (remove #(re-matches #"^[a-zA-Z_][a-zA-Z0-9_]*$" (name %)) headers))]
     (when (seq header-diff)
       (pu/init-throw  (str "The required header field(s) "
                            (as-> header-diff h
-                             (map #(-> % name str/upper-case) h)
+                             (map #(clean-header-text % design-type) h)
                              (str/join "', '" h)
                              (str/replace h #"visible_" design-type)
                              (str "'" h "'"))
                            " are missing.")))
     (when invalid-headers
       (pu/init-throw  (str "One or more headers contains invalid characters: '"
-                           (str/join "', '" (map #(-> % name str/upper-case) invalid-headers))
+                           (str/join "', '" (map #(clean-header-text % design-type) invalid-headers))
                            "'")))))
 
 (defn- load-external-data! [project-id distribution file-name file-base64 design-type primary-key]

--- a/src/sql/changes/update_2021-06-28_retire_ext_tables.sql
+++ b/src/sql/changes/update_2021-06-28_retire_ext_tables.sql
@@ -247,3 +247,11 @@ $$ LANGUAGE PLPGSQL;
 DROP schema ext_tables CASCADE;
 
 VACUUM FULL;
+
+CREATE TABLE ext_samples (
+    sample_uid           SERIAL PRIMARY KEY,
+    plot_rid             integer NOT NULL REFERENCES plots (plot_uid) ON DELETE CASCADE ON UPDATE CASCADE,
+    sample_geom          geometry(geometry,4326),
+    visible_id           integer,
+    extra_sample_info    jsonb
+);

--- a/src/sql/changes/update_2021-06-28_retire_ext_tables.sql
+++ b/src/sql/changes/update_2021-06-28_retire_ext_tables.sql
@@ -247,11 +247,3 @@ $$ LANGUAGE PLPGSQL;
 DROP schema ext_tables CASCADE;
 
 VACUUM FULL;
-
-CREATE TABLE ext_samples (
-    sample_uid           SERIAL PRIMARY KEY,
-    plot_rid             integer NOT NULL REFERENCES plots (plot_uid) ON DELETE CASCADE ON UPDATE CASCADE,
-    sample_geom          geometry(geometry,4326),
-    visible_id           integer,
-    extra_sample_info    jsonb
-);

--- a/src/sql/changes/update_2021-08-17_ext_tables_restore.sql
+++ b/src/sql/changes/update_2021-08-17_ext_tables_restore.sql
@@ -1,0 +1,7 @@
+CREATE TABLE ext_samples (
+    sample_uid           SERIAL PRIMARY KEY,
+    plot_rid             integer NOT NULL REFERENCES plots (plot_uid) ON DELETE CASCADE ON UPDATE CASCADE,
+    sample_geom          geometry(geometry,4326),
+    visible_id           integer,
+    extra_sample_info    jsonb
+);

--- a/src/sql/functions/project.sql
+++ b/src/sql/functions/project.sql
@@ -280,7 +280,7 @@ CREATE OR REPLACE FUNCTION set_boundary(_project_id integer, _m_buffer real)
 $$ LANGUAGE SQL;
 
 -- Copy plot data and sample data
-CREATE OR REPLACE FUNCTION copy_project_plots_samples(_old_project_uid integer, _new_project_uid integer)
+CREATE OR REPLACE FUNCTION copy_project_plots_samples(_old_project_id integer, _new_project_id integer)
  RETURNS integer AS $$
 
     WITH project_plots AS (
@@ -292,11 +292,11 @@ CREATE OR REPLACE FUNCTION copy_project_plots_samples(_old_project_uid integer, 
         FROM projects p
         INNER JOIN plots pl
             ON project_rid = project_uid
-            AND project_rid = _old_project_uid
+            AND project_rid = _old_project_id
     ), inserting AS (
         INSERT INTO plots
             (project_rid, plot_geom, visible_id, extra_plot_info)
-        SELECT _new_project_uid, plot_geom, visible_id, extra_plot_info
+        SELECT _new_project_id, plot_geom, visible_id, extra_plot_info
         FROM project_plots
         RETURNING plot_uid as plid
     ), new_ordered AS (
@@ -305,7 +305,7 @@ CREATE OR REPLACE FUNCTION copy_project_plots_samples(_old_project_uid integer, 
         SELECT * from new_ordered inner join project_plots USING (rowid)
     ), inserting_samples AS (
         INSERT INTO samples
-            (plot_rid,  sample_geom, visible_id, extra_sample_info)
+            (plot_rid, sample_geom, visible_id, extra_sample_info)
         SELECT plid, sample_geom, visible_id, extra_sample_info
         FROM (
             SELECT plid, sample_geom, s.visible_id, extra_sample_info
@@ -321,7 +321,7 @@ CREATE OR REPLACE FUNCTION copy_project_plots_samples(_old_project_uid integer, 
 $$ LANGUAGE SQL;
 
 -- Copy other project fields that may not have been correctly passed from UI
-CREATE OR REPLACE FUNCTION copy_project_plots_stats(_old_project_uid integer, _new_project_uid integer)
+CREATE OR REPLACE FUNCTION copy_project_plots_stats(_old_project_id integer, _new_project_id integer)
  RETURNS void AS $$
 
     UPDATE projects
@@ -342,18 +342,35 @@ CREATE OR REPLACE FUNCTION copy_project_plots_stats(_old_project_uid integer, _n
             plot_size,            sample_distribution,
             samples_per_plot,     sample_resolution
          FROM projects
-         WHERE project_uid = _old_project_uid) n
+         WHERE project_uid = _old_project_id) n
     WHERE
-        project_uid = _new_project_uid
+        project_uid = _new_project_id
 
 $$ LANGUAGE SQL;
 
 -- Combines individual functions needed to copy all plot and sample information
-CREATE OR REPLACE FUNCTION copy_template_plots(_old_project_uid integer, _new_project_uid integer)
+CREATE OR REPLACE FUNCTION copy_template_plots(_old_project_id integer, _new_project_id integer)
  RETURNS void AS $$
 
-    SELECT * FROM copy_project_plots_samples(_old_project_uid, _new_project_uid);
-    SELECT * FROM copy_project_plots_stats(_old_project_uid, _new_project_uid);
+    SELECT * FROM copy_project_plots_samples(_old_project_id, _new_project_id);
+    SELECT * FROM copy_project_plots_stats(_old_project_id, _new_project_id);
+
+$$ LANGUAGE SQL;
+
+-- Copy samples from external file backup
+CREATE OR REPLACE FUNCTION copy_project_ext_samples(_project_id integer)
+ RETURNS void AS $$
+
+    INSERT INTO samples
+        (plot_rid, sample_geom, visible_id, extra_sample_info)
+    SELECT plot_rid, sample_geom, visible_id, extra_sample_info
+    FROM (
+        SELECT plot_rid, sample_geom, es.visible_id, extra_sample_info
+        FROM ext_samples es
+        INNER JOIN plots
+            ON plot_uid = plot_rid
+        WHERE project_rid = _project_id
+    ) B
 
 $$ LANGUAGE SQL;
 

--- a/src/sql/tables/all.sql
+++ b/src/sql/tables/all.sql
@@ -126,6 +126,15 @@ CREATE TABLE samples (
     extra_sample_info    jsonb
 );
 
+-- A duplicate of external file samples for restoring samples
+CREATE TABLE ext_samples (
+    ext_sample_uid       SERIAL PRIMARY KEY,
+    plot_rid             integer NOT NULL REFERENCES plots (plot_uid) ON DELETE CASCADE ON UPDATE CASCADE,
+    sample_geom          geometry(geometry,4326),
+    visible_id           integer,
+    extra_sample_info    jsonb
+);
+
 -- Stores information about a plot as data is collected, including the user who collected it
 -- By other means we restrict it to 1 user_plot per plot
 -- 1 project -> many |plots ->                                     many samples|


### PR DESCRIPTION
## Purpose
Save external samples for restoring later.  This is only needed when allow-drawn-samples? is true.

## Related Issues
Closes CEO-185

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `CEO-### #review <comment>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
1. Create a project with "allow users to draw samples" and a shp file for samples.
2. As the admin click through some plots and draw samples and delete some of the existing shapes in the plot
3. Publish the project
4. The samples drawn should be gone, and the original shape should exists.
