### PR TITLE
CEO-244 Only show QA/QC mode for Projects with QA/QC mode enabled

### DIFF
--- a/src/js/collection.js
+++ b/src/js/collection.js
@@ -867,6 +867,7 @@ class Collection extends React.Component {
                         currentUserId={this.state.currentUserId}
                         inAdminMode={this.state.inAdminMode}
                         isProjectAdmin={this.state.currentProject.isProjectAdmin}
+                        isQAQCEnabled={this.state.currentProject.designSettings?.qaqcAssignment?.qaqcMethod !== "none"}
                         loadingPlots={this.state.plotList.length === 0}
                         navigationMode={this.state.navigationMode}
                         navToFirstPlot={this.navToFirstPlot}
@@ -1184,6 +1185,7 @@ class PlotNavigation extends React.Component {
             collectConfidence,
             inAdminMode,
             isProjectAdmin,
+            isQAQCEnabled,
             loadingPlots,
             navigationMode,
             plotters,
@@ -1212,7 +1214,7 @@ class PlotNavigation extends React.Component {
                             <option value="flagged">Flagged plots</option>
                             {collectConfidence && (<option value="confidence">Low Confidence</option>)}
                             {inAdminMode && (<option value="user">User</option>)}
-                            {inAdminMode && (<option value="qaqc">QA/QC</option>)}
+                            {inAdminMode && isQAQCEnabled && (<option value="qaqc">QA/QC</option>)}
                         </select>
                     </div>
                     {isProjectAdmin && this.adminMode(inAdminMode, setAdminMode)}


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
EOM

## Related Issues
Closes CEO-244

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `CEO-### #review <comment>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
<!-- Create a BDD style test script -->
1. Given I am an admin, When I view a project, And the project has QA/QC enabled, Then I can select the QA/QC navigation mode.

