### PR TITLE
CEO-217 Add select plot by user to nav

### DIFF
--- a/src/js/components/Select.js
+++ b/src/js/components/Select.js
@@ -13,7 +13,7 @@ function Option({option, valueKey = "value", labelKey = "label"}) {
     );
 }
 
-export function Select({
+export default function Select({
     disabled,
     label,
     id,

--- a/src/js/project/AssignPlots.js
+++ b/src/js/project/AssignPlots.js
@@ -1,7 +1,7 @@
 import React from "react";
 
 import {ProjectContext} from "./constants";
-import {Select} from "../components/Select";
+import Select from "../components/Select";
 import {removeAtIndex} from "../utils/generalUtils";
 
 export default class AssignPlots extends React.Component {

--- a/src/js/project/QualityControl.js
+++ b/src/js/project/QualityControl.js
@@ -1,7 +1,7 @@
 import React from "react";
 
 import {ProjectContext} from "./constants";
-import {Select} from "../components/Select";
+import Select from "../components/Select";
 
 export default class QualityControl extends React.Component {
     constructor(props) {

--- a/src/sql/functions/plots.sql
+++ b/src/sql/functions/plots.sql
@@ -46,7 +46,9 @@ CREATE TYPE collection_return AS (
     confidence         integer,
     visible_id         integer,
     plot_geom          text,
-    extra_plot_info    jsonb
+    extra_plot_info    jsonb,
+    user_id            integer,
+    email              text
 );
 
 CREATE OR REPLACE FUNCTION select_unanalyzed_plots(_project_id integer, _user_id integer, _admin_mode boolean)
@@ -65,7 +67,9 @@ CREATE OR REPLACE FUNCTION select_unanalyzed_plots(_project_id integer, _user_id
         confidence,
         visible_id,
         ST_AsGeoJSON(plot_geom) as plot_geom,
-        extra_plot_info
+        extra_plot_info,
+        -1,
+        NULL
     FROM plots
     LEFT JOIN assigned_plots ap
         ON plot_uid = ap.plot_rid
@@ -94,10 +98,14 @@ CREATE OR REPLACE FUNCTION select_analyzed_plots(_project_id integer, _user_id i
         confidence,
         visible_id,
         ST_AsGeoJSON(plot_geom) as plot_geom,
-        extra_plot_info
+        extra_plot_info,
+        u.user_uid,
+        u.email
     FROM plots
     INNER JOIN user_plots up
         ON plot_uid = plot_rid
+    INNER JOIN users u
+        ON u.user_uid = up.user_rid
     WHERE project_rid = _project_id
         AND (up.user_rid = _user_id OR _admin_mode)
     ORDER BY visible_id ASC
@@ -113,10 +121,14 @@ CREATE OR REPLACE FUNCTION select_flagged_plots(_project_id integer, _user_id in
         confidence,
         visible_id,
         ST_AsGeoJSON(plot_geom) as plot_geom,
-        extra_plot_info
+        extra_plot_info,
+        u.user_uid,
+        u.email
     FROM plots
     LEFT JOIN user_plots up
         ON plot_uid = plot_rid
+    INNER JOIN users u
+        ON u.user_uid = up.user_rid
     WHERE project_rid = _project_id
         AND (up.user_rid = _user_id OR _admin_mode)
         AND flagged = TRUE
@@ -133,10 +145,14 @@ CREATE OR REPLACE FUNCTION select_confidence_plots(_project_id integer, _user_id
         confidence,
         visible_id,
         ST_AsGeoJSON(plot_geom) as plot_geom,
-        extra_plot_info
+        extra_plot_info,
+        u.user_uid,
+        u.email
     FROM plots
     INNER JOIN user_plots up
         ON plot_uid = plot_rid
+    INNER JOIN users u
+        ON u.user_uid = up.user_rid
     WHERE project_rid = _project_id
         AND (up.user_rid = _user_id OR _admin_mode)
         AND confidence <= _threshold


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Enable viewing multiple user plots for admins. Adds a "User" selector when in admin mode and there are multiple plots.

## Related Issues
Closes CEO-217

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `CEO-### #review <comment>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
<!-- Create a BDD style test script -->
1. Given I am an admin, When I view a project, and I enable admin mode, And I view analyzed plots, Then I can switch between multiple users' plots.

## Screenshots
<!-- Add a screen shot when UI changes are included -->
<img width="359" alt="Screen Shot 2021-09-16 at 3 01 12 PM" src="https://user-images.githubusercontent.com/1829313/133691496-9f6d19c2-8a1c-4c30-af7c-d0e18fcfd286.png">

