### PR TITLE
Show dropdown in admin mode so admin can see who answered what

### DIFF
--- a/src/js/collection.js
+++ b/src/js/collection.js
@@ -545,12 +545,16 @@ class Collection extends React.Component {
 
     setCurrentUserId = currentUserId => {
         const {allPlots} = this.state;
-        const newPlot = allPlots.find(p => p.userId === currentUserId);
-        this.setState({
-            currentUserId,
-            currentPlot: newPlot,
-            ...this.newPlotValues(newPlot)
-        });
+        const newPlot = (allPlots || []).find(p => p.userId === currentUserId);
+        if (newPlot) {
+            this.setState({
+                currentUserId,
+                currentPlot: newPlot,
+                ...this.newPlotValues(newPlot)
+            });
+        } else {
+            this.setState({currentUserId});
+        }
     };
 
     postValuesToDB = () => {
@@ -879,7 +883,7 @@ class Collection extends React.Component {
                         navToPlot={this.navToPlot}
                         navToPrevPlot={this.navToPrevPlot}
                         plotters={this.state.plotters}
-                        plotUser={(this.state.allPlots || []).filter(p => p.userId)}
+                        plotUsers={(this.state.allPlots || []).filter(p => p.userId)}
                         setAdminMode={this.setAdminMode}
                         setCurrentUserId={this.setCurrentUserId}
                         setNavigationMode={this.setNavigationMode}

--- a/src/js/collection.js
+++ b/src/js/collection.js
@@ -1209,7 +1209,7 @@ class PlotNavigation extends React.Component {
                     </div>
                     {isProjectAdmin && this.reviewMode(inReviewMode, setReviewMode)}
                     {["confidence", "qaqc"].includes(navigationMode) && this.thresholdSlider(threshold, setThreshold)}
-                    {inAdminMode && this.selectUser(
+                    {inReviewMode && this.selectUser(
                         navigationMode === "user" ? plotters : plotUsers,
                         currentUserId,
                         setCurrentUserId

--- a/src/sql/functions/plots.sql
+++ b/src/sql/functions/plots.sql
@@ -89,8 +89,8 @@ CREATE OR REPLACE FUNCTION select_unanalyzed_plots(_project_id integer, _user_id
         visible_id,
         ST_AsGeoJSON(plot_geom) as plot_geom,
         extra_plot_info,
-        -1,
-        NULL
+        ap.user_rid,
+        u.email
     FROM plots
     LEFT JOIN assigned_plots ap
         ON plot_uid = ap.plot_rid
@@ -99,6 +99,8 @@ CREATE OR REPLACE FUNCTION select_unanalyzed_plots(_project_id integer, _user_id
         AND (ap.user_rid = up.user_rid OR (select count from assigned_count) = 0)
     LEFT JOIN plot_locks pl
         ON plot_uid = pl.plot_rid
+    LEFT JOIN users u
+        ON ap.user_rid = u.user_uid
     WHERE project_rid = _project_id
         AND user_plot_uid IS NULL
         AND ((ap.user_rid IS NULL


### PR DESCRIPTION
## Purpose
Show dropdown in admin mode so admin can see who answered what
Remove some repeat code.

## Related Issues
Closes CEO-238

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `CEO-### #review <comment>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
1.When in admin mode, every navigation mode shows a dropdown
2. When project has no qaqc, dropdown should be disabled

## Screenshots
![image](https://user-images.githubusercontent.com/33734037/134605980-5651be4d-e634-4f02-917e-9029a4a74ae6.png)

