### PR TITLE
Fix timesToReview logic, add SME message

### DIFF
--- a/src/js/project/CreateProjectWizard.js
+++ b/src/js/project/CreateProjectWizard.js
@@ -310,7 +310,7 @@ export default class CreateProjectWizard extends React.Component {
                 && "The assigned Quality Control percentage must be greater than 0.",
             (qaqcMethod === "sme" && smes.length === 0)
                 && "At least one user must be added as an SME.",
-            (qaqcMethod === "overlap" && timesToReview >= 2)
+            (qaqcMethod === "overlap" && timesToReview < 2)
                 && "# of Reviews must be at least 2.",
             (qaqcMethod === "overlap" && timesToReview > users.length)
                 && "# of Reviews cannot be greater than the number of assigned users."

--- a/src/js/project/QualityControl.js
+++ b/src/js/project/QualityControl.js
@@ -169,6 +169,9 @@ export default class QualityControl extends React.Component {
                             </button>
                         </div>
                         {this.renderAssignedSMEs(assignedSMEs)}
+                        <p className="font-italic ml-2 small">
+                            - SME: Subject Matter Expert
+                        </p>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Fixes the following:
* Fix the error logic for `timesToReview`
* Adds a message for Subject Matter Experts (SME)

## Screenshots
<!-- Add a screen shot when UI changes are included -->
<img width="311" alt="Screen Shot 2021-09-23 at 9 26 14 AM" src="https://user-images.githubusercontent.com/1829313/134546558-6388c4f3-2a20-4e8c-b7b6-e3c019c81bd0.png">

