### PR TITLE
Add error message when percent is 0

### DIFF
--- a/src/js/project/CreateProjectWizard.js
+++ b/src/js/project/CreateProjectWizard.js
@@ -307,9 +307,9 @@ export default class CreateProjectWizard extends React.Component {
             (userMethod === "percent" && percents.reduce((acc, p) => acc + p, 0) !== 100)
                 && "The assigned plot percentages must equal 100%.",
             (userMethod === "percent" && percents.reduce((acc, p) => (acc || p === 0), false))
-                && "All plot percentages must be greater than 0%.",
+                && "All plot assignment percentages must be greater than 0%.",
             (["overlap", "sme"].includes(qaqcMethod) && percent === 0)
-                && "The assigned Quality Control percentage must be greater than 0.",
+                && "The assigned Quality Control percentage must be greater than 0%.",
             (qaqcMethod === "sme" && smes.length === 0)
                 && "At least one user must be added as an SME.",
             (qaqcMethod === "overlap" && users.length === 1)

--- a/src/js/project/CreateProjectWizard.js
+++ b/src/js/project/CreateProjectWizard.js
@@ -306,6 +306,8 @@ export default class CreateProjectWizard extends React.Component {
                 && "At least one user must be added to the plot assignment.",
             (userMethod === "percent" && percents.reduce((acc, p) => acc + p, 0) !== 100)
                 && "The assigned plot percentages must equal 100%.",
+            (userMethod === "percent" && percents.reduce((acc, p) => (acc || p === 0), false))
+                && "All plot percentages must be greater than 0%.",
             (["overlap", "sme"].includes(qaqcMethod) && percent === 0)
                 && "The assigned Quality Control percentage must be greater than 0.",
             (qaqcMethod === "sme" && smes.length === 0)


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Displays an error message for when User Assignment is "percent" and the percent assigned is 0%.

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `CEO-### #review <comment>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Screenshots
<!-- Add a screen shot when UI changes are included -->
![Screen Shot 2021-09-29 at 9 13 04 AM](https://user-images.githubusercontent.com/1829313/135307856-d35c0b49-280c-4fb6-85ee-b78c11865d32.png)

