### PR TITLE
CEO-228 Add timesToReview input

### DIFF
--- a/src/clj/collect_earth_online/db/projects.clj
+++ b/src/clj/collect_earth_online/db/projects.clj
@@ -45,9 +45,10 @@
                        :userAssignment   {:userMethod "none"
                                           :users      []
                                           :percents   []}
-                       :qaqcAssignment   {:qaqcMethod "none"
-                                          :percent    0
-                                          :smes       []}})
+                       :qaqcAssignment   {:qaqcMethod    "none"
+                                          :percent       0
+                                          :smes          []
+                                          :timesToReview 2}})
 
 (defn get-home-projects [{:keys [params]}]
   (data-response (mapv (fn [{:keys [project_id institution_id name description num_plots centroid editable]}]

--- a/src/js/project/CreateProjectWizard.js
+++ b/src/js/project/CreateProjectWizard.js
@@ -281,7 +281,7 @@ export default class CreateProjectWizard extends React.Component {
             originalProject,
             designSettings: {
                 userAssignment: {userMethod, users, percents},
-                qaqcAssignment: {qaqcMethod, smes, percent}
+                qaqcAssignment: {qaqcMethod, smes, percent, timesToReview}
             }
         } = this.context;
         const totalPlots = this.getTotalPlots();
@@ -309,7 +309,11 @@ export default class CreateProjectWizard extends React.Component {
             (["overlap", "sme"].includes(qaqcMethod) && percent === 0)
                 && "The assigned Quality Control percentage must be greater than 0.",
             (qaqcMethod === "sme" && smes.length === 0)
-                && "At least one user must be added as an SME."
+                && "At least one user must be added as an SME.",
+            (qaqcMethod === "overlap" && timesToReview === 0)
+                && "# of Reviews must be greater than 0.",
+            (qaqcMethod === "overlap" && timesToReview > users.length)
+                && "# of Reviews cannot be greater than the number of assigned users."
         ];
         return errorList.filter(e => e);
     };

--- a/src/js/project/CreateProjectWizard.js
+++ b/src/js/project/CreateProjectWizard.js
@@ -310,8 +310,8 @@ export default class CreateProjectWizard extends React.Component {
                 && "The assigned Quality Control percentage must be greater than 0.",
             (qaqcMethod === "sme" && smes.length === 0)
                 && "At least one user must be added as an SME.",
-            (qaqcMethod === "overlap" && timesToReview === 0)
-                && "# of Reviews must be greater than 0.",
+            (qaqcMethod === "overlap" && timesToReview >= 2)
+                && "# of Reviews must be at least 2.",
             (qaqcMethod === "overlap" && timesToReview > users.length)
                 && "# of Reviews cannot be greater than the number of assigned users."
         ];

--- a/src/js/project/QualityControl.js
+++ b/src/js/project/QualityControl.js
@@ -131,7 +131,7 @@ export default class QualityControl extends React.Component {
                             className="form-control form-control-sm ml-3"
                             id="reviews"
                             max="100"
-                            min="0"
+                            min="2"
                             onChange={e => this.setTimesToReview(parseInt(e.target.value))}
                             type="number"
                             value={timesToReview}

--- a/src/js/project/QualityControl.js
+++ b/src/js/project/QualityControl.js
@@ -24,6 +24,8 @@ export default class QualityControl extends React.Component {
 
     setPercent = percent => this.setAssignment({percent});
 
+    setTimesToReview = timesToReview => this.setAssignment({timesToReview});
+
     resetSelectedUser = () => this.setState({selectedUser: -1});
 
     addSME = id => {
@@ -72,7 +74,7 @@ export default class QualityControl extends React.Component {
             ["overlap", "Overlap"],
             ["sme", "SME Verification"]
         ];
-        const {qaqcMethod, percent, smes} = this.getAssignment();
+        const {qaqcMethod, percent, smes, timesToReview} = this.getAssignment();
         const {allowDrawnSamples} = this.context;
         const {selectedUser} = this.state;
         const {institutionUserList} = this.props;
@@ -120,6 +122,20 @@ export default class QualityControl extends React.Component {
                                 {percent}%
                             </div>
                         </div>
+                    </div>
+                )}
+                {qaqcMethod === "overlap" && (
+                    <div className="mt-3 form-inline">
+                        <label htmlFor="reviews"># of Reviews:</label>
+                        <input
+                            className="form-control form-control-sm ml-3"
+                            id="reviews"
+                            max="100"
+                            min="0"
+                            onChange={e => this.setTimesToReview(parseInt(e.target.value))}
+                            type="number"
+                            value={timesToReview}
+                        />
                     </div>
                 )}
                 {qaqcMethod === "sme" && (

--- a/src/js/projectAdmin.js
+++ b/src/js/projectAdmin.js
@@ -25,7 +25,8 @@ class Project extends React.Component {
                 qaqcAssignment: {
                     qaqcMethod: "none",
                     percent: 0,
-                    smes: []
+                    smes: [],
+                    timesToReview: 2
                 },
                 sampleGeometries: {
                     points: true,


### PR DESCRIPTION
## Purpose
Adds input to enter # of Reviews (`timesToReview`). Validates that the `timesToReview` is always between 1 and the number of assigned users.

## Related Issues
Closes CEO-228

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `CEO-### #review <comment>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
<!-- Create a BDD style test script -->
1. Given I am an admin, When I am creating a project, and I assign "Overlap" as the QA/QC method, Then I can assign the number of times to review.

## Screenshots
<!-- Add a screen shot when UI changes are included -->
![Screen Shot 2021-09-22 at 9 52 55 AM](https://user-images.githubusercontent.com/1829313/134387509-cfa5d2ee-598c-4c8e-b5a0-47686716cc93.png)


