### PR TITLE
Back end changes for navigation mode

### DIFF
--- a/src/clj/collect_earth_online/db/plots.clj
+++ b/src/clj/collect_earth_online/db/plots.clj
@@ -71,7 +71,7 @@
         project-id      (tc/val->int (:projectId params))
         visible-id      (tc/val->int (:visibleId params))
         user-id         (:userId params -1)
-        admin-mode?     (and (tc/val->bool (:adminMode params))
+        admin-mode?     (and (tc/val->bool (:inAdminMode params))
                              (is-proj-admin? user-id project-id nil))
         proj-plots      (case navigation-mode
                           "unanalyzed" (call-sql "select_unanalyzed_plots" project-id user-id admin-mode?)

--- a/src/clj/collect_earth_online/db/plots.clj
+++ b/src/clj/collect_earth_online/db/plots.clj
@@ -71,15 +71,12 @@
         project-id      (tc/val->int (:projectId params))
         visible-id      (tc/val->int (:visibleId params))
         user-id         (:userId params -1)
+        admin-mode?     (and (tc/val->bool (:adminMode params))
+                             (is-proj-admin? user-id project-id nil))
         proj-plots      (case navigation-mode
-                          "unanalyzed" (call-sql "select_unanalyzed_plots" project-id user-id)
-                          "analyzed"   (call-sql "select_user_analyzed_plots" project-id user-id)
-                           ;; TODO, CEO-201 make admin mode instead of all. This is because future types
-                           ;;       will need admin mode and its less code than duplicate modes for each.
-                           ;; FIXME, CEO-201 all mode does not work for multiple users.  Admin mode will need to fix this.
-                          "all"        (if (is-proj-admin? user-id project-id nil)
-                                         (call-sql "select_all_analyzed_plots" project-id user-id)
-                                         [])
+                          "unanalyzed" (call-sql "select_unanalyzed_plots" project-id user-id admin-mode?)
+                           ;; FIXME, CEO-217 analyzed mode + admin mode does not work for multiple users.
+                          "analyzed"   (call-sql "select_analyzed_plots" project-id user-id admin-mode?)
                           [])
         plot-info       (case direction
                           "next"     (some (fn [{:keys [visible_id] :as plot}]


### PR DESCRIPTION
## Purpose
Instead of a second option for each 

## Related Issues
Closes CEO-201

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `CEO-### #review <comment>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
1. As and Admin, when I select admin mode, and I navigate through analyzed plots, I see all users plots
