### PR TITLE
CEO-207 Add lower limit plots per user

### DIFF
--- a/src/js/project/CreateProjectWizard.js
+++ b/src/js/project/CreateProjectWizard.js
@@ -304,6 +304,8 @@ export default class CreateProjectWizard extends React.Component {
                 && "The plot size limit has been exceeded. Check the Plot Design section for detailed info.",
             (["equal", "percent"].includes(userMethod) && users.length === 0)
                 && "At least one user must be added to the plot assignment.",
+            (users.length > Math.round(totalPlots / users.length))
+                && `Too few plots per user. Each user must have at least ${users.length} plots.`,
             (userMethod === "percent" && percents.reduce((acc, p) => acc + p, 0) !== 100)
                 && "The assigned plot percentages must equal 100%.",
             (["overlap", "sme"].includes(qaqcMethod) && percent === 0)

--- a/src/js/project/CreateProjectWizard.js
+++ b/src/js/project/CreateProjectWizard.js
@@ -304,8 +304,8 @@ export default class CreateProjectWizard extends React.Component {
                 && "The plot size limit has been exceeded. Check the Plot Design section for detailed info.",
             (["equal", "percent"].includes(userMethod) && users.length === 0)
                 && "At least one user must be added to the plot assignment.",
-            (users.length > Math.round(totalPlots / users.length))
-                && `Too few plots per user. Each user must have at least ${users.length} plots.`,
+            (users.length > Math.round((totalPlots * (percent / 100)) / users.length))
+                && `Too few plots per user for Quality Control Overlap. Each user must have at least ${users.length} plots.`,
             (userMethod === "percent" && percents.reduce((acc, p) => acc + p, 0) !== 100)
                 && "The assigned plot percentages must equal 100%.",
             (["overlap", "sme"].includes(qaqcMethod) && percent === 0)


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Adds error message when too few plots have been assigned per user.

## Related Issues
Closes CEO-207

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `CEO-### #review <comment>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
<!-- Create a BDD style test script -->
1. Given I am an admin, When I am creating a project, And I assign plots, Then I must provide a minimum number of plots per user.

## Screenshots
<!-- Add a screen shot when UI changes are included -->
![Screen Shot 2021-09-29 at 9 09 48 AM](https://user-images.githubusercontent.com/1829313/135307317-43d93715-65b1-406f-8f29-b85d0c89155f.png)


