### PR TITLE
CEO-208 Admin save over user plots

### DIFF
--- a/src/clj/collect_earth_online/db/plots.clj
+++ b/src/clj/collect_earth_online/db/plots.clj
@@ -249,16 +249,16 @@
   (let [project-id       (tc/val->int (:projectId params))
         plot-id          (tc/val->int (:plotId params))
         session-user-id  (:userId params -1)
-        plot-user-id     (tc/val->int (:plotUserId params -1))
+        current-user-id  (tc/val->int (:currentUserId params -1))
         review-mode?     (and (tc/val->bool (:inReviewMode params))
-                              (pos? plot-user-id)
+                              (pos? current-user-id)
                               (is-proj-admin? session-user-id project-id nil))
         confidence       (tc/val->int (:confidence params))
         collection-start (tc/val->long (:collectionStart params))
         user-samples     (:userSamples params)
         user-images      (:userImages params)
         new-plot-samples (:newPlotSamples params)
-        user-id          (if review-mode? plot-user-id session-user-id)
+        user-id          (if review-mode? current-user-id session-user-id)
         ;; Samples created in the UI have IDs starting with 1. When the new sample is created
         ;; in Postgres, it gets different ID.  The user sample ID needs to be updated to match.
         id-translation   (when new-plot-samples
@@ -288,15 +288,15 @@
   (let [project-id       (tc/val->int (:projectId params))
         plot-id          (tc/val->int (:plotId params))
         user-id          (:userId params -1)
-        plot-user-id     (tc/val->int (:plotUserId params -1))
+        current-user-id  (tc/val->int (:currentUserId params -1))
         review-mode?     (and (tc/val->bool (:inReviewMode params false))
-                              (pos? plot-user-id)
+                              (pos? current-user-id)
                               (is-proj-admin? user-id project-id nil))
         collection-start (tc/val->long (:collectionStart params))
         flagged-reason   (:flaggedReason params)]
     (call-sql "flag_plot"
               plot-id
-              (if review-mode? plot-user-id user-id)
+              (if review-mode? current-user-id user-id)
               (when-not review-mode? (Timestamp. collection-start))
               flagged-reason)
     (unlock-plots user-id)

--- a/src/js/collection.js
+++ b/src/js/collection.js
@@ -620,7 +620,7 @@ class Collection extends React.Component {
                                 collectionStart: this.state.collectionStart,
                                 flaggedReason: this.state.currentPlot.flaggedReason,
                                 inReviewMode: this.state.inReviewMode,
-                                plotUserId: this.state.currentUserId
+                                currentUserId: this.state.currentUserId
                             })
                         }
                     )
@@ -657,7 +657,7 @@ class Collection extends React.Component {
                             plotSamples: this.state.currentProject.allowDrawnSamples
                                 && this.state.currentPlot.samples,
                             inReviewMode: this.state.inReviewMode,
-                            plotUserId: this.state.currentUserId
+                            currentUserId: this.state.currentUserId
                         })
                     }
                 )

--- a/src/js/collection.js
+++ b/src/js/collection.js
@@ -620,7 +620,7 @@ class Collection extends React.Component {
                                 collectionStart: this.state.collectionStart,
                                 flaggedReason: this.state.currentPlot.flaggedReason,
                                 inReviewMode: this.state.inReviewMode,
-                                plotUserId: this.state.currentPlot.userId
+                                plotUserId: this.state.currentUserId
                             })
                         }
                     )
@@ -657,7 +657,7 @@ class Collection extends React.Component {
                             plotSamples: this.state.currentProject.allowDrawnSamples
                                 && this.state.currentPlot.samples,
                             inReviewMode: this.state.inReviewMode,
-                            plotUserId: this.state.currentPlot.userId
+                            plotUserId: this.state.currentUserId
                         })
                     }
                 )

--- a/src/js/collection.js
+++ b/src/js/collection.js
@@ -618,7 +618,9 @@ class Collection extends React.Component {
                                 projectId: this.props.projectId,
                                 plotId: this.state.currentPlot.id,
                                 collectionStart: this.state.collectionStart,
-                                flaggedReason: this.state.currentPlot.flaggedReason
+                                flaggedReason: this.state.currentPlot.flaggedReason,
+                                inReviewMode: this.state.inReviewMode,
+                                plotUserId: this.state.currentPlot.userId
                             })
                         }
                     )
@@ -653,7 +655,9 @@ class Collection extends React.Component {
                             userSamples: this.state.userSamples,
                             userImages: this.state.userImages,
                             plotSamples: this.state.currentProject.allowDrawnSamples
-                                && this.state.currentPlot.samples
+                                && this.state.currentPlot.samples,
+                            inReviewMode: this.state.inReviewMode,
+                            plotUserId: this.state.currentPlot.userId
                         })
                     }
                 )


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Enable ability for admins to save over another user's plots.

## Related Issues
Closes CEO-208

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `CEO-### #review <comment>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
<!-- Create a BDD style test script -->
1. Given I am an admin, When I am reviewing a project, And I am in review mode, And I modify the sample answers, Then the sample answers are overwritten.

## Screenshots
<!-- Add a screen shot when UI changes are included -->

