### PR TITLE
CEO-7 Allow multiple users to collect the same plot

### DIFF
--- a/src/clj/collect_earth_online/db/plots.clj
+++ b/src/clj/collect_earth_online/db/plots.clj
@@ -9,6 +9,7 @@
 (defn- time-plus-five-min []
   (Timestamp. (+ (System/currentTimeMillis) (* 5 60 1000))))
 
+;; TODO, CEO-32 update to only show users available plots
 (defn get-project-plots [{:keys [params]}]
   (let [project-id (tc/val->int (:projectId params))
         max-plots  (tc/val->int (:max params) 100000)] ; 100000 loads in ~1.5 seconds.
@@ -40,14 +41,14 @@
   (unlock-plots (:userId params -1))
   (data-response ""))
 
-(defn- prepare-samples-array [plot-id]
+(defn- prepare-samples-array [plot-id user-id]
   (mapv (fn [{:keys [sample_id sample_geom saved_answers]}]
           {:id           sample_id
            :sampleGeom   sample_geom
            :savedAnswers (tc/jsonb->clj saved_answers)})
-        (call-sql "select_plot_samples" plot-id)))
+        (call-sql "select_plot_samples" plot-id user-id)))
 
-(defn- build-collection-plot [plot-info]
+(defn- build-collection-plot [plot-info user-id]
   (let [{:keys [plot_id
                 flagged
                 confidence
@@ -62,7 +63,7 @@
      :visibleId     visible_id
      :plotGeom      plot_geom
      :extraPlotInfo (tc/jsonb->clj extra_plot_info {})
-     :samples       (prepare-samples-array plot_id)}))
+     :samples       (prepare-samples-array plot_id user-id)}))
 
 (defn get-collection-plot [{:keys [params]}]
   (let [navigation-mode (:navigationMode params "unanalyzed")
@@ -73,8 +74,9 @@
         proj-plots      (case navigation-mode
                           "unanalyzed" (call-sql "select_unanalyzed_plots" project-id user-id)
                           "analyzed"   (call-sql "select_user_analyzed_plots" project-id user-id)
-                           ;; TODO, make admin mode instead of all. This is because future types
+                           ;; TODO, CEO-201 make admin mode instead of all. This is because future types
                            ;;       will need admin mode and its less code than duplicate modes for each.
+                           ;; FIXME, CEO-201 all mode does not work for multiple users.  Admin mode will need to fix this.
                           "all"        (if (is-proj-admin? user-id project-id nil)
                                          (call-sql "select_all_analyzed_plots" project-id user-id)
                                          [])
@@ -100,22 +102,21 @@
                   (:plot_id plot-info)
                   user-id
                   (time-plus-five-min))
-        (data-response (build-collection-plot plot-info)))
+        (data-response (build-collection-plot plot-info user-id)))
       (data-response "not-found"))))
 
 (defn add-user-samples [{:keys [params]}]
-  (let [project-id       (tc/val->int (:projectId params))
-        plot-id          (tc/val->int (:plotId params))
+  (let [plot-id          (tc/val->int (:plotId params))
         user-id          (:userId params -1)
         confidence       (tc/val->int (:confidence params))
         collection-start (tc/val->long (:collectionStart params))
         user-samples     (:userSamples params)
         user-images      (:userImages params)
-        plot-samples     (:plotSamples params)
-        user-plot-id     (when (not plot-samples)
-                           (sql-primitive (call-sql "check_user_plots" plot-id)))
-        id-translation   (when plot-samples
-                           (call-sql "delete_user_plot_by_plot" plot-id)
+        new-plot-samples (:newPlotSamples params)
+        ;; Samples created in the UI have IDs starting with 1. When the new sample is created
+        ;; in Postgres, it gets different ID.  The user sample ID needs to be updated to match.
+        id-translation   (when new-plot-samples
+                           (call-sql "delete_user_plot_by_plot" plot-id user-id)
                            (call-sql "delete_samples_by_plot" plot-id)
                            (reduce (fn [acc {:keys [id sampleGeom]}]
                                      (let [new-id (sql-primitive (call-sql "create_project_plot_sample"
@@ -124,20 +125,16 @@
                                                                            (tc/json->jsonb sampleGeom)))]
                                        (assoc acc (str id) (str new-id))))
                                    {}
-                                   plot-samples))]
+                                   new-plot-samples))]
     (if (some seq (vals user-samples))
-      (apply call-sql
-             (concat (if user-plot-id
-                       ["update_user_samples" user-plot-id]
-                       ["add_user_samples"])
-                     [project-id
-                      plot-id
-                      user-id
-                      (when (pos? confidence) confidence)
-                      (Timestamp. collection-start)
-                      (tc/clj->jsonb (set/rename-keys user-samples id-translation))
-                      (tc/clj->jsonb (set/rename-keys user-images id-translation))]))
-      (call-sql "delete_user_plot_by_plot" plot-id))
+      (call-sql "upsert_user_samples"
+                plot-id
+                user-id ; FIXME, CEO-208 in admin mode, we need to get the existing user id for the plot.
+                (when (pos? confidence) confidence)
+                (Timestamp. collection-start) ; TODO, CEO-208 dont update collection time for admin in admin mode.
+                (tc/clj->jsonb (set/rename-keys user-samples id-translation))
+                (tc/clj->jsonb (set/rename-keys user-images id-translation)))
+      (call-sql "delete_user_plot_by_plot" plot-id user-id)) ; FIXME, CEO-208 in admin mode, we need to get the existing user id for the plot.
     (unlock-plots user-id)
     (data-response "")))
 

--- a/src/sql/functions/project.sql
+++ b/src/sql/functions/project.sql
@@ -687,7 +687,6 @@ $$ LANGUAGE SQL;
 --
 
 -- Returns project aggregate data
--- TODO, return WKT geom
 CREATE OR REPLACE FUNCTION dump_project_plot_data(_project_id integer)
  RETURNS table (
     plot_id                    integer,
@@ -737,6 +736,7 @@ CREATE OR REPLACE FUNCTION dump_project_plot_data(_project_id integer)
         ON up.plot_rid = pl.plot_uid
     LEFT JOIN sample_values sv
         ON sv.sample_rid = s.sample_uid
+        AND user_plot_uid = sv.user_plot_rid
     LEFT JOIN users u
         ON u.user_uid = up.user_rid
     WHERE project_rid = _project_id
@@ -785,6 +785,7 @@ CREATE OR REPLACE FUNCTION dump_project_sample_data(_project_id integer)
         ON up.plot_rid = pl.plot_uid
     LEFT JOIN sample_values sv
         ON sample_uid = sv.sample_rid
+        AND user_plot_uid = sv.user_plot_rid
     LEFT JOIN imagery
         ON imagery_uid = sv.imagery_rid
     LEFT JOIN users u


### PR DESCRIPTION
## Purpose
Allow multiple users to collect the same plot, which is needed for QA/QC

## Related Issues
Closes CEO-7, CEO-196

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `CEO-### #review <comment>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
To test, create a project with the test data for qa/qc.  Update the users so that you can log in as at least two of them.
1. As a user, I can collect plots that are assigned to me.
2. As a second I can collect plots that are assigned to me and user 1
3. As user 1 I can navigate through my collected plots that were also collected by user 2 and my results show.