### PR TITLE
CEO-193 Add Confidence nav mode

### DIFF
--- a/src/clj/collect_earth_online/db/plots.clj
+++ b/src/clj/collect_earth_online/db/plots.clj
@@ -75,6 +75,7 @@
         direction       (:direction params "next")
         project-id      (tc/val->int (:projectId params))
         visible-id      (tc/val->int (:visibleId params))
+        threshold       (tc/val->int (:threshold params))
         user-id         (:userId params -1)
         admin-mode?     (and (tc/val->bool (:inAdminMode params))
                              (is-proj-admin? user-id project-id nil))
@@ -83,6 +84,7 @@
                            ;; FIXME, CEO-217 analyzed mode + admin mode does not work for multiple users.
                           "analyzed"   (call-sql "select_analyzed_plots" project-id user-id admin-mode?)
                           "flagged"    (call-sql "select_flagged_plots" project-id user-id admin-mode?)
+                          "confidence" (call-sql "select_confidence_plots" project-id user-id admin-mode? threshold)
                           [])
         plot-info       (case direction
                           "next"     (some (fn [{:keys [visible_id] :as plot}]

--- a/src/js/collection.js
+++ b/src/js/collection.js
@@ -1109,7 +1109,7 @@ class PlotNavigation extends React.Component {
         </div>
     );
 
-    confidenceThreshold = (threshold, setThreshold) => (
+    thresholdSlider = (threshold, setThreshold) => (
         <div className="my-2 d-flex align-items-center">
             <h3 className="w-100 mx-2 my-0">Threshold:</h3>
             <div className="d-flex">
@@ -1157,7 +1157,7 @@ class PlotNavigation extends React.Component {
                     </select>
                 </div>
                 {isProjectAdmin && this.adminMode(inAdminMode, setAdminMode)}
-                {navigationMode === "confidence" && this.confidenceThreshold(threshold, setThreshold)}
+                {navigationMode === "confidence" && this.thresholdSlider(threshold, setThreshold)}
                 {loadingPlots
                     ? <h3>Loading plot data...</h3>
                     : showNavButtons

--- a/src/js/components/Switch.js
+++ b/src/js/components/Switch.js
@@ -2,7 +2,7 @@ import React from "react";
 
 export default function Switch({label, onChange, checked}) {
     return (
-        <label className="switch">
+        <label className="switch mb-0">
             <input
                 checked={checked}
                 onChange={onChange}

--- a/src/sql/functions/plots.sql
+++ b/src/sql/functions/plots.sql
@@ -124,6 +124,26 @@ CREATE OR REPLACE FUNCTION select_flagged_plots(_project_id integer, _user_id in
 
 $$ LANGUAGE SQL;
 
+CREATE OR REPLACE FUNCTION select_confidence_plots(_project_id integer, _user_id integer, _admin_mode boolean, _threshold integer)
+ RETURNS setOf collection_return AS $$
+
+    SELECT plot_uid,
+        flagged,
+        flagged_reason,
+        confidence,
+        visible_id,
+        ST_AsGeoJSON(plot_geom) as plot_geom,
+        extra_plot_info
+    FROM plots
+    INNER JOIN user_plots up
+        ON plot_uid = plot_rid
+    WHERE project_rid = _project_id
+        AND (up.user_rid = _user_id OR _admin_mode)
+        AND confidence <= _threshold
+    ORDER BY visible_id ASC
+
+$$ LANGUAGE SQL;
+
 -- Lock plot to user
 CREATE OR REPLACE FUNCTION lock_plot(_plot_id integer, _user_id integer, _lock_end timestamp)
  RETURNS VOID AS $$


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Adds the "Low Confidence" option to the navigation menu. Enables users and admins to navigate to low-confidence plots below a certain threshold.

## Related Issues
Closes CEO-193

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `CEO-### #review <comment>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
<!-- Create a BDD style test script -->
1. Given I am an admin, When I view a project, And I select "Low Confidence" navigation mode, And admin mode is enabled, Then I can view plots with confidence below the threshold.
1. Given I am a user, When I view a project, And I select "Low Confidence" navigation mode, Then I can view my plots with confidence below the threshold.

## Screenshots
<!-- Add a screen shot when UI changes are included -->
Admin:
<img width="353" alt="Screen Shot 2021-09-16 at 9 38 39 AM" src="https://user-images.githubusercontent.com/1829313/133651449-1d487f95-d5df-4310-951c-8065f97041ff.png">

User:
<img width="359" alt="Screen Shot 2021-09-16 at 9 39 05 AM" src="https://user-images.githubusercontent.com/1829313/133651515-2697e958-fd86-4d6e-953e-b88f7f4fbff2.png">
