### PR TITLE
CEO-213 Clean up Assign/QC layout, Add UserSelect

### DIFF
--- a/src/js/components/Select.js
+++ b/src/js/components/Select.js
@@ -24,10 +24,10 @@ export default function Select({
     labelKey
 }) {
     return (
-        <div className="form-inline">
-            <label htmlFor={id}>{label}</label>
+        <>
+            <label className="col-5" htmlFor={id}>{label}</label>
             <select
-                className="form-control form-control-sm ml-3"
+                className="form-control form-control-sm col-5"
                 disabled={disabled}
                 id={id}
                 onChange={onChange}
@@ -41,6 +41,6 @@ export default function Select({
                         /* eslint-disable-next-line react/no-array-index-key */
                         <Option key={i} labelKey={labelKey} option={o} valueKey={valueKey}/>)}
             </select>
-        </div>
+        </>
     );
 }

--- a/src/js/components/UserSelect.js
+++ b/src/js/components/UserSelect.js
@@ -1,0 +1,36 @@
+import React, {useState} from "react";
+
+import Select from "./Select";
+
+export default function UserSelect({label, id, possibleUsers = [], addUser}) {
+    const [selectedUserId, setSelectedUserId] = useState(-1);
+
+    return (
+        <div className="form-row">
+            <Select
+                disabled={possibleUsers.length === 1}
+                id={id}
+                label={label}
+                labelKey="email"
+                onChange={e => setSelectedUserId(parseInt(e.target.value))}
+                options={possibleUsers.length > 1 ? possibleUsers : ["No users to assign."]}
+                value={selectedUserId}
+                valueKey="id"
+            />
+            <div className="col-1">
+                <button
+                    className="btn btn-sm btn-success"
+                    disabled={possibleUsers.length === 1 || selectedUserId === -1}
+                    onClick={() => {
+                        addUser(selectedUserId);
+                        setSelectedUserId(-1);
+                    }}
+                    title="Add User"
+                    type="button"
+                >
+                        +
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/src/js/project/AssignPlots.js
+++ b/src/js/project/AssignPlots.js
@@ -2,16 +2,10 @@ import React from "react";
 
 import {ProjectContext} from "./constants";
 import Select from "../components/Select";
+import UserSelect from "../components/UserSelect";
 import {formatNumberWithCommas, removeAtIndex} from "../utils/generalUtils";
 
 export default class AssignPlots extends React.Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            selectedUserId: -1
-        };
-    }
-
     getQaqcAssignment = () => this.context.designSettings.qaqcAssignment;
 
     getUserAssignment = () => this.context.designSettings.userAssignment;
@@ -33,16 +27,11 @@ export default class AssignPlots extends React.Component {
         newUserMethod === "none" ? {qaqcMethod: "none"} : null
     );
 
-    resetSelectedUser = () => {
-        this.setState({selectedUserId: -1});
-    };
-
     addUser = userId => {
         const {users, percents} = this.getUserAssignment();
         const newUsers = [...users, userId];
         const newPercents = [...percents, 0];
         this.setUserAssignment({users: newUsers, percents: newPercents});
-        this.resetSelectedUser();
     };
 
     removeUser = userId => {
@@ -53,7 +42,6 @@ export default class AssignPlots extends React.Component {
             users: newUsers,
             percents: removeAtIndex(percents, idx)
         });
-        this.resetSelectedUser();
     };
 
     assignPlotPercent = (userIndex, percent) => {
@@ -63,15 +51,15 @@ export default class AssignPlots extends React.Component {
     };
 
     renderAssignedUsers = (assignedUsers, isPercentage, percents, totalPlots) => (
-        <div className="d-flex flex-column mt-3">
+        <div>
             {assignedUsers.map(({id, email}, userIndex) => {
                 const numPlots = Math.round((percents[userIndex] / 100) * totalPlots);
                 return (
-                    <div key={id} className="d-flex justify-content-between mt-1">
-                        <div className="mr-5">
+                    <div key={id} className="form-row mt-1">
+                        <div className="col-5">
                             {isPercentage && (
                                 <div className="d-flex flex-column">
-                                    <div>
+                                    <div className="ml-2">
                                         <input
                                             className="form-control form-control-sm"
                                             max="100"
@@ -84,26 +72,31 @@ export default class AssignPlots extends React.Component {
                                         />
                                         &#37;
                                     </div>
-                                    <div className="font-italic mx-1 small">
-                                        - ~{formatNumberWithCommas(numPlots)} plots
+                                    <div className="font-italic small ml-2">
+                                        ~{formatNumberWithCommas(numPlots)} plots
                                     </div>
                                 </div>
                             )}
                         </div>
-                        <div className="d-flex">
+                        <div className="col-5">
                             <div
                                 style={{
                                     background: "white",
                                     border: "1px solid #ced4da",
                                     borderRadius: ".25rem",
                                     fontSize: ".875rem",
-                                    padding: ".25rem .5rem"
+                                    overflow: "hidden",
+                                    padding: ".25rem .5rem",
+                                    textOverflow: "ellipsis",
+                                    whiteSpace: "nowrap"
                                 }}
                             >
                                 {email}
                             </div>
+                        </div>
+                        <div className="col-1">
                             <button
-                                className="btn btn-sm btn-danger mx-2"
+                                className="btn btn-sm btn-danger"
                                 onClick={() => this.removeUser(id)}
                                 title={`Remove ${email}`}
                                 type="button"
@@ -123,7 +116,6 @@ export default class AssignPlots extends React.Component {
             ["equal", "Equal assignments"],
             ["percent", "Percentage of plots"]
         ];
-        const {selectedUserId} = this.state;
         const {institutionUserList, totalPlots} = this.props;
         const {userMethod, users, percents} = this.getUserAssignment();
         const possibleUsers = [
@@ -136,7 +128,7 @@ export default class AssignPlots extends React.Component {
         return (
             <div className="col-6">
                 <h3 className="mb-3">Assign Plots</h3>
-                <div className="d-flex">
+                <div className="form-row">
                     <Select
                         id="user-assignment"
                         label="User Assignment"
@@ -147,30 +139,15 @@ export default class AssignPlots extends React.Component {
                 </div>
                 {userMethod !== "none" && (
                     <div className="mt-3">
-                        <div className="d-flex">
-                            <Select
-                                disabled={possibleUsers.length === 1}
-                                id="assigned-users"
-                                label="Assigned Users"
-                                labelKey="email"
-                                onChange={e => this.setState({selectedUserId: parseInt(e.target.value)})}
-                                options={possibleUsers.length > 1 ? possibleUsers : ["No users to assign."]}
-                                value={this.state.selectedUserId}
-                                valueKey="id"
-                            />
-                            <button
-                                className="btn btn-sm btn-success mx-2"
-                                disabled={possibleUsers.length === 1 || selectedUserId === -1}
-                                onClick={() => this.addUser(selectedUserId)}
-                                title="Add User"
-                                type="button"
-                            >
-                                +
-                            </button>
-                        </div>
+                        <UserSelect
+                            addUser={this.addUser}
+                            id="assigned-users"
+                            label="Assigned Users"
+                            possibleUsers={possibleUsers}
+                        />
                         {this.renderAssignedUsers(assignedUsers, userMethod === "percent", percents, totalPlots)}
-                        {userMethod === "equal" && (
-                            <p className="font-italic mt-2 small">
+                        {userMethod === "equal" && assignedUsers.length > 0 && (
+                            <p className="font-italic ml-2 mt-2 small">
                                 - Each user will be assigned ~{formatNumberWithCommas(plotsPerUser)} plots
                             </p>
                         )}

--- a/src/js/project/QualityControl.js
+++ b/src/js/project/QualityControl.js
@@ -2,16 +2,10 @@ import React from "react";
 
 import {ProjectContext} from "./constants";
 import Select from "../components/Select";
+import UserSelect from "../components/UserSelect";
 import {formatNumberWithCommas} from "../utils/generalUtils";
 
 export default class QualityControl extends React.Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            selectedUser: -1
-        };
-    }
-
     getAssignment = () => this.context.designSettings.qaqcAssignment;
 
     getUserAssignment = () => this.context.designSettings.userAssignment;
@@ -29,43 +23,46 @@ export default class QualityControl extends React.Component {
 
     setTimesToReview = timesToReview => this.setAssignment({timesToReview});
 
-    resetSelectedUser = () => this.setState({selectedUser: -1});
-
     addSME = id => {
         const {smes} = this.getAssignment();
         this.setAssignment({smes: [...smes, id]});
-        this.resetSelectedUser();
     };
 
     removeSME = id => {
         const {smes} = this.getAssignment();
         this.setAssignment({smes: smes.filter(s => s !== id)});
-        this.resetSelectedUser();
     };
 
     renderAssignedSMEs = assignedSMEs => (
-        <div className="d-flex flex-column my-3">
+        <div>
             {assignedSMEs.map(({id, email}) => (
-                <div key={id} className="d-flex justify-content-end mt-1">
-                    <div
-                        style={{
-                            background: "white",
-                            border: "1px solid #ced4da",
-                            borderRadius: ".25rem",
-                            fontSize: ".875rem",
-                            padding: ".25rem .5rem"
-                        }}
-                    >
-                        {email}
+                <div key={id} className="form-row mt-1">
+                    <div className="col-5 offset-5">
+                        <div
+                            style={{
+                                background: "white",
+                                border: "1px solid #ced4da",
+                                borderRadius: ".25rem",
+                                fontSize: ".875rem",
+                                overflow: "hidden",
+                                padding: ".25rem .5rem",
+                                textOverflow: "ellipsis",
+                                whiteSpace: "nowrap"
+                            }}
+                        >
+                            {email}
+                        </div>
                     </div>
-                    <button
-                        className="btn btn-sm btn-danger mx-2"
-                        onClick={() => this.removeSME(id)}
-                        title={`Remove ${email}`}
-                        type="button"
-                    >
-                        -
-                    </button>
+                    <div className="col-1">
+                        <button
+                            className="btn btn-sm btn-danger"
+                            onClick={() => this.removeSME(id)}
+                            title={`Remove ${email}`}
+                            type="button"
+                        >
+                            -
+                        </button>
+                    </div>
                 </div>
             ))}
         </div>
@@ -80,7 +77,6 @@ export default class QualityControl extends React.Component {
         const {qaqcMethod, percent, smes, timesToReview} = this.getAssignment();
         const {userMethod} = this.getUserAssignment();
         const {allowDrawnSamples} = this.context;
-        const {selectedUser} = this.state;
         const {institutionUserList, totalPlots} = this.props;
         const possibleSMEs = [
             {id: -1, email: "Select user..."},
@@ -93,7 +89,7 @@ export default class QualityControl extends React.Component {
         return (
             <div className="col-6">
                 <h3 className="mb-3">Quality Control</h3>
-                <div className="d-flex">
+                <div className="form-row">
                     <Select
                         disabled={allowDrawnSamples || userMethod === "none"}
                         id="quality-mode"
@@ -103,7 +99,7 @@ export default class QualityControl extends React.Component {
                         value={qaqcMethod}
                     />
                 </div>
-                <p className="font-italic ml-2 my-1 small">
+                <p className="font-italic ml-2 mt-2 small">
                   - SME: Subject Matter Expert
                 </p>
                 {allowDrawnSamples ? (
@@ -118,33 +114,36 @@ export default class QualityControl extends React.Component {
 
                 )}
                 {qaqcMethod !== "none" && (
-                    <div className="d-flex flex-column mt-3">
-                        <label htmlFor="percent">Percent:</label>
+                    <>
+                        <div className="form-row mt-3">
+                            <label className="col-5" htmlFor="percent">Percent:</label>
+                            <div className="col-5 d-flex align-items-center">
+                                <input
+                                    className="form-control"
+                                    id="percent"
+                                    max="100"
+                                    min="0"
+                                    onChange={e => this.setPercent(parseInt(e.target.value))}
+                                    steps="5"
+                                    type="range"
+                                    value={percent}
+                                />
+                                <div style={{fontSize: "0.9rem", marginLeft: "0.5rem"}}>
+                                    {percent}%
+                                </div>
+                            </div>
+                        </div>
                         <p className="font-italic ml-2 small">
                             - Percent of each users plots to review
                         </p>
-                        <div className="d-flex mx-3">
-                            <input
-                                id="percent"
-                                max="100"
-                                min="0"
-                                onChange={e => this.setPercent(parseInt(e.target.value))}
-                                steps="5"
-                                type="range"
-                                value={percent}
-                            />
-                            <div style={{fontSize: "0.9rem", margin: "0.25rem 1rem"}}>
-                                {percent}%
-                            </div>
-                        </div>
-                    </div>
+                    </>
                 )}
                 {qaqcMethod === "overlap" && (
                     <>
-                        <div className="mt-3 form-inline">
-                            <label htmlFor="reviews"># of Reviews:</label>
+                        <div className="form-row mt-3">
+                            <label className="col-5" htmlFor="reviews"># of Reviews:</label>
                             <input
-                                className="form-control form-control-sm ml-3"
+                                className="col-5 form-control form-control-sm"
                                 id="reviews"
                                 max="100"
                                 min="2"
@@ -153,41 +152,27 @@ export default class QualityControl extends React.Component {
                                 value={timesToReview}
                             />
                         </div>
-                        <p className="font-italic mt-2 small">
+                        <p className="font-italic ml-2 mt-2 small">
                             - Plots to review: {formatNumberWithCommas(plotsToReview)}
                         </p>
                     </>
                 )}
 
                 {qaqcMethod === "sme" && (
-                    <div className="mt-3">
-                        <div className="d-flex">
-                            <Select
-                                disabled={possibleSMEs.length === 1}
-                                id="assigned-smes"
-                                label="Assigned SMEs"
-                                labelKey="email"
-                                onChange={e => this.setState({selectedUser: parseInt(e.target.value)})}
-                                options={possibleSMEs.length > 1 ? possibleSMEs : ["No Users to Assign"]}
-                                valueKey="id"
-                            />
-                            <button
-                                className="btn btn-sm btn-success mx-2"
-                                disabled={possibleSMEs.length === 1 || selectedUser === -1}
-                                onClick={() => this.addSME(selectedUser)}
-                                title="Add User"
-                                type="button"
-                            >
-                                +
-                            </button>
-                        </div>
+                    <>
+                        <UserSelect
+                            addUser={this.addSME}
+                            id="assigned-smes"
+                            label="Assigned SMEs"
+                            possibleUsers={possibleSMEs}
+                        />
                         {this.renderAssignedSMEs(assignedSMEs)}
                         {smes.length > 0 && (
-                            <p className="font-italic ml-2 small">
+                            <p className="font-italic ml-2 mt-2 small">
                                 - Each SME will review ~{formatNumberWithCommas(plotsPerSME)} plots
                             </p>
                         )}
-                    </div>
+                    </>
                 )}
             </div>
         );


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Align all form elements to a grid, rather than use flex alignment. Create a `UserSelect` component to simplify the AssignUsers/QualityControl components.

## Related Issues
Closes CEO-213

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `CEO-### #review <comment>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Screenshots
<!-- Add a screen shot when UI changes are included -->
Equal Assignment / Overlap
<img width="804" alt="Screen Shot 2021-10-01 at 10 53 36 AM" src="https://user-images.githubusercontent.com/1829313/135665510-606765a0-511f-47a3-a448-c06c35b3f905.png">

Percent Assignment / SMEs
<img width="798" alt="Screen Shot 2021-10-01 at 10 54 29 AM" src="https://user-images.githubusercontent.com/1829313/135665630-db0a2539-54b6-447e-8235-7c53c91ff8dc.png">


