### PR TITLE
CEO-255 Filter out users/SMEs from possibleUsers

### DIFF
--- a/src/js/project/AssignPlots.js
+++ b/src/js/project/AssignPlots.js
@@ -126,10 +126,10 @@ export default class AssignPlots extends React.Component {
         const {selectedUserId} = this.state;
         const {institutionUserList, totalPlots} = this.props;
         const {userMethod, users, percents} = this.getUserAssignment();
-        const {smes} = this.getQaqcAssignment();
+        const {qaqcMethod, smes} = this.getQaqcAssignment();
         const possibleUsers = [
             {id: -1, email: "Select user..."},
-            ...institutionUserList.filter(u => !users.includes(u.id) && !smes.includes(u.id))
+            ...institutionUserList.filter(u => !users.includes(u.id) && (qaqcMethod !== "sme" || !smes.includes(u.id)))
         ];
         const assignedUsers = institutionUserList.filter(u => users.includes(u.id));
         const plotsPerUser = Math.round(totalPlots / users.length);

--- a/src/js/project/AssignPlots.js
+++ b/src/js/project/AssignPlots.js
@@ -126,9 +126,10 @@ export default class AssignPlots extends React.Component {
         const {selectedUserId} = this.state;
         const {institutionUserList, totalPlots} = this.props;
         const {userMethod, users, percents} = this.getUserAssignment();
+        const {smes} = this.getQaqcAssignment();
         const possibleUsers = [
             {id: -1, email: "Select user..."},
-            ...institutionUserList.filter(u => !users.includes(u.id))
+            ...institutionUserList.filter(u => !users.includes(u.id) && !smes.includes(u.id))
         ];
         const assignedUsers = institutionUserList.filter(u => users.includes(u.id));
         const plotsPerUser = Math.round(totalPlots / users.length);

--- a/src/js/project/CreateProjectWizard.js
+++ b/src/js/project/CreateProjectWizard.js
@@ -1,4 +1,5 @@
 import React from "react";
+import _ from "lodash";
 
 import {ImagerySelection} from "./ImagerySelection";
 import {Overview, OverviewIntro} from "./Overview";
@@ -299,7 +300,10 @@ export default class CreateProjectWizard extends React.Component {
             (qaqcMethod === "overlap" && timesToReview < 2)
                 && "# of Reviews must be at least 2.",
             (qaqcMethod === "overlap" && timesToReview > users.length && users.length > 1)
-                && "# of Reviews cannot be greater than the number of assigned users."
+                && "# of Reviews cannot be greater than the number of assigned users.",
+            (userMethod !== "none" && qaqcMethod === "sme" && (_.union(users, smes)).length > 0)
+                && "Users cannot be an Assigned User and an SME. Please remove the duplicate users."
+
         ];
         return errorList.filter(e => e);
     };

--- a/src/js/project/QualityControl.js
+++ b/src/js/project/QualityControl.js
@@ -78,13 +78,13 @@ export default class QualityControl extends React.Component {
             ["sme", "SME Verification"]
         ];
         const {qaqcMethod, percent, smes, timesToReview} = this.getAssignment();
-        const {userMethod} = this.getUserAssignment();
+        const {userMethod, users} = this.getUserAssignment();
         const {allowDrawnSamples} = this.context;
         const {selectedUser} = this.state;
         const {institutionUserList, totalPlots} = this.props;
         const possibleSMEs = [
             {id: -1, email: "Select user..."},
-            ...institutionUserList.filter(({id}) => !smes.includes(id))
+            ...institutionUserList.filter(u => !users.includes(u.id) && !smes.includes(u.id))
         ];
         const assignedSMEs = institutionUserList.filter(({id}) => smes.includes(id));
         const plotsToReview = Math.round(totalPlots * (percent / 100));


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Filter out assigned users & assigned SMEs from the "possible users" that can be assigned to each. Also displays an error if a user is both an Assigned User and an SME.

## Related Issues
Closes CEO-255

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `CEO-### #review <comment>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
<!-- Create a BDD style test script -->
1. Given I am an admin, When I am creating a project, Then I cannot assign someone as both an assigned user and an SME.

## Screenshots
![image](https://user-images.githubusercontent.com/1829313/135693772-56e82f27-5323-4ef5-a2b4-5705c712047b.png)
