### PR TITLE
Filter QA/QC plots on agreement threshold

### DIFF
--- a/src/sql/functions/plots.sql
+++ b/src/sql/functions/plots.sql
@@ -86,8 +86,8 @@ CREATE OR REPLACE FUNCTION select_unanalyzed_plots(_project_id integer, _user_id
         visible_id,
         ST_AsGeoJSON(plot_geom) as plot_geom,
         extra_plot_info,
-        -1,
-        NULL
+        ap.user_rid,
+        u.email
     FROM plots
     LEFT JOIN assigned_plots ap
         ON plot_uid = ap.plot_rid
@@ -96,6 +96,8 @@ CREATE OR REPLACE FUNCTION select_unanalyzed_plots(_project_id integer, _user_id
         AND (ap.user_rid = up.user_rid OR (select count from assigned_count) = 0)
     LEFT JOIN plot_locks pl
         ON plot_uid = pl.plot_rid
+    LEFT JOIN users u
+        ON ap.user_rid = u.user_uid
     WHERE project_rid = _project_id
         AND user_plot_uid IS NULL
         AND ((ap.user_rid IS NULL
@@ -182,7 +184,7 @@ CREATE OR REPLACE FUNCTION select_confidence_plots(
 
 $$ LANGUAGE SQL;
 
-CREATE OR REPLACE FUNCTION select_qaqc_plots(_project_id integer, _threshold integer)
+CREATE OR REPLACE FUNCTION select_qaqc_plots(_project_id integer)
  RETURNS setOf collection_return AS $$
 
     WITH assigned_count AS (


### PR DESCRIPTION
## Purpose
Filter QA/QC plots on agreement threshold for the qaqc navigation mode.

## Related Issues
Closes CEO-221

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `CEO-### #review <comment>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
When on the collection page, and my project has qaqc enabled, and more than one plot has been analyzed twice, then clicking next will got to the next plot where the answer to samples to not match with X% under the threshold.
For example if there are 10 plots and 5 are the same and 5 are different, then it should show in the navigation under 50%
