### PR TITLE
CEO-215 Reset plots when assignments are updated

### DIFF
--- a/src/clj/collect_earth_online/db/projects.clj
+++ b/src/clj/collect_earth_online/db/projects.clj
@@ -522,13 +522,9 @@
        (same-ring? (exterior-ring (:coordinates geom1))
                    (exterior-ring (:coordinates geom2)))))
 
-(defn modified-assignment? [ds1 ds2]
-  (not= (-> ds1 (tc/jsonb->clj) (:userAssignment))
-        (-> ds2 (tc/jsonb->clj) (:userAssignment))))
-
-(defn modified-qaqc? [ds1 ds2]
-  (not= (-> ds1 (tc/jsonb->clj) (:qaqcAssignment))
-        (-> ds2 (tc/jsonb->clj) (:qaqcAssignment))))
+(defn modified-design? [ds1 ds2]
+  (not= (-> ds1 (tc/jsonb->clj))
+        (-> ds2 (tc/jsonb->clj))))
 
 (defn update-project! [{:keys [params]}]
   (let [project-id           (tc/val->int (:projectId params))
@@ -574,8 +570,7 @@
           nil
 
           (or (not= plot-distribution (:plot_distribution original-project))
-              (modified-assignment? design-settings (:design_settings original-project))
-              (modified-qaqc? design-settings (:design_settings original-project))
+              (modified-design? design-settings (:design_settings original-project))
               (if (#{"csv" "shp"} plot-distribution)
                 plot-file-base64
                 (or (not (same-polygon-boundary? (tc/jsonb->clj boundary) (tc/jsonb->clj (:boundary original-project))))

--- a/src/clj/collect_earth_online/db/projects.clj
+++ b/src/clj/collect_earth_online/db/projects.clj
@@ -522,6 +522,14 @@
        (same-ring? (exterior-ring (:coordinates geom1))
                    (exterior-ring (:coordinates geom2)))))
 
+(defn modified-assignment? [ds1 ds2]
+  (not= (-> ds1 (tc/jsonb->clj) (:userAssignment))
+        (-> ds2 (tc/jsonb->clj) (:userAssignment))))
+
+(defn modified-qaqc? [ds1 ds2]
+  (not= (-> ds1 (tc/jsonb->clj) (:qaqcAssignment))
+        (-> ds2 (tc/jsonb->clj) (:qaqcAssignment))))
+
 (defn update-project! [{:keys [params]}]
   (let [project-id           (tc/val->int (:projectId params))
         imagery-id           (or (:imageryId params) (get-first-public-imagery))
@@ -566,6 +574,8 @@
           nil
 
           (or (not= plot-distribution (:plot_distribution original-project))
+              (modified-assignment? design-settings (:design_settings original-project))
+              (modified-qaqc? design-settings (:design_settings original-project))
               (if (#{"csv" "shp"} plot-distribution)
                 plot-file-base64
                 (or (not (same-polygon-boundary? (tc/jsonb->clj boundary) (tc/jsonb->clj (:boundary original-project))))

--- a/src/js/project/ReviewChanges.js
+++ b/src/js/project/ReviewChanges.js
@@ -146,8 +146,7 @@ export default class ReviewChanges extends React.Component {
             || !_.isEqual(projectDetails.surveyRules, originalProject.surveyRules);
 
     plotDesignChanged = ({designSettings}, {designSettings: originalDesignSettings}) =>
-        !(_.isEqual(designSettings?.userAssignment, originalDesignSettings?.userAssignment))
-            || !(_.isEqual(designSettings?.qaqcAssignment, originalDesignSettings?.qaqcAssignment));
+        !(_.isEqual(designSettings, originalDesignSettings));
 
     plotsUpdated = (projectDetails, originalProject) =>
         projectDetails.plotDistribution !== originalProject.plotDistribution

--- a/src/js/project/ReviewChanges.js
+++ b/src/js/project/ReviewChanges.js
@@ -58,7 +58,8 @@ export default class ReviewChanges extends React.Component {
     updateProject = () => {
         // TODO: Match project details in context as in state (i.e. do not spread into context).
         const updateSurvey = this.surveyQuestionUpdated(this.context, this.context.originalProject);
-        const extraMessage = this.plotsUpdated(this.context, this.context.originalProject)
+        const extraMessage = (this.plotsUpdated(this.context, this.context.originalProject)
+          || this.assignmentsUpdated(this.context, this.context.originalProject))
             ? "  Plots and samples will be recreated, losing all collection data."
             : this.samplesUpdated(this.context, this.context.originalProject)
                 ? "  Samples will be recreated, losing all collection data."
@@ -143,6 +144,10 @@ export default class ReviewChanges extends React.Component {
     surveyQuestionUpdated = (projectDetails, originalProject) =>
         !_.isEqual(projectDetails.surveyQuestions, originalProject.surveyQuestions)
             || !_.isEqual(projectDetails.surveyRules, originalProject.surveyRules);
+
+    assignmentsUpdated = ({designSettings}, {designSettings: originalDesignSettings}) =>
+        !(_.isEqual(designSettings?.userAssignment, originalDesignSettings?.userAssignment))
+            || !(_.isEqual(designSettings?.qaqcAssignment, originalDesignSettings?.qaqcAssignment));
 
     plotsUpdated = (projectDetails, originalProject) =>
         projectDetails.plotDistribution !== originalProject.plotDistribution

--- a/src/js/project/ReviewChanges.js
+++ b/src/js/project/ReviewChanges.js
@@ -59,7 +59,7 @@ export default class ReviewChanges extends React.Component {
         // TODO: Match project details in context as in state (i.e. do not spread into context).
         const updateSurvey = this.surveyQuestionUpdated(this.context, this.context.originalProject);
         const extraMessage = (this.plotsUpdated(this.context, this.context.originalProject)
-          || this.assignmentsUpdated(this.context, this.context.originalProject))
+          || this.plotDesignChanged(this.context, this.context.originalProject))
             ? "  Plots and samples will be recreated, losing all collection data."
             : this.samplesUpdated(this.context, this.context.originalProject)
                 ? "  Samples will be recreated, losing all collection data."
@@ -145,7 +145,7 @@ export default class ReviewChanges extends React.Component {
         !_.isEqual(projectDetails.surveyQuestions, originalProject.surveyQuestions)
             || !_.isEqual(projectDetails.surveyRules, originalProject.surveyRules);
 
-    assignmentsUpdated = ({designSettings}, {designSettings: originalDesignSettings}) =>
+    plotDesignChanged = ({designSettings}, {designSettings: originalDesignSettings}) =>
         !(_.isEqual(designSettings?.userAssignment, originalDesignSettings?.userAssignment))
             || !(_.isEqual(designSettings?.qaqcAssignment, originalDesignSettings?.qaqcAssignment));
 


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Checks the User & QA/QC assignments, and updates the plots when either has been modified.

## Related Issues
Closes CEO-215

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `CEO-### #review <comment>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
<!-- Create a BDD style test script -->
1. Given I am an admin, When I am updating a project, And I change the User Assignments or Quality Control, Then I am warned that the collected plots will be deleted, And the plots are updated.

