### PR TITLE
Wrap navigation instead of hitting the end of a list

### DIFF
--- a/src/clj/collect_earth_online/db/plots.clj
+++ b/src/clj/collect_earth_online/db/plots.clj
@@ -97,8 +97,7 @@
                                                grouped-plots)
                                          (->> grouped-plots
                                               (first)
-                                              (second)
-                                              (into [])))
+                                              (second)))
                           "previous" (or (->> grouped-plots
                                               (sort-by first #(compare %2 %1))
                                               (some (fn [[plot-id plots]]
@@ -106,8 +105,7 @@
                                                            plots))))
                                          (->> grouped-plots
                                               (last)
-                                              (second)
-                                              (into [])))
+                                              (second)))
                           "id"       (some (fn [[plot-id plots]]
                                              (and (= plot-id visible-id)
                                                   plots))

--- a/src/clj/collect_earth_online/db/plots.clj
+++ b/src/clj/collect_earth_online/db/plots.clj
@@ -85,22 +85,29 @@
                              (is-proj-admin? user-id project-id nil))
         proj-plots      (case navigation-mode
                           "unanalyzed" (call-sql "select_unanalyzed_plots" project-id user-id admin-mode?)
-                           ;; FIXME, CEO-217 analyzed mode + admin mode does not work for multiple users.
-                          "analyzed"   (call-sql "select_analyzed_plots" project-id user-id admin-mode?)
-                          "flagged"    (call-sql "select_flagged_plots" project-id user-id admin-mode?)
+                          "analyzed"   (call-sql "select_analyzed_plots"   project-id user-id admin-mode?)
+                          "flagged"    (call-sql "select_flagged_plots"    project-id user-id admin-mode?)
                           "confidence" (call-sql "select_confidence_plots" project-id user-id admin-mode? threshold)
                           [])
         grouped-plots   (into (sorted-map) (group-by :visible_id proj-plots))
         plots-info      (case direction
-                          "next"     (some (fn [[plot-id plots]]
-                                             (and (> plot-id visible-id)
-                                                  plots))
-                                           grouped-plots)
-                          "previous" (->> grouped-plots
-                                          (sort-by first #(compare %2 %1))
-                                          (some (fn [[plot-id plots]]
-                                                  (and (< plot-id visible-id)
-                                                       plots))))
+                          "next"     (or (some (fn [[plot-id plots]]
+                                                 (and (> plot-id visible-id)
+                                                      plots))
+                                               grouped-plots)
+                                         (->> grouped-plots
+                                              (first)
+                                              (second)
+                                              (into [])))
+                          "previous" (or (->> grouped-plots
+                                              (sort-by first #(compare %2 %1))
+                                              (some (fn [[plot-id plots]]
+                                                      (and (< plot-id visible-id)
+                                                           plots))))
+                                         (->> grouped-plots
+                                              (last)
+                                              (second)
+                                              (into [])))
                           "id"       (some (fn [[plot-id plots]]
                                              (and (= plot-id visible-id)
                                                   plots))

--- a/src/js/collection.js
+++ b/src/js/collection.js
@@ -298,23 +298,6 @@ class Collection extends React.Component {
         }
     };
 
-    navErrorMessage = (direction, navigationMode) => {
-        if (direction === "id") {
-            return "Plot not found for this navigation mode.";
-        } else {
-            const modeDescription = {
-                all: "the",
-                analyzed: "your",
-                unanalyzed: "the"
-            }[navigationMode];
-            return "You have reached the "
-                + (direction === "next" ? "end" : "beginning")
-                + " of "
-                + modeDescription
-                + " list of plots.";
-        }
-    };
-
     getPlotData = (visibleId, direction) => {
         const {navigationMode, inAdminMode, threshold} = this.state;
         const {projectId} = this.props;
@@ -331,7 +314,7 @@ class Collection extends React.Component {
                 .then(response => (response.ok ? response.json() : Promise.reject(response)))
                 .then(data => {
                     if (data === "not-found") {
-                        alert(this.navErrorMessage(direction, navigationMode));
+                        alert((direction === "id" ? "Plot not" : "No more plots") + " found for this navigation mode.");
                     } else {
                         this.setState({
                             allPlots: data,


### PR DESCRIPTION
## Purpose
Wrap navigation instead of hitting the end of a list

## Related Issues
Closes CEO-226

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `CEO-### #review <comment>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
1. When on the collection page, select any navigation mode, and I click next repeatedly, the plot number should increment until it hits the last plot and then the next plot should be the first sequentially for that mode.
1. When on the collection page, select any navigation mode, and I click previous repeatedly, the plot number should decrement until it hits the first plot and then the next plot should be the last sequentially for that mode.
