### PR TITLE
CEO-242 Rename Admin Mode to Review Mode

### DIFF
--- a/src/clj/collect_earth_online/db/plots.clj
+++ b/src/clj/collect_earth_online/db/plots.clj
@@ -129,7 +129,7 @@
            :savedAnswers (tc/jsonb->clj saved_answers)})
         (call-sql "select_plot_samples" plot-id user-id)))
 
-(defn- build-collection-plot [plot-info user-id admin-mode?]
+(defn- build-collection-plot [plot-info user-id review-mode?]
   (let [{:keys [plot_id
                 flagged
                 confidence
@@ -146,7 +146,7 @@
      :visibleId     visible_id
      :plotGeom      plot_geom
      :extraPlotInfo (tc/jsonb->clj extra_plot_info {})
-     :samples       (prepare-samples-array plot_id (if (and admin-mode? (pos? user_id))
+     :samples       (prepare-samples-array plot_id (if (and review-mode? (pos? user_id))
                                                      user_id
                                                      user-id))
      :userId        user_id
@@ -165,13 +165,13 @@
         threshold       (tc/val->int (:threshold params))
         user-id         (:userId params -1)
         current-user-id (tc/val->int (:currentUserId params -1))
-        admin-mode?     (and (tc/val->bool (:inAdminMode params))
+        review-mode?     (and (tc/val->bool (:inReviewMode params))
                              (is-proj-admin? user-id project-id nil))
         proj-plots      (case navigation-mode
-                          "unanalyzed" (call-sql "select_unanalyzed_plots" project-id user-id admin-mode?)
-                          "analyzed"   (call-sql "select_analyzed_plots"   project-id user-id admin-mode?)
-                          "flagged"    (call-sql "select_flagged_plots"    project-id user-id admin-mode?)
-                          "confidence" (call-sql "select_confidence_plots" project-id user-id admin-mode? threshold)
+                          "unanalyzed" (call-sql "select_unanalyzed_plots" project-id user-id review-mode?)
+                          "analyzed"   (call-sql "select_analyzed_plots"   project-id user-id review-mode?)
+                          "flagged"    (call-sql "select_flagged_plots"    project-id user-id review-mode?)
+                          "confidence" (call-sql "select_confidence_plots" project-id user-id review-mode? threshold)
                           "natural"    (concat (call-sql "select_analyzed_plots" project-id user-id false)
                                                (call-sql "select_unanalyzed_plots" project-id user-id false))
                           "user"       (call-sql "select_analyzed_plots" project-id current-user-id false)
@@ -212,7 +212,7 @@
                   (:plot_id (first plots-info))
                   user-id
                   (time-plus-five-min))
-        (data-response (map #(build-collection-plot % user-id admin-mode?) plots-info)))
+        (data-response (map #(build-collection-plot % user-id review-mode?) plots-info)))
       (data-response "not-found"))))
 
 ;;;

--- a/src/js/collection.js
+++ b/src/js/collection.js
@@ -202,9 +202,7 @@ class Collection extends React.Component {
             if (project.id > 0 && project.availability !== "archived") {
                 this.setState({currentProject: project});
                 const {inReviewMode} = getProjectPreferences(project.id);
-                if (project.isProjectAdmin && inReviewMode) {
-                    this.setReviewMode(inReviewMode);
-                }
+                this.setReviewMode(project.isProjectAdmin && (inReviewMode || (project.availability === "published" && inReviewMode !== false)));
                 return Promise.resolve("resolved");
             } else {
                 return Promise.reject(
@@ -537,7 +535,7 @@ class Collection extends React.Component {
         this.setState({inReviewMode});
         setProjectPreferences(currentProject.id, {inReviewMode});
         if (inReviewMode && this.state.navigationMode === "natural") {
-            this.setNavigationMode("unanalyzed");
+            this.setNavigationMode("analyzed");
         } else if (!inReviewMode && ["qaqc", "user"].includes(this.state.navigationMode)) {
             this.setNavigationMode("natural");
         }

--- a/src/js/utils/preferences.js
+++ b/src/js/utils/preferences.js
@@ -5,7 +5,7 @@
 const ceo = "ceo:";
 const project = "project:";
 
-const defaultPreferences = {inAdminMode: null};
+const defaultPreferences = {inReviewMode: null};
 
 export function getPreference(key) {
     return window.localStorage.getItem(ceo + key);

--- a/src/sql/functions/plots.sql
+++ b/src/sql/functions/plots.sql
@@ -72,7 +72,7 @@ CREATE TYPE collection_return AS (
     email              text
 );
 
-CREATE OR REPLACE FUNCTION select_unanalyzed_plots(_project_id integer, _user_id integer, _admin_mode boolean)
+CREATE OR REPLACE FUNCTION select_unanalyzed_plots(_project_id integer, _user_id integer, _review_mode boolean)
  RETURNS setOf collection_return AS $$
 
     WITH assigned_count AS (
@@ -107,12 +107,12 @@ CREATE OR REPLACE FUNCTION select_unanalyzed_plots(_project_id integer, _user_id
                 AND (pl.lock_end IS NULL
                      OR localtimestamp > pl.lock_end)) -- unlocked
              OR ap.user_rid = _user_id                 -- assigned
-             OR _admin_mode)                           -- admin TODO, CEO-208 should admin be able to visit a locked plot? probably.
+             OR _review_mode)                           -- admin TODO, CEO-208 should admin be able to visit a locked plot? probably.
     ORDER BY visible_id ASC
 
 $$ LANGUAGE SQL;
 
-CREATE OR REPLACE FUNCTION select_analyzed_plots(_project_id integer, _user_id integer, _admin_mode boolean)
+CREATE OR REPLACE FUNCTION select_analyzed_plots(_project_id integer, _user_id integer, _review_mode boolean)
  RETURNS setOf collection_return AS $$
 
     SELECT plot_uid,
@@ -130,12 +130,12 @@ CREATE OR REPLACE FUNCTION select_analyzed_plots(_project_id integer, _user_id i
     INNER JOIN users u
         ON u.user_uid = up.user_rid
     WHERE project_rid = _project_id
-        AND (up.user_rid = _user_id OR _admin_mode)
+        AND (up.user_rid = _user_id OR _review_mode)
     ORDER BY visible_id ASC
 
 $$ LANGUAGE SQL;
 
-CREATE OR REPLACE FUNCTION select_flagged_plots(_project_id integer, _user_id integer, _admin_mode boolean)
+CREATE OR REPLACE FUNCTION select_flagged_plots(_project_id integer, _user_id integer, _review_mode boolean)
  RETURNS setOf collection_return AS $$
 
     SELECT plot_uid,
@@ -153,7 +153,7 @@ CREATE OR REPLACE FUNCTION select_flagged_plots(_project_id integer, _user_id in
     INNER JOIN users u
         ON u.user_uid = up.user_rid
     WHERE project_rid = _project_id
-        AND (up.user_rid = _user_id OR _admin_mode)
+        AND (up.user_rid = _user_id OR _review_mode)
         AND flagged = TRUE
     ORDER BY visible_id ASC
 
@@ -162,7 +162,7 @@ $$ LANGUAGE SQL;
 CREATE OR REPLACE FUNCTION select_confidence_plots(
     _project_id integer,
     _user_id integer,
-    _admin_mode boolean,
+    _review_mode boolean,
     _threshold integer
  ) RETURNS setOf collection_return AS $$
 
@@ -181,7 +181,7 @@ CREATE OR REPLACE FUNCTION select_confidence_plots(
     INNER JOIN users u
         ON u.user_uid = up.user_rid
     WHERE project_rid = _project_id
-        AND (up.user_rid = _user_id OR _admin_mode)
+        AND (up.user_rid = _user_id OR _review_mode)
         AND confidence <= _threshold
     ORDER BY visible_id ASC
 


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Also changes the default behavior of "Review Mode" to only be enabled by default when a project has been "published."

## Related Issues
Closes CEO-242

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `CEO-### #review <comment>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
1. As an admin, When I create a project, And I leave it in Draft Mode, And I go to the project overview page, Then Review Mode is turned off by default.
1. As an admin, When I create a project, And I publish the project, And I go to the project overview page, Then Review Mode is turned on by default.

## Screenshots
<!-- Add a screen shot when UI changes are included -->
![Screen Shot 2021-09-24 at 10 41 35 AM](https://user-images.githubusercontent.com/1829313/134717997-6dcfcbc7-e369-4f8d-87f9-09535aebf2e8.png)


