### PR TITLE
CEO-227 Disable QA/QC selector if no users are assigned

### DIFF
--- a/src/js/project/QualityControl.js
+++ b/src/js/project/QualityControl.js
@@ -13,6 +13,8 @@ export default class QualityControl extends React.Component {
 
     getAssignment = () => this.context.designSettings.qaqcAssignment;
 
+    getUserAssignment = () => this.context.designSettings.userAssignment;
+
     setAssignment = newAssignment => {
         const assignment = this.getAssignment();
         this.context.setProjectDetails({
@@ -75,6 +77,7 @@ export default class QualityControl extends React.Component {
             ["sme", "SME Verification"]
         ];
         const {qaqcMethod, percent, smes, timesToReview} = this.getAssignment();
+        const {users} = this.getUserAssignment();
         const {allowDrawnSamples} = this.context;
         const {selectedUser} = this.state;
         const {institutionUserList} = this.props;
@@ -89,7 +92,7 @@ export default class QualityControl extends React.Component {
                 <h3 className="mb-3">Quality Control</h3>
                 <div className="d-flex">
                     <Select
-                        disabled={allowDrawnSamples}
+                        disabled={allowDrawnSamples || users.length === 0}
                         id="quality-mode"
                         label="Quality Mode"
                         onChange={e => this.setMethod(e.target.value)}
@@ -97,6 +100,11 @@ export default class QualityControl extends React.Component {
                         value={qaqcMethod}
                     />
                 </div>
+                {users.length === 0 && (
+                    <p className="font-italic mt-2 small">
+                        Please add assigned users to enable Quality Control.
+                    </p>
+                )}
                 {allowDrawnSamples && (
                     <p className="font-italic mt-2 small">
                         When User-Drawn samples are enabled, the project cannot support Quality Control of plots.

--- a/src/js/project/QualityControl.js
+++ b/src/js/project/QualityControl.js
@@ -100,16 +100,16 @@ export default class QualityControl extends React.Component {
                         value={qaqcMethod}
                     />
                 </div>
-                {users.length === 0 && (
-                    <p className="font-italic mt-2 small">
-                        Please add assigned users to enable Quality Control.
-                    </p>
-                )}
-                {allowDrawnSamples && (
+                {allowDrawnSamples ? (
                     <p className="font-italic mt-2 small">
                         When User-Drawn samples are enabled, the project cannot support Quality Control of plots.
                         Disable User-Drawn samples to re-enable Quality Control.
                     </p>
+                ) : users.length === 0 && (
+                    <p className="font-italic mt-2 small">
+                        Please add assigned users to enable Quality Control.
+                    </p>
+
                 )}
                 {qaqcMethod !== "none" && (
                     <div className="d-flex flex-column mt-3">


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Disables Quality Control selector when there are no assigned users. Adds a short warning message.

## Related Issues
Closes CEO-227

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `CEO-### #review <comment>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
<!-- Create a BDD style test script -->
1. Given I am an admin, When I am creating a Project, Then I cannot assign a Quality Control method until I have added assigned users.

## Screenshots
<!-- Add a screen shot when UI changes are included -->
![Screen Shot 2021-09-22 at 10 06 57 AM](https://user-images.githubusercontent.com/1829313/134389461-494c7020-b334-437e-a5fd-b1b66c01dd18.png)


