### PR TITLE
CEO-191 Add flagged plots to navigation

### DIFF
--- a/src/clj/collect_earth_online/db/plots.clj
+++ b/src/clj/collect_earth_online/db/plots.clj
@@ -82,6 +82,7 @@
                           "unanalyzed" (call-sql "select_unanalyzed_plots" project-id user-id admin-mode?)
                            ;; FIXME, CEO-217 analyzed mode + admin mode does not work for multiple users.
                           "analyzed"   (call-sql "select_analyzed_plots" project-id user-id admin-mode?)
+                          "flagged"    (call-sql "select_flagged_plots" project-id user-id admin-mode?)
                           [])
         plot-info       (case direction
                           "next"     (some (fn [{:keys [visible_id] :as plot}]

--- a/src/sql/functions/imagery.sql
+++ b/src/sql/functions/imagery.sql
@@ -1,5 +1,5 @@
 -- NAMESPACE: imagery
--- REQUIRES: clear, member
+-- REQUIRES: clear, member, project
 
 --
 --  IMAGERY FUNCTIONS

--- a/src/sql/functions/plots.sql
+++ b/src/sql/functions/plots.sql
@@ -104,6 +104,26 @@ CREATE OR REPLACE FUNCTION select_analyzed_plots(_project_id integer, _user_id i
 
 $$ LANGUAGE SQL;
 
+CREATE OR REPLACE FUNCTION select_flagged_plots(_project_id integer, _user_id integer, _admin_mode boolean)
+ RETURNS setOf collection_return AS $$
+
+    SELECT plot_uid,
+        flagged,
+        flagged_reason,
+        confidence,
+        visible_id,
+        ST_AsGeoJSON(plot_geom) as plot_geom,
+        extra_plot_info
+    FROM plots
+    LEFT JOIN user_plots up
+        ON plot_uid = plot_rid
+    WHERE project_rid = _project_id
+        AND (up.user_rid = _user_id OR _admin_mode)
+        AND flagged = TRUE
+    ORDER BY visible_id ASC
+
+$$ LANGUAGE SQL;
+
 -- Lock plot to user
 CREATE OR REPLACE FUNCTION lock_plot(_plot_id integer, _user_id integer, _lock_end timestamp)
  RETURNS VOID AS $$


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Adds "Flagged" to the navigation menu, enabling a user to view their flagged plots.

## Related Issues
Closes CEO-191

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `CEO-### #review <comment>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
<!-- Create a BDD style test script -->
1. Given I am a user, When I am on the collection page, Then I can navigate to my flagged plots.

## Screenshots
<!-- Add a screen shot when UI changes are included -->
![Screen Shot 2021-09-15 at 2 43 50 PM](https://user-images.githubusercontent.com/1829313/133513835-5403fe45-14fd-45d1-a71e-64d299c17741.png)
