### PR TITLE
CEO-202 Add 'Natural' navigation mode

### DIFF
--- a/src/clj/collect_earth_online/db/plots.clj
+++ b/src/clj/collect_earth_online/db/plots.clj
@@ -91,27 +91,27 @@
                           "natural"    (concat (call-sql "select_unanalyzed_plots" project-id user-id admin-mode?)
                                                (call-sql "select_analyzed_plots" project-id user-id admin-mode?))
                           [])
-        sorted-plots    (sort-by first (group-by :visible_id proj-plots))
+        grouped-plots    (group-by :visible_id proj-plots)
         plots-info      (case direction
                           "next"     (or (some (fn [[plot-id plots]]
                                                  (and (> plot-id visible-id)
                                                       plots))
-                                               sorted-plots)
-                                         (->> sorted-plots
+                                               grouped-plots)
+                                         (->> grouped-plots
                                               (first)
                                               (second)))
-                          "previous" (or (->> sorted-plots
+                          "previous" (or (->> grouped-plots
                                               (sort-by first #(compare %2 %1))
                                               (some (fn [[plot-id plots]]
                                                       (and (< plot-id visible-id)
                                                            plots))))
-                                         (->> sorted-plots
+                                         (->> grouped-plots
                                               (last)
                                               (second)))
                           "id"       (some (fn [[plot-id plots]]
                                              (and (= plot-id visible-id)
                                                   plots))
-                                           sorted-plots))]
+                                           grouped-plots))]
     (if plots-info
       (do
         (unlock-plots user-id)

--- a/src/clj/collect_earth_online/db/plots.clj
+++ b/src/clj/collect_earth_online/db/plots.clj
@@ -69,6 +69,19 @@
      :userId        user_id
      :email         email}))
 
+(defn- get-natural-plots
+  "Returns un/analyzed plots depending on `direction`.
+   \"next\" returns the unanalyzed plus the first analyzed plot.
+   \"previous\" returns analyzed plus the last unanalyzed plot.
+   \"id\" returns all plots"
+  [direction project-id user-id admin-mode?]
+  (let [unanalyzed (->> (call-sql "select_unanalyzed_plots" project-id user-id admin-mode?) (sort-by :visible_id))
+        analyzed   (->> (call-sql "select_analyzed_plots" project-id user-id admin-mode?) (group-by :visible_id) (sort-by first))]
+    (case direction
+      "next"     (concat unanalyzed (-> analyzed (first) (val)))
+      "previous" (concat (mapcat val analyzed) [(last unanalyzed)])
+      "id"       (concat (mapcat val analyzed) unanalyzed))))
+
 (defn get-collection-plot
   "Gets plot information needed for the collections page.  The plot
    returned is based off of the navigation mode and direction.  Valid
@@ -88,28 +101,29 @@
                           "analyzed"   (call-sql "select_analyzed_plots"   project-id user-id admin-mode?)
                           "flagged"    (call-sql "select_flagged_plots"    project-id user-id admin-mode?)
                           "confidence" (call-sql "select_confidence_plots" project-id user-id admin-mode? threshold)
+                          "natural"    (get-natural-plots direction project-id user-id admin-mode?)
                           [])
-        grouped-plots   (into (sorted-map) (group-by :visible_id proj-plots))
+        sorted-plots    (sort-by first (group-by :visible_id proj-plots))
         plots-info      (case direction
                           "next"     (or (some (fn [[plot-id plots]]
                                                  (and (> plot-id visible-id)
                                                       plots))
-                                               grouped-plots)
-                                         (->> grouped-plots
+                                               sorted-plots)
+                                         (->> sorted-plots
                                               (first)
                                               (second)))
-                          "previous" (or (->> grouped-plots
+                          "previous" (or (->> sorted-plots
                                               (sort-by first #(compare %2 %1))
                                               (some (fn [[plot-id plots]]
                                                       (and (< plot-id visible-id)
                                                            plots))))
-                                         (->> grouped-plots
+                                         (->> sorted-plots
                                               (last)
                                               (second)))
                           "id"       (some (fn [[plot-id plots]]
                                              (and (= plot-id visible-id)
                                                   plots))
-                                           grouped-plots))]
+                                           sorted-plots))]
     (if plots-info
       (do
         (unlock-plots user-id)

--- a/src/clj/collect_earth_online/db/plots.clj
+++ b/src/clj/collect_earth_online/db/plots.clj
@@ -88,10 +88,10 @@
                           "analyzed"   (call-sql "select_analyzed_plots"   project-id user-id admin-mode?)
                           "flagged"    (call-sql "select_flagged_plots"    project-id user-id admin-mode?)
                           "confidence" (call-sql "select_confidence_plots" project-id user-id admin-mode? threshold)
-                          "natural"    (concat (call-sql "select_unanalyzed_plots" project-id user-id admin-mode?)
-                                               (call-sql "select_analyzed_plots" project-id user-id admin-mode?))
+                          "natural"    (concat (call-sql "select_analyzed_plots" project-id user-id false)
+                                               (call-sql "select_unanalyzed_plots" project-id user-id false))
                           [])
-        grouped-plots    (group-by :visible_id proj-plots)
+        grouped-plots   (group-by :visible_id proj-plots)
         plots-info      (case direction
                           "next"     (or (some (fn [[plot-id plots]]
                                                  (and (> plot-id visible-id)

--- a/src/js/collection.js
+++ b/src/js/collection.js
@@ -197,11 +197,9 @@ class Collection extends React.Component {
         .then(project => {
             // TODO This logic is currently invalid since this route can never return an archived project.
             if (project.id > 0 && project.availability !== "archived") {
+                this.setState({currentProject: project});
                 const {inAdminMode} = getProjectPreferences(project.id);
-                this.setState({
-                    currentProject: project,
-                    inAdminMode: project.isProjectAdmin && (inAdminMode === null || inAdminMode)
-                });
+                this.setAdminMode(project.isProjectAdmin && (inAdminMode === null || inAdminMode));
                 return Promise.resolve("resolved");
             } else {
                 return Promise.reject(
@@ -514,9 +512,8 @@ class Collection extends React.Component {
 
     setNavigationMode = newMode => this.setState({navigationMode: newMode});
 
-    setAdminMode = () => {
+    setAdminMode = inAdminMode => {
         const {currentProject} = this.state;
-        const inAdminMode = !this.state.inAdminMode;
         this.setState({inAdminMode});
         setProjectPreferences(currentProject.id, {inAdminMode});
         if (inAdminMode && this.state.navigationMode === "natural") {
@@ -1095,7 +1092,7 @@ class PlotNavigation extends React.Component {
             <div style={{display: "inline-block"}}>
                 <Switch
                     checked={inAdminMode}
-                    onChange={setAdminMode}
+                    onChange={() => setAdminMode(!inAdminMode)}
                 />
             </div>
         </div>

--- a/src/js/collection.js
+++ b/src/js/collection.js
@@ -49,7 +49,7 @@ class Collection extends React.Component {
             showQuitModal: false,
             answerMode: "question",
             modalMessage: null,
-            navigationMode: "unanalyzed",
+            navigationMode: "natural",
             threshold: 90
         };
     }
@@ -1160,6 +1160,7 @@ class PlotNavigation extends React.Component {
                             style={{flex: "1 1 auto"}}
                             value={navigationMode}
                         >
+                            <option value="natural">Natural</option>
                             <option value="unanalyzed">Unanalyzed plots</option>
                             <option value="analyzed">Analyzed plots</option>
                             <option value="flagged">Flagged plots</option>

--- a/src/js/collection.js
+++ b/src/js/collection.js
@@ -519,6 +519,9 @@ class Collection extends React.Component {
         const inAdminMode = !this.state.inAdminMode;
         this.setState({inAdminMode});
         setProjectPreferences(currentProject.id, {inAdminMode});
+        if (inAdminMode && this.state.navigationMode === "natural") {
+            this.setNavigationMode("unanalyzed");
+        }
     };
 
     setThreshold = threshold => this.setState({threshold});
@@ -1160,7 +1163,7 @@ class PlotNavigation extends React.Component {
                             style={{flex: "1 1 auto"}}
                             value={navigationMode}
                         >
-                            <option value="natural">Natural</option>
+                            {!inAdminMode && (<option value="natural">Natural</option>)}
                             <option value="unanalyzed">Unanalyzed plots</option>
                             <option value="analyzed">Analyzed plots</option>
                             <option value="flagged">Flagged plots</option>


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Adds 'Natural' navigation mode to collection UI.

## Related Issues
Closes CEO-202

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `CEO-### #review <comment>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
<!-- Create a BDD style test script -->
1. Given I am a user, When I am collecting, And I select 'Natural' navigation mode, And I am viewing an unanalyzed plot, And I click to the previous plot, Then I am shown my previously analyzed plot.
1. Given I am a user, When I am collecting, And I select 'Natural' navigation mode, And I am viewing my first analyzed plot, And I click to the previous plot, Then I am shown the last unanalyzed plot.
1. Given I am a user, When I am collecting, And I select 'Natural' navigation mode, And I am viewing my last unanalyzed plot, And I click to the next plot, Then I am shown the first analyzed plot.
1. Given I am a user, When I am collecting, And I select 'Natural' navigation mode, And I am viewing my last analyzed plot, And I click to the next plot, Then I am shown the first unanalyzed plot.

## Screenshots
<!-- Add a screen shot when UI changes are included -->
![Screen Shot 2021-09-20 at 11 48 19 AM](https://user-images.githubusercontent.com/1829313/134057559-b6dae7d0-b1b3-4355-8718-11419a0b2bc9.png)