### PR TITLE
Show "refresh" to admins in review mode

### DIFF
--- a/src/js/collection.js
+++ b/src/js/collection.js
@@ -1103,7 +1103,10 @@ class PlotNavigation extends React.Component {
                 onClick={() => this.props.navToPlot(this.state.newPlotInput)}
                 type="button"
             >
-                Go to plot
+                {this.state.newPlotInput === this.props.currentPlot.visibleId
+                    && this.props.inAdminMode
+                    ? "Refresh"
+                    : "Go to plot"}
             </button>
         </div>
     );


### PR DESCRIPTION
## Purpose
Show "refresh" to admins in review mode

## Related Issues
Closes CEO-245

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `CEO-### #review <comment>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
On the collection page, in admin mode, the button next to the plot number says "Refresh".
On the collection page, in admin mode, when I change the plot number the button next to the plot number says "Go to plot".

## Screenshots
![image](https://user-images.githubusercontent.com/33734037/134696649-7fe16307-0662-44b0-9aec-6401b705a9fe.png)

