### PR TITLE
CEO-194 Add 'QA/QC' navigation mode

### DIFF
--- a/src/clj/collect_earth_online/db/plots.clj
+++ b/src/clj/collect_earth_online/db/plots.clj
@@ -88,6 +88,7 @@
         project-id      (tc/val->int (:projectId params))
         visible-id      (tc/val->int (:visibleId params))
         threshold       (tc/val->int (:threshold params))
+        concordance     (tc/val->int (:concordance params))
         user-id         (:userId params -1)
         current-user-id (tc/val->int (:currentUserId params -1))
         admin-mode?     (and (tc/val->bool (:inAdminMode params))
@@ -100,6 +101,7 @@
                           "natural"    (concat (call-sql "select_analyzed_plots" project-id user-id false)
                                                (call-sql "select_unanalyzed_plots" project-id user-id false))
                           "user"       (call-sql "select_analyzed_plots" project-id current-user-id false)
+                          "qaqc"       (call-sql "select_qaqc_plots" project-id concordance)
                           [])
         grouped-plots   (group-by :visible_id proj-plots)
         plots-info      (case direction

--- a/src/clj/collect_earth_online/db/plots.clj
+++ b/src/clj/collect_earth_online/db/plots.clj
@@ -88,7 +88,6 @@
         project-id      (tc/val->int (:projectId params))
         visible-id      (tc/val->int (:visibleId params))
         threshold       (tc/val->int (:threshold params))
-        concordance     (tc/val->int (:concordance params))
         user-id         (:userId params -1)
         current-user-id (tc/val->int (:currentUserId params -1))
         admin-mode?     (and (tc/val->bool (:inAdminMode params))
@@ -101,7 +100,7 @@
                           "natural"    (concat (call-sql "select_analyzed_plots" project-id user-id false)
                                                (call-sql "select_unanalyzed_plots" project-id user-id false))
                           "user"       (call-sql "select_analyzed_plots" project-id current-user-id false)
-                          "qaqc"       (call-sql "select_qaqc_plots" project-id concordance)
+                          "qaqc"       (call-sql "select_qaqc_plots" project-id threshold)
                           [])
         grouped-plots   (group-by :visible_id proj-plots)
         plots-info      (case direction

--- a/src/js/collection.js
+++ b/src/js/collection.js
@@ -30,7 +30,6 @@ class Collection extends React.Component {
             currentImagery: {id: "", sourceConfig: {}},
             currentPlot: {},
             currentUserId: -1,
-            concordance: 90,
             // attribution for showing in the map
             imageryAttribution: "",
             // attributes to record when sample is saved
@@ -312,7 +311,7 @@ class Collection extends React.Component {
     };
 
     getPlotData = (visibleId, direction) => {
-        const {concordance, currentUserId, navigationMode, inAdminMode, threshold} = this.state;
+        const {currentUserId, navigationMode, inAdminMode, threshold} = this.state;
         const {projectId} = this.props;
         this.processModal(
             "Getting plot",
@@ -323,8 +322,7 @@ class Collection extends React.Component {
                 direction,
                 inAdminMode,
                 threshold,
-                currentUserId,
-                concordance
+                currentUserId
             }))
                 .then(response => (response.ok ? response.json() : Promise.reject(response)))
                 .then(data => {
@@ -539,8 +537,6 @@ class Collection extends React.Component {
     };
 
     setThreshold = threshold => this.setState({threshold});
-
-    setConcordance = concordance => this.setState({concordance});
 
     setCurrentPlot = currentPlot => this.setState({currentPlot, ...this.newPlotValues(currentPlot)});
 
@@ -864,7 +860,6 @@ class Collection extends React.Component {
                         collectConfidence={this.state.currentProject?.projectOptions?.collectConfidence}
                         currentPlot={this.state.currentPlot}
                         currentUserId={this.state.currentUserId}
-                        concordance={this.state.concordance}
                         inAdminMode={this.state.inAdminMode}
                         isProjectAdmin={this.state.currentProject.isProjectAdmin}
                         loadingPlots={this.state.plotList.length === 0}
@@ -877,7 +872,6 @@ class Collection extends React.Component {
                         setAdminMode={this.setAdminMode}
                         setCurrentPlot={this.setCurrentPlot}
                         setCurrentUserId={this.setCurrentUserId}
-                        setConcordance={this.setConcordance}
                         setNavigationMode={this.setNavigationMode}
                         setThreshold={this.setThreshold}
                         showNavButtons={this.state.currentPlot.id}
@@ -1124,19 +1118,19 @@ class PlotNavigation extends React.Component {
         </div>
     );
 
-    percentSlider = (label, value, setValue) => (
+    thresholdSlider = (threshold, setThreshold) => (
         <div className="my-2 d-flex align-items-center">
-            <h3 className="w-100 mx-2 my-0">{label}</h3>
+            <h3 className="w-100 mx-2 my-0">Threshold:</h3>
             <div className="d-flex">
                 <input
                     max="100"
                     min="0"
-                    onChange={e => setValue(parseInt(e.target.value))}
+                    onChange={e => setThreshold(parseInt(e.target.value))}
                     type="range"
-                    value={value}
+                    value={threshold}
                 />
                 <div className="ml-2" style={{fontSize: "0.8rem"}}>
-                    {`${value}%`}
+                    {`${threshold}%`}
                 </div>
             </div>
         </div>
@@ -1178,7 +1172,6 @@ class PlotNavigation extends React.Component {
             currentPlot,
             currentUserId,
             collectConfidence,
-            concordance,
             inAdminMode,
             isProjectAdmin,
             loadingPlots,
@@ -1187,7 +1180,6 @@ class PlotNavigation extends React.Component {
             setAdminMode,
             setCurrentPlot,
             setCurrentUserId,
-            setConcordance,
             setNavigationMode,
             setThreshold,
             showNavButtons,
@@ -1214,9 +1206,9 @@ class PlotNavigation extends React.Component {
                         </select>
                     </div>
                     {isProjectAdmin && this.adminMode(inAdminMode, setAdminMode)}
-                    {navigationMode === "confidence" && this.percentSlider("Threshold:", threshold, setThreshold)}
+                    {navigationMode === "confidence" && this.thresholdSlider(threshold, setThreshold)}
                     {navigationMode === "user" && this.selectUser(plotters, currentUserId, setCurrentUserId)}
-                    {navigationMode === "qaqc" && this.percentSlider("Concordance:", concordance, setConcordance)}
+                    {navigationMode === "qaqc" && this.thresholdSlider(threshold, setThreshold)}
                     {inAdminMode && navigationMode !== "user" && allPlots?.length > 1 && this.selectPlot(currentPlot, allPlots, setCurrentPlot)}
                 </div>
                 <div className="mt-2">

--- a/src/js/collection.js
+++ b/src/js/collection.js
@@ -533,7 +533,7 @@ class Collection extends React.Component {
         setProjectPreferences(currentProject.id, {inAdminMode});
         if (inAdminMode && this.state.navigationMode === "natural") {
             this.setNavigationMode("unanalyzed");
-        } else if (!inAdminMode && this.state.navigationMode === "qaqc") {
+        } else if (!inAdminMode && ["qaqc", "user"].includes(this.state.navigationMode)) {
             this.setNavigationMode("natural");
         }
     };

--- a/src/js/collection.js
+++ b/src/js/collection.js
@@ -533,6 +533,8 @@ class Collection extends React.Component {
         setProjectPreferences(currentProject.id, {inAdminMode});
         if (inAdminMode && this.state.navigationMode === "natural") {
             this.setNavigationMode("unanalyzed");
+        } else if (!inAdminMode && this.state.navigationMode === "qaqc") {
+            this.setNavigationMode("natural");
         }
     };
 

--- a/src/js/collection.js
+++ b/src/js/collection.js
@@ -30,6 +30,7 @@ class Collection extends React.Component {
             currentImagery: {id: "", sourceConfig: {}},
             currentPlot: {},
             currentUserId: -1,
+            concordance: 90,
             // attribution for showing in the map
             imageryAttribution: "",
             // attributes to record when sample is saved
@@ -311,7 +312,7 @@ class Collection extends React.Component {
     };
 
     getPlotData = (visibleId, direction) => {
-        const {currentUserId, navigationMode, inAdminMode, threshold} = this.state;
+        const {concordance, currentUserId, navigationMode, inAdminMode, threshold} = this.state;
         const {projectId} = this.props;
         this.processModal(
             "Getting plot",
@@ -322,7 +323,8 @@ class Collection extends React.Component {
                 direction,
                 inAdminMode,
                 threshold,
-                currentUserId
+                currentUserId,
+                concordance
             }))
                 .then(response => (response.ok ? response.json() : Promise.reject(response)))
                 .then(data => {
@@ -537,6 +539,8 @@ class Collection extends React.Component {
     };
 
     setThreshold = threshold => this.setState({threshold});
+
+    setConcordance = concordance => this.setState({concordance});
 
     setCurrentPlot = currentPlot => this.setState({currentPlot, ...this.newPlotValues(currentPlot)});
 
@@ -860,6 +864,7 @@ class Collection extends React.Component {
                         collectConfidence={this.state.currentProject?.projectOptions?.collectConfidence}
                         currentPlot={this.state.currentPlot}
                         currentUserId={this.state.currentUserId}
+                        concordance={this.state.concordance}
                         inAdminMode={this.state.inAdminMode}
                         isProjectAdmin={this.state.currentProject.isProjectAdmin}
                         loadingPlots={this.state.plotList.length === 0}
@@ -872,6 +877,7 @@ class Collection extends React.Component {
                         setAdminMode={this.setAdminMode}
                         setCurrentPlot={this.setCurrentPlot}
                         setCurrentUserId={this.setCurrentUserId}
+                        setConcordance={this.setConcordance}
                         setNavigationMode={this.setNavigationMode}
                         setThreshold={this.setThreshold}
                         showNavButtons={this.state.currentPlot.id}
@@ -1118,19 +1124,19 @@ class PlotNavigation extends React.Component {
         </div>
     );
 
-    thresholdSlider = (threshold, setThreshold) => (
+    percentSlider = (label, value, setValue) => (
         <div className="my-2 d-flex align-items-center">
-            <h3 className="w-100 mx-2 my-0">Threshold:</h3>
+            <h3 className="w-100 mx-2 my-0">{label}</h3>
             <div className="d-flex">
                 <input
                     max="100"
                     min="0"
-                    onChange={e => setThreshold(parseInt(e.target.value))}
+                    onChange={e => setValue(parseInt(e.target.value))}
                     type="range"
-                    value={threshold}
+                    value={value}
                 />
                 <div className="ml-2" style={{fontSize: "0.8rem"}}>
-                    {`${threshold}%`}
+                    {`${value}%`}
                 </div>
             </div>
         </div>
@@ -1172,6 +1178,7 @@ class PlotNavigation extends React.Component {
             currentPlot,
             currentUserId,
             collectConfidence,
+            concordance,
             inAdminMode,
             isProjectAdmin,
             loadingPlots,
@@ -1180,6 +1187,7 @@ class PlotNavigation extends React.Component {
             setAdminMode,
             setCurrentPlot,
             setCurrentUserId,
+            setConcordance,
             setNavigationMode,
             setThreshold,
             showNavButtons,
@@ -1202,11 +1210,13 @@ class PlotNavigation extends React.Component {
                             <option value="flagged">Flagged plots</option>
                             {collectConfidence && (<option value="confidence">Low Confidence</option>)}
                             {inAdminMode && (<option value="user">User</option>)}
+                            {inAdminMode && (<option value="qaqc">QA/QC</option>)}
                         </select>
                     </div>
                     {isProjectAdmin && this.adminMode(inAdminMode, setAdminMode)}
-                    {navigationMode === "confidence" && this.thresholdSlider(threshold, setThreshold)}
+                    {navigationMode === "confidence" && this.percentSlider("Threshold:", threshold, setThreshold)}
                     {navigationMode === "user" && this.selectUser(plotters, currentUserId, setCurrentUserId)}
+                    {navigationMode === "qaqc" && this.percentSlider("Concordance:", concordance, setConcordance)}
                     {inAdminMode && navigationMode !== "user" && allPlots?.length > 1 && this.selectPlot(currentPlot, allPlots, setCurrentPlot)}
                 </div>
                 <div className="mt-2">

--- a/src/sql/functions/plots.sql
+++ b/src/sql/functions/plots.sql
@@ -182,7 +182,7 @@ CREATE OR REPLACE FUNCTION select_confidence_plots(
 
 $$ LANGUAGE SQL;
 
-CREATE OR REPLACE FUNCTION select_qaqc_plots(_project_id integer, _concordance integer)
+CREATE OR REPLACE FUNCTION select_qaqc_plots(_project_id integer, _threshold integer)
  RETURNS setOf collection_return AS $$
 
     WITH assigned_count AS (

--- a/src/sql/functions/plots.sql
+++ b/src/sql/functions/plots.sql
@@ -182,6 +182,40 @@ CREATE OR REPLACE FUNCTION select_confidence_plots(
 
 $$ LANGUAGE SQL;
 
+CREATE OR REPLACE FUNCTION select_qaqc_plots(_project_id integer, _concordance integer)
+ RETURNS setOf collection_return AS $$
+
+    WITH assigned_count AS (
+        SELECT ap.plot_rid plot_rid, count(ap.user_rid) users
+        FROM plots, assigned_plots ap
+        WHERE project_rid = _project_id
+            AND plot_uid = ap.plot_rid
+        GROUP BY ap.plot_rid
+    )
+
+    SELECT plot_uid,
+        up.flagged,
+        up.flagged_reason,
+        confidence,
+        visible_id,
+        ST_AsGeoJSON(plot_geom) as plot_geom,
+        extra_plot_info,
+        u.user_uid,
+        u.email
+    FROM plots
+    INNER JOIN assigned_count ac
+        ON plot_uid = ac.plot_rid
+    INNER JOIN user_plots up
+        ON plot_uid = up.plot_rid
+    INNER JOIN users u
+        ON u.user_uid = up.user_rid
+    WHERE project_rid = _project_id
+        AND ac.users > 1
+    ORDER BY visible_id ASC
+
+$$ LANGUAGE SQL;
+
+
 -- Lock plot to user
 CREATE OR REPLACE FUNCTION lock_plot(_plot_id integer, _user_id integer, _lock_end timestamp)
  RETURNS VOID AS $$


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Adds 'QA/QC' mode to the navigation modes. Returns all plots that have more than 1 user assigned to them.

Currently, the concordance slider does nothing.

## Related Issues
Closes CEO-194

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `CEO-### #review <comment>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
<!-- Create a BDD style test script -->
1. Given I am an admin, When I am viewing a project, And I enable 'QA/QC' mode, Then I am shown plots with multiple users assigned, And that are within the concordance level.

## Screenshots
<!-- Add a screen shot when UI changes are included -->
![Screen Shot 2021-09-21 at 1 28 24 PM](https://user-images.githubusercontent.com/1829313/134242787-467f0cab-abb3-4a98-a2d8-ec74898697a3.png)


