### PR TITLE
CEO-219 Add 'User' navigation mode

### DIFF
--- a/src/clj/collect_earth_online/routing.clj
+++ b/src/clj/collect_earth_online/routing.clj
@@ -108,6 +108,9 @@
    [:get  "/get-collection-plot"]            {:handler     plots/get-collection-plot
                                               :auth-type   :collect
                                               :auth-action :block}
+   [:get  "/get-plotters"]                   {:handler     plots/get-plotters
+                                              :auth-type   :collect
+                                              :auth-action :block}
    [:get  "/get-project-plots"]              {:handler     plots/get-project-plots}
    [:get  "/get-plot-sample-geom"]           {:handler     plots/get-plot-sample-geom}
    [:post "/add-user-samples"]               {:handler     plots/add-user-samples

--- a/src/sql/functions/plots.sql
+++ b/src/sql/functions/plots.sql
@@ -37,6 +37,24 @@ CREATE OR REPLACE FUNCTION select_plot_geom(_plot_id integer)
 
 $$ LANGUAGE SQL;
 
+-- Get all users who have plotted on a project
+CREATE OR REPLACE FUNCTION select_plotters(_project_id integer)
+ RETURNS table (
+    user_id    integer,
+    email      text
+ ) AS $$
+
+    SELECT DISTINCT(up.user_rid) user_id, u.email
+    FROM plots p
+    INNER JOIN user_plots up
+        ON p.plot_uid = up.plot_rid
+    INNER JOIN users u
+        ON u.user_uid = up.user_rid
+    WHERE p.project_rid = _project_id
+    ORDER BY user_id
+
+$$ LANGUAGE SQL;
+
 -- This return type is so the collection functions match return types.
 DROP TYPE IF EXISTS collection_return CASCADE;
 CREATE TYPE collection_return AS (


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Adds 'User' navigation mode, which only navigates through a particular user's plots.

## Related Issue
Closes CEO-219

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `CEO-### #review <comment>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
<!-- Create a BDD style test script -->
1. Given I am an admin, When I view a project, And I select 'Users' navigation mode, Then I can navigate through a particular user's plots.

## Screenshots
<!-- Add a screen shot when UI changes are included -->
![Screen Shot 2021-09-21 at 10 26 59 AM](https://user-images.githubusercontent.com/1829313/134218600-6a6b18a1-da83-42cd-908e-7cafb15f3f5b.png)

