### PR TITLE
CEO-177 Use RequiredInput for survey collection inputs

### DIFF
--- a/src/js/components/InstitutionEditor.js
+++ b/src/js/components/InstitutionEditor.js
@@ -59,7 +59,7 @@ export default function InstitutionEditor({
                         label="Description"
                         maxLength="2000"
                         onChange={e => setInstitutionDetails("description", e.target.value)}
-                        textarea
+                        type="textarea"
                         value={description}
                     />
                 </div>

--- a/src/js/components/RequiredInput.js
+++ b/src/js/components/RequiredInput.js
@@ -1,23 +1,24 @@
 import React, {useState} from "react";
 
-export default function RequiredInput({id, label, maxLength, onChange, value, textarea}) {
+export default function RequiredInput({id, label, maxLength, onChange, value, type, placeholder}) {
     const [touched, setTouched] = useState(false);
 
     return (
-        <>
+        <div style={{display: "flex", flexDirection: "column"}}>
             {label && (
                 <label htmlFor={id}>
                     <span style={{color: "red"}}>*</span>
                     {label}
                 </label>
             )}
-            {textarea ? (
+            {type === "textarea" ? (
                 <textarea
                     className="form-control"
                     id={id}
                     maxLength={maxLength}
                     onBlur={() => setTouched(true)}
                     onChange={onChange}
+                    placeholder={placeholder}
                     required
                     rows="4"
                     value={value}
@@ -29,17 +30,19 @@ export default function RequiredInput({id, label, maxLength, onChange, value, te
                     maxLength={maxLength}
                     onBlur={() => setTouched(true)}
                     onChange={onChange}
+                    onFocus={() => console.log("focus")}
+                    placeholder={placeholder}
                     required
                     style={touched && value.length === 0 ? {borderColor: "red"} : {}}
-                    type="text"
+                    type={type || "text"}
                     value={value}
                 />
             )}
             {touched && value.length === 0 && (
                 <div className="invalid-feedback" style={{display: "block"}}>
-                    {`${label} is required.`}
+                    {`${label || "This field "} is required.`}
                 </div>
             )}
-        </>
+        </div>
     );
 }

--- a/src/js/components/SurveyCollection.js
+++ b/src/js/components/SurveyCollection.js
@@ -5,6 +5,7 @@ import {CollapsibleTitle} from "./FormComponents";
 import RulesCollectionModal from "./RulesCollectionModal";
 import SvgIcon from "./SvgIcon";
 import {mercator} from "../utils/mercator";
+import RequiredInput from "./RequiredInput";
 
 export class SurveyCollection extends React.Component {
     ruleFunctions = {
@@ -710,10 +711,10 @@ class AnswerInput extends React.Component {
                             }}
                         />
                     </div>
-                    <input
+                    <RequiredInput
+                        key={answers[0].answer + "_" + answers[0].id}
                         className="form-control mr-2"
                         id={answers[0].answer + "_" + answers[0].id}
-                        name={answers[0].answer + "_" + answers[0].id}
                         onChange={e => this.updateInputValue(dataType === "number"
                             ? Number(e.target.value)
                             : e.target.value)}
@@ -721,14 +722,18 @@ class AnswerInput extends React.Component {
                         type={dataType}
                         value={newInput}
                     />
-                    <input
-                        className="text-center btn btn-outline-lightgreen btn-sm"
+                    <button
+                        className="text-center btn btn-outline-lightgreen btn-sm ml-2"
                         id="save-input"
                         name="save-input"
-                        onClick={() => validateAndSetCurrentValue(surveyNode, answers[0].id, newInput)}
+                        onClick={() => {
+                            if (newInput) validateAndSetCurrentValue(surveyNode, answers[0].id, newInput);
+                        }}
+                        style={{height: "2.5rem"}}
                         type="button"
-                        value="Save"
-                    />
+                    >
+                        Save
+                    </button>
                 </div>
             ) : null;
     }


### PR DESCRIPTION
Purpose
Prevent a user from saving a blank answer for text or number input questions. Shows an error dialogue and disables the save button.

Related Issues
Closes CEO-177

Submission Checklist
 Commits include the JIRA issue and the #review hashtag (e.g. CEO-### #review <comment>)
 Code passes linter rules (npm run eslint/clj-kondo --lint src)
Testing
Given I a visitor, When I am collecting, And I attempt to save an empty input answer, Then I am presented with an error.

## Screenshots
![eample](https://user-images.githubusercontent.com/33734037/130131927-90e65c2e-896c-4407-a14c-26ac5e47fcc9.png)
