### PR TITLE
CEO-210 Disable user-drawn when QA/QC is enabled, and vice-versa

### DIFF
--- a/src/js/project/QualityControl.js
+++ b/src/js/project/QualityControl.js
@@ -73,6 +73,7 @@ export default class QualityControl extends React.Component {
             ["sme", "SME Verification"]
         ];
         const {qaqcMethod, percent, smes} = this.getAssignment();
+        const {allowDrawnSamples} = this.context;
         const {selectedUser} = this.state;
         const {institutionUserList} = this.props;
         const possibleSMEs = [
@@ -86,6 +87,7 @@ export default class QualityControl extends React.Component {
                 <h3 className="mb-3">Quality Control</h3>
                 <div className="d-flex">
                     <Select
+                        disabled={allowDrawnSamples}
                         id="quality-mode"
                         label="Quality Mode"
                         onChange={e => this.setMethod(e.target.value)}
@@ -93,6 +95,12 @@ export default class QualityControl extends React.Component {
                         value={qaqcMethod}
                     />
                 </div>
+                {allowDrawnSamples && (
+                    <p className="font-italic mt-2 small">
+                        When User-Drawn samples are enabled, the project cannot support Quality Control of plots.
+                        Disable User-Drawn samples to re-enable Quality Control.
+                    </p>
+                )}
                 {qaqcMethod !== "none" && (
                     <div className="d-flex mt-3">
                         <label htmlFor="percent">Percent:</label>

--- a/src/js/project/SampleDesign.js
+++ b/src/js/project/SampleDesign.js
@@ -77,7 +77,7 @@ export class SampleDesign extends React.Component {
         } = this.context;
         const totalPlots = this.props.getTotalPlots();
         const samplesPerPlot = this.props.getSamplesPerPlot();
-        const qaqcEnabled = ["overlap", "sme"].includes(qaqcMethod);
+        const qaqcEnabled = qaqcMethod !== "none";
 
         const sampleOptions = {
             random: {

--- a/src/js/project/SampleDesign.js
+++ b/src/js/project/SampleDesign.js
@@ -70,13 +70,14 @@ export class SampleDesign extends React.Component {
     render() {
         const {
             allowDrawnSamples,
-            designSettings: {sampleGeometries},
+            designSettings: {sampleGeometries, qaqcAssignment: {qaqcMethod}},
             plotDistribution,
             sampleDistribution,
             setProjectDetails
         } = this.context;
         const totalPlots = this.props.getTotalPlots();
         const samplesPerPlot = this.props.getSamplesPerPlot();
+        const qaqcEnabled = ["overlap", "sme"].includes(qaqcMethod);
 
         const sampleOptions = {
             random: {
@@ -111,8 +112,8 @@ export class SampleDesign extends React.Component {
             none: {
                 display: "None",
                 description: "Do not predefine any samples. Requires users to draw their own samples during collection.",
-                inputs: [() => <h3>Users will draw samples at collection time.</h3>]
-
+                inputs: [() => <h3>Users will draw samples at collection time.</h3>],
+                disabled: qaqcEnabled
             }
         };
 
@@ -195,7 +196,7 @@ export class SampleDesign extends React.Component {
                         <input
                             checked={allowDrawnSamples || sampleDistribution === "none"}
                             className="form-check-input"
-                            disabled={sampleDistribution === "none"}
+                            disabled={sampleDistribution === "none" || qaqcEnabled}
                             id="allow-drawn-samples"
                             onChange={() => setProjectDetails({allowDrawnSamples: !allowDrawnSamples})}
                             type="checkbox"
@@ -211,6 +212,12 @@ export class SampleDesign extends React.Component {
                         - Enable this to allow users to draw and label points, lines,
                         and polygons during data collection.
                     </p>
+                    {qaqcEnabled && (
+                        <p className="font-italic ml-2 small">
+                            - When Quality Control is enabled, the project can no longer support User Drawn samples.
+                            Set Quality Control to &quot;None&quot; to re-enable User-Drawn Samples.
+                        </p>
+                    )}
                     {allowDrawnSamples && (
                         <div className="form-group">
                             <label


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
When QA/QC is enabled, disables the "None" sample distribution option and disables the User-Drawn samples section. Displays a message to describe why it's disabled.

When User-Drawn samples are enabled, also disables the Quality Control section and shows a message.

## Related Issues
Closes CEO-210

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `CEO-### #review <comment>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
<!-- Create a BDD style test script -->
1. Given I am an admin, When I am creating a project, And I enable a Quality Control method, Then I can no longer select "None" for my spatial distribution.
1. Given I am an admin, When I am creating a project, And I enable a Quality Control method, Then I can no longer enable User-Drawn samples.
1. Given I am an admin, When I am creating a project, And I enable User-Drawn samples, Then I can no longer enable Quality Control.


## Screenshots
<!-- Add a screen shot when UI changes are included -->
"None" spatial distribution disabled
![image](https://user-images.githubusercontent.com/1829313/132885687-bd07d773-2c82-48f1-a1a4-13fbc8867436.png)

User-drawn samples disabled, plus new error message
![image](https://user-images.githubusercontent.com/1829313/132885696-d30f92cc-e4d0-4c57-b174-969f261a03b6.png)

![Screen Shot 2021-09-10 at 11 01 50 AM](https://user-images.githubusercontent.com/1829313/132897577-99811c87-d734-493b-b446-1c7b7cfbf755.png)
