### PR TITLE
CEO-206 Fix verification for emails with '+'

### DIFF
--- a/src/clj/collect_earth_online/db/users.clj
+++ b/src/clj/collect_earth_online/db/users.clj
@@ -1,5 +1,6 @@
 (ns collect-earth-online.db.users
-  (:import java.time.format.DateTimeFormatter
+  (:import java.net.URLEncoder
+           java.time.format.DateTimeFormatter
            java.time.LocalDateTime
            java.util.UUID)
   (:require [clojure.string :as str]
@@ -58,7 +59,7 @@
                                    "  %sverify-email?email=%s&passwordResetKey=%s\n\n"
                                    "Kind Regards,\n"
                                    "  The CEO Team")
-                              email email timestamp (get-base-url) email reset-key)]
+                              email email timestamp (get-base-url) (URLEncoder/encode email) reset-key)]
         (call-sql "add_user" email password reset-key)
         (try
           (send-mail email nil nil "Welcome to CEO!" email-msg "text/plain")


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Encodes the email address in the verification email so emails with special characters (e.g. `+`) will be correctly parsed.

## Related Issues
Closes CEO-206
