### PR TITLE
CEO-212 Refresh SSL Keystore every 60 seconds

### DIFF
--- a/src/clj/collect_earth_online/server.clj
+++ b/src/clj/collect_earth_online/server.clj
@@ -9,7 +9,8 @@
 (defonce server           (atom nil))
 (defonce clean-up-service (atom nil))
 
-(def expires-in "1 hour in msecs" (* 1000 60 60))
+(def ^:private expires-in "1 hour in msecs" (* 1000 60 60))
+(def ^:private keystore-scan-interval 60) ; seconds
 
 (defn- expired? [last-mod-time]
   (> (- (System/currentTimeMillis) last-mod-time) expires-in))
@@ -62,11 +63,12 @@
                         {:port  (:http-port options)
                          :join? false}
                         (when ssl?
-                          {:ssl?          true
-                           :ssl-port      https-port
-                           :keystore      "./.key/keystore.pkcs12"
-                           :keystore-type "pkcs12"
-                           :key-password  "foobar"}))]
+                          {:ssl?                   true
+                           :ssl-port               https-port
+                           :keystore               "./.key/keystore.pkcs12"
+                           :keystore-type          "pkcs12"
+                           :keystore-scan-interval keystore-scan-interval
+                           :key-password           "foobar"}))]
         (if (and (not has-key?) https-port)
           (println "ERROR:\n"
                    "  An SSL key is required if an HTTPS port is specified.\n"


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Refreshes SSL Keystore every 60 seconds.

## Related Issues
Closes CEO-212

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `CEO-### #review <comment>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)
