### PR TITLE
CEO-232 Add unsaved changes warning

### DIFF
--- a/src/js/collection.js
+++ b/src/js/collection.js
@@ -372,7 +372,7 @@ class Collection extends React.Component {
     navToFirstPlot = () => this.getPlotData(-10000000, "next");
 
     navToNextPlot = ignoreCheck => {
-        if (ignoreCheck === true || this.confirmUnsaved()) {
+        if (ignoreCheck || this.confirmUnsaved()) {
             this.getPlotData(this.state.currentPlot.visibleId, "next");
         }
     };
@@ -1131,7 +1131,7 @@ class PlotNavigation extends React.Component {
             </button>
             <button
                 className="btn btn-outline-lightgreen btn-sm mx-1"
-                onClick={this.props.navToNextPlot}
+                onClick={() => this.props.navToNextPlot()}
                 type="button"
             >
                 <UnicodeIcon icon="rightCaret"/>


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Show a unsaved changes warning when a user tries to hit "Back" and has unsaved answers.

## Related Issues
Closes CEO-232

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `CEO-### #review <comment>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
<!-- Create a BDD style test script -->
1. Given I am a user, When I am collecting, And I have unsaved answers, And I try to navigate away, Then I am shown a unsaved changes warning.

## Screenshots
<!-- Add a screen shot when UI changes are included -->
#### Unsaved changes alert
<img width="1418" alt="Screen Shot 2021-09-29 at 2 20 22 PM" src="https://user-images.githubusercontent.com/1829313/135350130-eea54984-0891-48b0-a1ca-168108cc7cb1.png">

#### Unsaved confirm alert when using the plot nav
![image](https://user-images.githubusercontent.com/1829313/135532343-34a59808-3b17-4732-9430-18ddda15a03d.png)

