### PR TITLE
Disable QC based on none user assignment

### DIFF
--- a/src/js/project/AssignPlots.js
+++ b/src/js/project/AssignPlots.js
@@ -12,19 +12,26 @@ export default class AssignPlots extends React.Component {
         };
     }
 
+    getQaqcAssignment = () => this.context.designSettings.qaqcAssignment;
+
     getUserAssignment = () => this.context.designSettings.userAssignment;
 
-    setUserAssignment = newUserAssignment => {
+    setUserAssignment = (newUserAssignment, newQaqcAssignment) => {
+        const qaqcAssignment = this.getQaqcAssignment();
         const userAssignment = this.getUserAssignment();
         this.context.setProjectDetails({
             designSettings: {
                 ...this.context.designSettings,
+                qaqcAssignment: {...qaqcAssignment, ...newQaqcAssignment},
                 userAssignment: {...userAssignment, ...newUserAssignment}
             }
         });
     };
 
-    setMethod = userMethod => this.setUserAssignment({userMethod});
+    setMethod = newUserMethod => this.setUserAssignment(
+        {userMethod: newUserMethod},
+        newUserMethod === "none" ? {qaqcMethod: "none"} : null
+    );
 
     resetSelectedUser = () => {
         this.setState({selectedUserId: -1});

--- a/src/js/project/CreateProjectWizard.js
+++ b/src/js/project/CreateProjectWizard.js
@@ -310,9 +310,11 @@ export default class CreateProjectWizard extends React.Component {
                 && "The assigned Quality Control percentage must be greater than 0.",
             (qaqcMethod === "sme" && smes.length === 0)
                 && "At least one user must be added as an SME.",
+            (qaqcMethod === "overlap" && users.length === 1)
+                    && "At least two assigned users are required for overlap mode.",
             (qaqcMethod === "overlap" && timesToReview < 2)
                 && "# of Reviews must be at least 2.",
-            (qaqcMethod === "overlap" && timesToReview > users.length)
+            (qaqcMethod === "overlap" && timesToReview > users.length && users.length > 1)
                 && "# of Reviews cannot be greater than the number of assigned users."
         ];
         return errorList.filter(e => e);

--- a/src/js/project/QualityControl.js
+++ b/src/js/project/QualityControl.js
@@ -77,7 +77,7 @@ export default class QualityControl extends React.Component {
             ["sme", "SME Verification"]
         ];
         const {qaqcMethod, percent, smes, timesToReview} = this.getAssignment();
-        const {users} = this.getUserAssignment();
+        const {userMethod} = this.getUserAssignment();
         const {allowDrawnSamples} = this.context;
         const {selectedUser} = this.state;
         const {institutionUserList} = this.props;
@@ -92,7 +92,7 @@ export default class QualityControl extends React.Component {
                 <h3 className="mb-3">Quality Control</h3>
                 <div className="d-flex">
                     <Select
-                        disabled={allowDrawnSamples || users.length === 0}
+                        disabled={allowDrawnSamples || userMethod === "none"}
                         id="quality-mode"
                         label="Quality Mode"
                         onChange={e => this.setMethod(e.target.value)}
@@ -105,9 +105,9 @@ export default class QualityControl extends React.Component {
                         When User-Drawn samples are enabled, the project cannot support Quality Control of plots.
                         Disable User-Drawn samples to re-enable Quality Control.
                     </p>
-                ) : users.length === 0 && (
+                ) : userMethod === "none" && (
                     <p className="font-italic mt-2 small">
-                        Please add assigned users to enable Quality Control.
+                        Please assign users to enable Quality Control.
                     </p>
 
                 )}


### PR DESCRIPTION
## Purpose
Disable QC based on none user assignment for when a user assigns some users and then goes back to none. 
Hide QC controls when none is selected but users where assigned

## Related Issues
Closes CEO-234

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `CEO-### #review <comment>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
1. Select equal assignment
2. add a user
3. select overlap
4. select no assignment
QC should go back to disabled with no controls showing.
