### PR TITLE
Parse quotes for CSV headers

### DIFF
--- a/src/clj/collect_earth_online/generators/external_file.clj
+++ b/src/clj/collect_earth_online/generators/external_file.clj
@@ -105,7 +105,8 @@
                         (mapv #(-> %
                                    (str/lower-case)
                                    (str/replace "\uFEFF" "")
-                                   (str/replace #"-| " "_")
+                                   (str/replace #"^\"|\"$" "")
+                                   (str/replace #"-| |\"" "_")
                                    (str/replace #"^(x|longitude|long|center_x)$" "lon")
                                    (str/replace #"^(y|latitude|center_y)$" "lat")
                                    (str/replace (re-pattern (str "^" design-type "id$")) "visible_id")


### PR DESCRIPTION
## Purpose
Some csv apps add quotes around strings.  This would break

## Related Issues
Closes CEO-155

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `CEO-### #review <comment>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
1. Upload a csv file where the headers are wrapped in string (`"plotId", "sampleId"`)