### PR TITLE
CEO-186 Add Plot assignment fields

### DIFF
--- a/src/clj/collect_earth_online/db/projects.clj
+++ b/src/clj/collect_earth_online/db/projects.clj
@@ -41,7 +41,10 @@
 
 (def default-settings {:sampleGeometries {:points   true
                                           :lines    true
-                                          :polygons true}})
+                                          :polygons true}
+                       :userAssignment   {:userMethod "none"
+                                          :users      []
+                                          :percents   []}})
 
 (defn get-home-projects [{:keys [params]}]
   (data-response (mapv (fn [{:keys [project_id institution_id name description num_plots centroid editable]}]

--- a/src/js/components/Select.js
+++ b/src/js/components/Select.js
@@ -2,16 +2,27 @@ import React from "react";
 
 import {isString} from "../utils/generalUtils";
 
-function Option({option}) {
+function Option({option, valueKey = "value", labelKey = "label"}) {
     const [value, label] = isString(option, "String")
-        ? [option, option] : Array.isArray(option)
-            ? [option[0], option[1]] : [option.value, option.label];
+        ? [option, option]
+        : Array.isArray(option)
+            ? [option[0], option[1]]
+            : [option[valueKey], option[labelKey]];
     return (
         <option key={value} value={value}>{label}</option>
     );
 }
 
-export function Select({disabled, label, id, onChange, value, options}) {
+export function Select({
+    disabled,
+    label,
+    id,
+    onChange,
+    value,
+    options,
+    valueKey,
+    labelKey
+}) {
     return (
         <div className="form-inline">
             <label htmlFor={id}>{label}</label>
@@ -23,10 +34,12 @@ export function Select({disabled, label, id, onChange, value, options}) {
                 value={value}
             >
                 {Array.isArray(options)
-                    /* eslint-disable-next-line react/no-array-index-key */
-                    ? options.map((o, i) => (<Option key={i} option={o}/>))
-                    /* eslint-disable-next-line react/no-array-index-key */
-                    : Object.values(options).map((o, i) => (<Option key={i} option={o}/>))}
+                    ? options.map((o, i) =>
+                        /* eslint-disable-next-line react/no-array-index-key */
+                        <Option key={i} labelKey={labelKey} option={o} valueKey={valueKey}/>)
+                    : Object.values(options).map((o, i) =>
+                        /* eslint-disable-next-line react/no-array-index-key */
+                        <Option key={i} labelKey={labelKey} option={o} valueKey={valueKey}/>)}
             </select>
         </div>
     );

--- a/src/js/components/Select.js
+++ b/src/js/components/Select.js
@@ -1,0 +1,33 @@
+import React from "react";
+
+import {isString} from "../utils/generalUtils";
+
+function Option({option}) {
+    const [value, label] = isString(option, "String")
+        ? [option, option] : Array.isArray(option)
+            ? [option[0], option[1]] : [option.value, option.label];
+    return (
+        <option key={value} value={value}>{label}</option>
+    );
+}
+
+export function Select({disabled, label, id, onChange, value, options}) {
+    return (
+        <div className="form-inline">
+            <label htmlFor={id}>{label}</label>
+            <select
+                className="form-control form-control-sm ml-3"
+                disabled={disabled}
+                id={id}
+                onChange={onChange}
+                value={value}
+            >
+                {Array.isArray(options)
+                    /* eslint-disable-next-line react/no-array-index-key */
+                    ? options.map((o, i) => (<Option key={i} option={o}/>))
+                    /* eslint-disable-next-line react/no-array-index-key */
+                    : Object.values(options).map((o, i) => (<Option key={i} option={o}/>))}
+            </select>
+        </div>
+    );
+}

--- a/src/js/project/AssignPlots.js
+++ b/src/js/project/AssignPlots.js
@@ -1,0 +1,162 @@
+import React from "react";
+
+import {ProjectContext} from "./constants";
+import {Select} from "../components/Select";
+import {removeAtIndex} from "../utils/generalUtils";
+
+export default class AssignPlots extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            selectedUserIdId: -1
+        };
+    }
+
+    getUserAssignment = () => this.context.designSettings.userAssignment;
+
+    setUserAssignment = newUserAssignment => {
+        const userAssignment = this.getUserAssignment();
+        this.context.setProjectDetails({
+            designSettings: {
+                ...this.context.designSettings,
+                userAssignment: {...userAssignment, ...newUserAssignment}
+            }
+        });
+    };
+
+    setMethod = userMethod => this.setUserAssignment({userMethod});
+
+    resetSelectedUser = () => {
+        this.setState({selectedUserId: -1});
+    };
+
+    addUser = userId => {
+        const {users, percents} = this.getUserAssignment();
+        const newUsers = [...users, userId];
+        const newPercents = [...percents, 0];
+        this.setUserAssignment({users: newUsers, percents: newPercents});
+        this.resetSelectedUser();
+    };
+
+    removeUser = userId => {
+        const {users, percents} = this.getUserAssignment();
+        const idx = users.indexOf(userId);
+        const newUsers = users.filter(u => u !== userId);
+        this.setUserAssignment({
+            users: newUsers,
+            percents: removeAtIndex(percents, idx)
+        });
+        this.resetSelectedUser();
+    };
+
+    assignPlotPercent = (userIndex, percent) => {
+        const {percents} = this.getUserAssignment();
+        percents[userIndex] = percent;
+        this.setUserAssignment({percents});
+    };
+
+    renderAssignedUsers = (users, isPercentage, percents) => (
+        <div className="d-flex flex-column mt-3">
+            {users.map((user, userIndex) => (
+                <div key={user.id} className="d-flex justify-content-between mt-1">
+                    <div className="mr-5">
+                        {isPercentage && (
+                            <>
+                                <input
+                                    className="form-control form-control-sm"
+                                    max="100"
+                                    min="0"
+                                    onChange={e => this.assignPlotPercent(userIndex, parseInt(e.target.value))}
+                                    placeholder="%"
+                                    style={{display: "inline-block", width: "3.5rem"}}
+                                    type="number"
+                                    value={percents[userIndex]}
+                                />
+                                &#37;
+                            </>
+                        )}
+                    </div>
+                    <div className="d-flex">
+                        <div
+                            style={{
+                                background: "white",
+                                border: "1px solid #ced4da",
+                                borderRadius: ".25rem",
+                                fontSize: ".875rem",
+                                padding: ".25rem .5rem"
+                            }}
+                        >
+                            {user.email}
+                        </div>
+                        <button
+                            className="btn btn-sm btn-danger mx-2"
+                            onClick={() => this.removeUser(user.id)}
+                            title={`Remove ${user.email}`}
+                            type="button"
+                        >
+                            -
+                        </button>
+                    </div>
+                </div>
+            ))}
+        </div>
+    );
+
+    render() {
+        const methods = [
+            ["none", "No assignments"],
+            ["equal", "Equal assignments"],
+            ["percent", "Percentage of plots"]
+        ];
+        const {selectedUserId} = this.state;
+        // allUsers is a positional array of [id, email]
+        const {allUsers} = this.props;
+        const {userMethod, users, percents} = this.getUserAssignment();
+        const possibleUsers = [[-1, "Select user..."],
+                               ...Object.keys(allUsers)
+                                   .map(id => [parseInt(id), allUsers[id]])
+                                   .filter(u => !users.includes(u[0]))]; // Comparing user ids
+        const assignedUsers = users.map(id => ({id, email: allUsers[id]}));
+
+        return (
+            <div className="mr-3" style={{maxWidth: "50%"}}>
+                <h3 className="mb-3">Assign Plots</h3>
+                <div className="d-flex">
+                    <Select
+                        id="user-assignment"
+                        label="User Assignment"
+                        onChange={e => this.setMethod(e.target.value)}
+                        options={methods}
+                        value={userMethod}
+                    />
+                </div>
+                {userMethod !== "none" && (
+                    <div className="mt-3">
+                        <div className="d-flex">
+                            <Select
+                                disabled={possibleUsers.length === 1}
+                                id="assigned-users"
+                                label="Assigned Users"
+                                onChange={e => this.setState({selectedUserId: parseInt(e.target.value)})}
+                                options={possibleUsers.length > 1 ? possibleUsers : ["No users to assign."]}
+                                value={this.state.selectedUserId}
+                            />
+                            <button
+                                className="btn btn-sm btn-success mx-2"
+                                disabled={possibleUsers.length === 1 || selectedUserId === -1}
+                                onClick={() => this.addUser(selectedUserId)}
+                                title="Add User"
+                                type="button"
+                            >
+                                +
+                            </button>
+                        </div>
+                        {this.renderAssignedUsers(assignedUsers, userMethod === "percent", percents)}
+                    </div>
+                )}
+            </div>
+        );
+    }
+}
+
+AssignPlots.contextType = ProjectContext;

--- a/src/js/project/AssignPlots.js
+++ b/src/js/project/AssignPlots.js
@@ -8,7 +8,7 @@ export default class AssignPlots extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            selectedUserIdId: -1
+            selectedUserId: -1
         };
     }
 
@@ -55,10 +55,10 @@ export default class AssignPlots extends React.Component {
         this.setUserAssignment({percents});
     };
 
-    renderAssignedUsers = (users, isPercentage, percents) => (
+    renderAssignedUsers = (assignedUsers, isPercentage, percents) => (
         <div className="d-flex flex-column mt-3">
-            {users.map((user, userIndex) => (
-                <div key={user.id} className="d-flex justify-content-between mt-1">
+            {assignedUsers.map(({id, email}, userIndex) => (
+                <div key={id} className="d-flex justify-content-between mt-1">
                     <div className="mr-5">
                         {isPercentage && (
                             <>
@@ -86,12 +86,12 @@ export default class AssignPlots extends React.Component {
                                 padding: ".25rem .5rem"
                             }}
                         >
-                            {user.email}
+                            {email}
                         </div>
                         <button
                             className="btn btn-sm btn-danger mx-2"
-                            onClick={() => this.removeUser(user.id)}
-                            title={`Remove ${user.email}`}
+                            onClick={() => this.removeUser(id)}
+                            title={`Remove ${email}`}
                             type="button"
                         >
                             -
@@ -109,14 +109,13 @@ export default class AssignPlots extends React.Component {
             ["percent", "Percentage of plots"]
         ];
         const {selectedUserId} = this.state;
-        // allUsers is a positional array of [id, email]
-        const {allUsers} = this.props;
+        const {institutionUserList} = this.props;
         const {userMethod, users, percents} = this.getUserAssignment();
-        const possibleUsers = [[-1, "Select user..."],
-                               ...Object.keys(allUsers)
-                                   .map(id => [parseInt(id), allUsers[id]])
-                                   .filter(u => !users.includes(u[0]))]; // Comparing user ids
-        const assignedUsers = users.map(id => ({id, email: allUsers[id]}));
+        const possibleUsers = [
+            {id: -1, email: "Select user..."},
+            ...institutionUserList.filter(u => !users.includes(u.id))
+        ];
+        const assignedUsers = institutionUserList.filter(u => users.includes(u.id));
 
         return (
             <div className="mr-3" style={{maxWidth: "50%"}}>
@@ -137,9 +136,11 @@ export default class AssignPlots extends React.Component {
                                 disabled={possibleUsers.length === 1}
                                 id="assigned-users"
                                 label="Assigned Users"
+                                labelKey="email"
                                 onChange={e => this.setState({selectedUserId: parseInt(e.target.value)})}
                                 options={possibleUsers.length > 1 ? possibleUsers : ["No users to assign."]}
                                 value={this.state.selectedUserId}
+                                valueKey="id"
                             />
                             <button
                                 className="btn btn-sm btn-success mx-2"

--- a/src/js/project/PlotDesign.js
+++ b/src/js/project/PlotDesign.js
@@ -327,9 +327,7 @@ export class PlotDesign extends React.Component {
                         && `* The maximum allowed number for the selected plot distribution is ${formatNumberWithCommas(plotLimit)}.`}
                 </p>
                 <div className="d-flex">
-                    <AssignPlots
-                        allUsers={institutionUserList.reduce((acc, u) => { acc[u.id] = u.email; return acc; }, {})}
-                    />
+                    <AssignPlots institutionUserList={institutionUserList}/>
                 </div>
             </div>
         );

--- a/src/js/project/PlotDesign.js
+++ b/src/js/project/PlotDesign.js
@@ -3,6 +3,7 @@ import React from "react";
 import {formatNumberWithCommas, encodeFileAsBase64, truncate} from "../utils/generalUtils";
 import {ProjectContext, plotLimit} from "./constants";
 import {mercator} from "../utils/mercator";
+import AssignPlots from "./AssignPlots";
 
 export class PlotDesign extends React.Component {
     constructor(props) {
@@ -243,6 +244,7 @@ export class PlotDesign extends React.Component {
 
     render() {
         const {plotDistribution, plotShape} = this.context;
+        const {institutionUserList} = this.props;
         const totalPlots = this.props.getTotalPlots();
         const plotUnits = plotShape === "circle" ? "Plot diameter (m)" : "Plot width (m)";
 
@@ -324,6 +326,11 @@ export class PlotDesign extends React.Component {
                     {totalPlots > 0 && totalPlots > plotLimit
                         && `* The maximum allowed number for the selected plot distribution is ${formatNumberWithCommas(plotLimit)}.`}
                 </p>
+                <div className="d-flex">
+                    <AssignPlots
+                        allUsers={institutionUserList.reduce((acc, u) => { acc[u.id] = u.email; return acc; }, {})}
+                    />
+                </div>
             </div>
         );
     }

--- a/src/js/project/SampleDesign.js
+++ b/src/js/project/SampleDesign.js
@@ -61,6 +61,7 @@ export class SampleDesign extends React.Component {
         const {sampleGeometries} = this.context.designSettings;
         this.context.setProjectDetails({
             designSettings: {
+                ...this.context.designSettings,
                 sampleGeometries: {...sampleGeometries, [geometry]: !sampleGeometries[geometry]}
             }
         });
@@ -143,6 +144,7 @@ export class SampleDesign extends React.Component {
                                 allowDrawnSamples: (newDistributionType === "none") || allowDrawnSamples,
                                 sampleDistribution: newDistributionType,
                                 designSettings: {
+                                    ...this.context.designSettings,
                                     sampleGeometries: {
                                         ...sampleGeometries,
                                         points: points || pointRequired

--- a/src/js/projectAdmin.js
+++ b/src/js/projectAdmin.js
@@ -17,6 +17,11 @@ class Project extends React.Component {
             name: "",
             description: "",
             designSettings: {
+                userAssignment: {
+                    userMethod: "none",
+                    users: [],
+                    percents: []
+                },
                 sampleGeometries: {
                     points: true,
                     lines: true,

--- a/src/js/utils/generalUtils.js
+++ b/src/js/utils/generalUtils.js
@@ -178,3 +178,19 @@ export function asPercentage(part, total) {
         ? (100.0 * (part / total)).toFixed(2)
         : "0.00";
 }
+
+export function isArguments(val) { return toString.call(val) === "[object Arguments]"; }
+export function isFunction(val) { return toString.call(val) === "[object Function]"; }
+export function isString(val) { return toString.call(val) === "[object String]"; }
+export function isDate(val) { return toString.call(val) === "[object Date]"; }
+export function isRegExp(val) { return toString.call(val) === "[object RegExp]"; }
+
+/**
+* Removes the item from array at index
+* @param {array} arr
+* @param {number} index
+* @returns {array}
+*/
+export function removeAtIndex(arr, index) {
+    return arr.slice(0, index).concat(arr.slice(index + 1, arr.length));
+}


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Adds fields to the Plot Design page for assigning plots to users.

## Related Issues
Closes CEO-186

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `CEO-### #review <comment>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
<!-- Create a BDD style test script -->
1. Given I am an admin, When I am creating a project, Then I can assign an equal or percentage of plots to users.

## Screenshots
<!-- Add a screen shot when UI changes are included -->
![Screen Shot 2021-09-09 at 11 00 45 AM](https://user-images.githubusercontent.com/1829313/132738554-25643f90-9e2c-4b0a-acba-2f258a053715.png)
