### PR TITLE
CEO-187 Add QA/QC fields

### DIFF
--- a/src/clj/collect_earth_online/db/projects.clj
+++ b/src/clj/collect_earth_online/db/projects.clj
@@ -44,7 +44,10 @@
                                           :polygons true}
                        :userAssignment   {:userMethod "none"
                                           :users      []
-                                          :percents   []}})
+                                          :percents   []}
+                       :qaqcAssignment   {:qaqcMethod "none"
+                                          :percent    0
+                                          :smes       []}})
 
 (defn get-home-projects [{:keys [params]}]
   (data-response (mapv (fn [{:keys [project_id institution_id name description num_plots centroid editable]}]

--- a/src/js/project/AssignPlots.js
+++ b/src/js/project/AssignPlots.js
@@ -118,7 +118,7 @@ export default class AssignPlots extends React.Component {
         const assignedUsers = institutionUserList.filter(u => users.includes(u.id));
 
         return (
-            <div className="mr-3" style={{maxWidth: "50%"}}>
+            <div className="mx-5 col-4">
                 <h3 className="mb-3">Assign Plots</h3>
                 <div className="d-flex">
                     <Select

--- a/src/js/project/CreateProjectWizard.js
+++ b/src/js/project/CreateProjectWizard.js
@@ -279,7 +279,10 @@ export default class CreateProjectWizard extends React.Component {
             plotFileName,
             useTemplatePlots,
             originalProject,
-            designSettings: {userAssignment: {userMethod, users, percents}}
+            designSettings: {
+                userAssignment: {userMethod, users, percents},
+                qaqcAssignment: {qaqcMethod, smes, percent}
+            }
         } = this.context;
         const totalPlots = this.getTotalPlots();
         const plotFileNeeded = !useTemplatePlots
@@ -301,8 +304,12 @@ export default class CreateProjectWizard extends React.Component {
                 && "The plot size limit has been exceeded. Check the Plot Design section for detailed info.",
             (["equal", "percent"].includes(userMethod) && users.length === 0)
                 && "At least one user must be added to the plot assignment.",
-            (userMethod === "percent" && percents.reduce((acc, percent) => acc + percent, 0) !== 100)
-                && "The assigned plot percentages must equal 100%."
+            (userMethod === "percent" && percents.reduce((acc, p) => acc + p, 0) !== 100)
+                && "The assigned plot percentages must equal 100%.",
+            (["overlap", "sme"].includes(qaqcMethod) && percent === 0)
+                && "The assigned Quality Control percentage must be greater than 0.",
+            (qaqcMethod === "sme" && smes.length === 0)
+                && "At least one user must be added as an SME."
         ];
         return errorList.filter(e => e);
     };

--- a/src/js/project/PlotDesign.js
+++ b/src/js/project/PlotDesign.js
@@ -280,8 +280,6 @@ export class PlotDesign extends React.Component {
             }
         };
 
-        const allUsers = institutionUserList.reduce((acc, u) => { acc[u.id] = u.email; return acc; }, {});
-
         return (
             <div id="plot-design">
                 <div className="row">

--- a/src/js/project/PlotDesign.js
+++ b/src/js/project/PlotDesign.js
@@ -4,6 +4,7 @@ import {formatNumberWithCommas, encodeFileAsBase64, truncate} from "../utils/gen
 import {ProjectContext, plotLimit} from "./constants";
 import {mercator} from "../utils/mercator";
 import AssignPlots from "./AssignPlots";
+import QualityControl from "./QualityControl";
 
 export class PlotDesign extends React.Component {
     constructor(props) {
@@ -279,6 +280,8 @@ export class PlotDesign extends React.Component {
             }
         };
 
+        const allUsers = institutionUserList.reduce((acc, u) => { acc[u.id] = u.email; return acc; }, {});
+
         return (
             <div id="plot-design">
                 <div className="row">
@@ -326,8 +329,9 @@ export class PlotDesign extends React.Component {
                     {totalPlots > 0 && totalPlots > plotLimit
                         && `* The maximum allowed number for the selected plot distribution is ${formatNumberWithCommas(plotLimit)}.`}
                 </p>
-                <div className="d-flex">
+                <div className="d-flex row">
                     <AssignPlots institutionUserList={institutionUserList}/>
+                    <QualityControl institutionUserList={institutionUserList}/>
                 </div>
             </div>
         );

--- a/src/js/project/QualityControl.js
+++ b/src/js/project/QualityControl.js
@@ -94,8 +94,11 @@ export default class QualityControl extends React.Component {
                     />
                 </div>
                 {qaqcMethod !== "none" && (
-                    <div className="d-flex mt-3">
+                    <div className="d-flex flex-column mt-3">
                         <label htmlFor="percent">Percent:</label>
+                        <p className="font-italic ml-2 small">
+                            - Percent of each users plots to review
+                        </p>
                         <div className="d-flex mx-3">
                             <input
                                 id="percent"

--- a/src/js/project/QualityControl.js
+++ b/src/js/project/QualityControl.js
@@ -38,10 +38,10 @@ export default class QualityControl extends React.Component {
         this.resetSelectedUser();
     };
 
-    renderUsers = users => (
+    renderAssignedSMEs = assignedSMEs => (
         <div className="d-flex flex-column mt-3">
-            {users.map(user => (
-                <div key={user.id} className="d-flex justify-content-end mt-1">
+            {assignedSMEs.map(({id, email}) => (
+                <div key={id} className="d-flex justify-content-end mt-1">
                     <div
                         style={{
                             background: "white",
@@ -51,12 +51,12 @@ export default class QualityControl extends React.Component {
                             padding: ".25rem .5rem"
                         }}
                     >
-                        {user.email}
+                        {email}
                     </div>
                     <button
                         className="btn btn-sm btn-danger mx-2"
-                        onClick={() => this.removeSME(user.id)}
-                        title={`Remove ${user.email}`}
+                        onClick={() => this.removeSME(id)}
+                        title={`Remove ${email}`}
                         type="button"
                     >
                         -
@@ -74,12 +74,12 @@ export default class QualityControl extends React.Component {
         ];
         const {qaqcMethod, percent, smes} = this.getAssignment();
         const {selectedUser} = this.state;
-        const {allUsers} = this.props;
-        const assignedSMEs = smes.map(id => ({id, email: allUsers[id]}));
-        const possibleSMEs = [[-1, "Select user..."],
-                              ...Object.keys(allUsers)
-                                  .map(id => [parseInt(id), allUsers[id]])
-                                  .filter(u => !smes.includes(u[0]))];
+        const {institutionUserList} = this.props;
+        const possibleSMEs = [
+            {id: -1, email: "Select user..."},
+            ...institutionUserList.filter(({id}) => !smes.includes(id))
+        ];
+        const assignedSMEs = institutionUserList.filter(({id}) => smes.includes(id));
 
         return (
             <div className="col-4 mx-5">
@@ -115,15 +115,17 @@ export default class QualityControl extends React.Component {
                     <div className="mt-3">
                         <div className="d-flex">
                             <Select
-                                disabled={possibleSMEs.length === 0}
+                                disabled={possibleSMEs.length === 1}
                                 id="assigned-smes"
                                 label="Assigned SMEs"
+                                labelKey="email"
                                 onChange={e => this.setState({selectedUser: parseInt(e.target.value)})}
                                 options={possibleSMEs.length > 1 ? possibleSMEs : ["No Users to Assign"]}
+                                valueKey="id"
                             />
                             <button
                                 className="btn btn-sm btn-success mx-2"
-                                disabled={possibleSMEs.length === 0 || selectedUser === -1}
+                                disabled={possibleSMEs.length === 1 || selectedUser === -1}
                                 onClick={() => this.addSME(selectedUser)}
                                 title="Add User"
                                 type="button"
@@ -131,7 +133,7 @@ export default class QualityControl extends React.Component {
                                 +
                             </button>
                         </div>
-                        {this.renderUsers(assignedSMEs)}
+                        {this.renderAssignedSMEs(assignedSMEs)}
                     </div>
                 )}
             </div>

--- a/src/js/project/QualityControl.js
+++ b/src/js/project/QualityControl.js
@@ -1,0 +1,142 @@
+import React from "react";
+
+import {ProjectContext} from "./constants";
+import {Select} from "../components/Select";
+
+export default class QualityControl extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            selectedUser: -1
+        };
+    }
+
+    getAssignment = () => this.context.designSettings.qaqcAssignment;
+
+    setAssignment = newAssignment => {
+        const assignment = this.getAssignment();
+        this.context.setProjectDetails({
+            designSettings: {...this.context.designSettings, qaqcAssignment: {...assignment, ...newAssignment}}
+        });
+    };
+
+    setMethod = qaqcMethod => this.setAssignment({qaqcMethod});
+
+    setPercent = percent => this.setAssignment({percent});
+
+    resetSelectedUser = () => this.setState({selectedUser: -1});
+
+    addSME = id => {
+        const {smes} = this.getAssignment();
+        this.setAssignment({smes: [...smes, id]});
+        this.resetSelectedUser();
+    };
+
+    removeSME = id => {
+        const {smes} = this.getAssignment();
+        this.setAssignment({smes: smes.filter(s => s !== id)});
+        this.resetSelectedUser();
+    };
+
+    renderUsers = users => (
+        <div className="d-flex flex-column mt-3">
+            {users.map(user => (
+                <div key={user.id} className="d-flex justify-content-end mt-1">
+                    <div
+                        style={{
+                            background: "white",
+                            border: "1px solid #ced4da",
+                            borderRadius: ".25rem",
+                            fontSize: ".875rem",
+                            padding: ".25rem .5rem"
+                        }}
+                    >
+                        {user.email}
+                    </div>
+                    <button
+                        className="btn btn-sm btn-danger mx-2"
+                        onClick={() => this.removeSME(user.id)}
+                        title={`Remove ${user.email}`}
+                        type="button"
+                    >
+                        -
+                    </button>
+                </div>
+            ))}
+        </div>
+    );
+
+    render() {
+        const qualityMethods = [
+            ["none", "None"],
+            ["overlap", "Overlap"],
+            ["sme", "SME Verification"]
+        ];
+        const {qaqcMethod, percent, smes} = this.getAssignment();
+        const {selectedUser} = this.state;
+        const {allUsers} = this.props;
+        const assignedSMEs = smes.map(id => ({id, email: allUsers[id]}));
+        const possibleSMEs = [[-1, "Select user..."],
+                              ...Object.keys(allUsers)
+                                  .map(id => [parseInt(id), allUsers[id]])
+                                  .filter(u => !smes.includes(u[0]))];
+
+        return (
+            <div className="col-4 mx-5">
+                <h3 className="mb-3">Quality Control</h3>
+                <div className="d-flex">
+                    <Select
+                        id="quality-mode"
+                        label="Quality Mode"
+                        onChange={e => this.setMethod(e.target.value)}
+                        options={qualityMethods}
+                        value={qaqcMethod}
+                    />
+                </div>
+                {qaqcMethod !== "none" && (
+                    <div className="d-flex mt-3">
+                        <label htmlFor="percent">Percent:</label>
+                        <div className="d-flex mx-3">
+                            <input
+                                id="percent"
+                                max="100"
+                                min="0"
+                                onChange={e => this.setPercent(parseInt(e.target.value))}
+                                type="range"
+                                value={percent}
+                            />
+                            <div style={{fontSize: "0.9rem", margin: "0.25rem 1rem"}}>
+                                {percent}%
+                            </div>
+                        </div>
+                    </div>
+                )}
+                {qaqcMethod === "sme" && (
+                    <div className="mt-3">
+                        <div className="d-flex">
+                            <Select
+                                disabled={possibleSMEs.length === 0}
+                                id="assigned-smes"
+                                label="Assigned SMEs"
+                                onChange={e => this.setState({selectedUser: parseInt(e.target.value)})}
+                                options={possibleSMEs.length > 1 ? possibleSMEs : ["No Users to Assign"]}
+                            />
+                            <button
+                                className="btn btn-sm btn-success mx-2"
+                                disabled={possibleSMEs.length === 0 || selectedUser === -1}
+                                onClick={() => this.addSME(selectedUser)}
+                                title="Add User"
+                                type="button"
+                            >
+                                +
+                            </button>
+                        </div>
+                        {this.renderUsers(assignedSMEs)}
+                    </div>
+                )}
+            </div>
+        );
+    }
+}
+
+QualityControl.contextType = ProjectContext;

--- a/src/js/projectAdmin.js
+++ b/src/js/projectAdmin.js
@@ -22,6 +22,11 @@ class Project extends React.Component {
                     users: [],
                     percents: []
                 },
+                qaqcAssignment: {
+                    qaqcMethod: "none",
+                    percent: 0,
+                    smes: []
+                },
                 sampleGeometries: {
                     points: true,
                     lines: true,


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Adds QA/QC fields to the Plot Design page of the Project Wizard. 

## Related Issues
Closes CEO-187

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `CEO-### #review <comment>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
<!-- Create a BDD style test script -->
1. Given I am an admin, When I create a project, And I assign the Quality Control to "Overlap", Then a certain percentage of plots are assigned multiple times.
1. Given I am an admin, When I create a project, And I can assign the Quality Control to "SME Verification," Then the plots are assigned to SMEs to verify the plots.

## Screenshots
<!-- Add a screen shot when UI changes are included -->
![Screen Shot 2021-09-10 at 8 42 22 AM](https://user-images.githubusercontent.com/1829313/132880510-35715d2f-20ef-4393-a4b6-98f445e5c563.png)

![Screen Shot 2021-09-10 at 8 42 36 AM](https://user-images.githubusercontent.com/1829313/132880547-7b12d227-8d0a-4053-aad3-8be8991007a2.png)

