### PR TITLE
CEO-254 Use Assigned/Default instead of Natural

### DIFF
--- a/src/js/collection.js
+++ b/src/js/collection.js
@@ -908,7 +908,7 @@ class Collection extends React.Component {
                         currentPlot={this.state.currentPlot}
                         currentUserId={this.state.currentUserId}
                         inReviewMode={this.state.inReviewMode}
-                        isAssignedPlots={this.state.currentProject.designSettings?.userAssignment?.userMethod !== "none"}
+                        hasAssignedPlots={this.state.currentProject.designSettings?.userAssignment?.userMethod !== "none"}
                         isProjectAdmin={this.state.currentProject.isProjectAdmin}
                         isQAQCEnabled={this.state.currentProject.designSettings?.qaqcAssignment?.qaqcMethod !== "none"}
                         loadingPlots={this.state.plotList.length === 0}
@@ -1209,7 +1209,7 @@ class PlotNavigation extends React.Component {
             currentPlot,
             collectConfidence,
             inReviewMode,
-            isAssignedPlots,
+            hasAssignedPlots,
             isProjectAdmin,
             isQAQCEnabled,
             loadingPlots,
@@ -1234,7 +1234,7 @@ class PlotNavigation extends React.Component {
                             style={{flex: "1 1 auto"}}
                             value={navigationMode}
                         >
-                            {!inReviewMode && (<option value="natural">{isAssignedPlots ? "Assigned" : "Default"}</option>)}
+                            {!inReviewMode && (<option value="natural">{hasAssignedPlots ? "Assigned" : "Default"}</option>)}
                             <option value="unanalyzed">Unanalyzed plots</option>
                             <option value="analyzed">Analyzed plots</option>
                             <option value="flagged">Flagged plots</option>

--- a/src/js/collection.js
+++ b/src/js/collection.js
@@ -908,6 +908,7 @@ class Collection extends React.Component {
                         currentPlot={this.state.currentPlot}
                         currentUserId={this.state.currentUserId}
                         inReviewMode={this.state.inReviewMode}
+                        isAssignedPlots={this.state.currentProject.designSettings?.userAssignment?.userMethod !== "none"}
                         isProjectAdmin={this.state.currentProject.isProjectAdmin}
                         isQAQCEnabled={this.state.currentProject.designSettings?.qaqcAssignment?.qaqcMethod !== "none"}
                         loadingPlots={this.state.plotList.length === 0}
@@ -1208,6 +1209,7 @@ class PlotNavigation extends React.Component {
             currentPlot,
             collectConfidence,
             inReviewMode,
+            isAssignedPlots,
             isProjectAdmin,
             isQAQCEnabled,
             loadingPlots,
@@ -1232,7 +1234,7 @@ class PlotNavigation extends React.Component {
                             style={{flex: "1 1 auto"}}
                             value={navigationMode}
                         >
-                            {!inReviewMode && (<option value="natural">Natural</option>)}
+                            {!inReviewMode && (<option value="natural">{isAssignedPlots ? "Assigned" : "Default"}</option>)}
                             <option value="unanalyzed">Unanalyzed plots</option>
                             <option value="analyzed">Analyzed plots</option>
                             <option value="flagged">Flagged plots</option>


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Rather than have a "Natural" navigation mode, use the label of "Assigned" when the project has assigned plots or "Default" when there are not assigned plots.

## Related Issues
Closes CEO-254

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `CEO-### #review <comment>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
<!-- Create a BDD style test script -->
1. Given I am a User, When I view a project with Assigned plots, Then I am shown the "Assigned" navigation mode by default.
1. Given I am a User, When I view a project without Assigned plots, Then I am shown the "Default" navigation mode by default.

## Screenshots
<!-- Add a screen shot when UI changes are included -->
Assigned Plots
<img width="566" alt="Screen Shot 2021-10-01 at 3 33 05 PM" src="https://user-images.githubusercontent.com/1829313/135692838-5d0ed549-d86a-458c-9858-7fba0e62b96e.png">

No Assigned Plots
<img width="560" alt="Screen Shot 2021-
10-01 at 3 32 44 PM" src="https://user-images.githubusercontent.com/1829313/135692811-97596773-7f9f-4d3d-bf4b-d8d692a78f4a.png">

