### PR TITLE
CEO-253 Warn users flagging a plot will clear answers

### DIFF
--- a/src/js/collection.js
+++ b/src/js/collection.js
@@ -596,8 +596,16 @@ class Collection extends React.Component {
         }
     };
 
+    hasAnswers = () =>
+        (Object.values(this.state.userSamples)
+            .reduce((acc, sample) => acc || (Object.keys(sample).length > 0), false)
+        || Object.values(this.state.originalUserSamples)
+            .reduce((acc, sample) => acc || (Object.keys(sample).length > 0), false));
+
+    confirmFlag = () => !this.hasAnswers() || confirm("Flagging this plot will delete your previous answers. Are you sure you want to continue?");
+
     postValuesToDB = () => {
-        if (this.state.currentPlot.flagged) {
+        if (this.state.currentPlot.flagged && this.confirmFlag()) {
             this.processModal(
                 "Saving flagged plot",
                 () => fetch(

--- a/src/js/collection.js
+++ b/src/js/collection.js
@@ -596,43 +596,42 @@ class Collection extends React.Component {
         }
     };
 
-    hasAnswers = () =>
-        (Object.values(this.state.userSamples)
-            .reduce((acc, sample) => acc || (Object.keys(sample).length > 0), false)
-        || Object.values(this.state.originalUserSamples)
-            .reduce((acc, sample) => acc || (Object.keys(sample).length > 0), false));
+    hasAnswers = () => _.some(Object.values(this.state.userSamples), sample => !(_.isEmpty(sample)))
+        || _.some(Object.values(this.state.userSamples), sample => !(_.isEmpty(sample)));
 
     confirmFlag = () => !this.hasAnswers() || confirm("Flagging this plot will delete your previous answers. Are you sure you want to continue?");
 
     postValuesToDB = () => {
-        if (this.state.currentPlot.flagged && this.confirmFlag()) {
-            this.processModal(
-                "Saving flagged plot",
-                () => fetch(
-                    "/flag-plot",
-                    {
-                        method: "POST",
-                        headers: {
-                            "Accept": "application/json",
-                            "Content-Type": "application/json"
-                        },
-                        body: JSON.stringify({
-                            projectId: this.props.projectId,
-                            plotId: this.state.currentPlot.id,
-                            collectionStart: this.state.collectionStart,
-                            flaggedReason: this.state.currentPlot.flaggedReason
-                        })
-                    }
-                )
-                    .then(response => {
-                        if (response.ok) {
-                            return this.navToNextPlot(true);
-                        } else {
-                            console.log(response);
-                            alert("Error flagging plot as bad. See console for details.");
+        if (this.state.currentPlot.flagged) {
+            if (this.confirmFlag()) {
+                this.processModal(
+                    "Saving flagged plot",
+                    () => fetch(
+                        "/flag-plot",
+                        {
+                            method: "POST",
+                            headers: {
+                                "Accept": "application/json",
+                                "Content-Type": "application/json"
+                            },
+                            body: JSON.stringify({
+                                projectId: this.props.projectId,
+                                plotId: this.state.currentPlot.id,
+                                collectionStart: this.state.collectionStart,
+                                flaggedReason: this.state.currentPlot.flaggedReason
+                            })
                         }
-                    })
-            );
+                    )
+                        .then(response => {
+                            if (response.ok) {
+                                return this.navToNextPlot(true);
+                            } else {
+                                console.log(response);
+                                alert("Error flagging plot as bad. See console for details.");
+                            }
+                        })
+                );
+            }
         } else {
             this.processModal(
                 "Saving plot answers",


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Adds a confirmation when flagging plots that have existing answers.

## Related Issues
Closes CEO-253

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `CEO-### #review <comment>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
<!-- Create a BDD style test script -->
1. Given I am a user, When I am collecting, And I have answered some questions, And I flag a plot, Then I am presented with a warning that my answers will be cleared.

## Screenshots
<!-- Add a screen shot when UI changes are included -->
<img width="1251" alt="Screen Shot 2021-10-01 at 3 24 00 PM" src="https://user-images.githubusercontent.com/1829313/135692270-66f24800-6c05-4816-8810-161b913a2428.png">


