### PR TITLE
Optimize query for institution stats

### DIFF
--- a/src/clj/collect_earth_online/routing.clj
+++ b/src/clj/collect_earth_online/routing.clj
@@ -86,6 +86,7 @@
                                               :auth-action :block}
    [:get  "/get-home-projects"]              {:handler     projects/get-home-projects}
    [:get  "/get-institution-projects"]       {:handler     projects/get-institution-projects}
+   [:get  "/get-institution-project-stats"]  {:handler     projects/get-institution-project-stats}
    [:get  "/get-project-by-id"]              {:handler     projects/get-project-by-id}
    [:get  "/get-template-projects"]          {:handler     projects/get-template-projects}
    [:get  "/get-template-by-id"]             {:handler     projects/get-template-by-id}

--- a/src/js/institutionDashboard.js
+++ b/src/js/institutionDashboard.js
@@ -17,7 +17,6 @@ class InstitutionDashboard extends React.Component {
         this.processModal(
             "Loading project list",
             this.getProjectList()
-                .then(projectList => this.setState({projectList}))
                 .catch(response => {
                     console.error(response);
                     alert("Error retrieving the project list. See console for details.");
@@ -27,23 +26,10 @@ class InstitutionDashboard extends React.Component {
 
     /// API Calls
 
-    // TODO, These should probably be 1 API call on the backend to reduce the number of connections
-    getProjectList = () => fetch(`/get-institution-projects?institutionId=${this.props.institutionId}`)
-        .then(response => (response.ok ? response.json() : Promise.reject(response)))
-        .then(data => this.getProjectDetails(data));
-
-    getProjectDetails = projects => Promise.all(projects.map(proj => fetch(`/get-project-stats?projectId=${proj.id}`)
-        .then(response => (response.ok ? response.json() : Promise.reject(response)))
-        .then(data => ({
-            id: proj.id,
-            name: proj.name,
-            numPlots: proj.numPlots,
-            unanalyzedPlots: data.unanalyzedPlots,
-            analyzedPlots: data.analyzedPlots,
-            flaggedPlots: data.flaggedPlots,
-            contributors: data.contributors,
-            members: data.members
-        }))));
+    getProjectList = () =>
+        fetch(`/get-institution-project-stats?institutionId=${this.props.institutionId}`)
+            .then(response => (response.ok ? response.json() : Promise.reject(response)))
+            .then(data => this.setState({projectList: data}));
 
     /// Helpers
 
@@ -63,32 +49,34 @@ class InstitutionDashboard extends React.Component {
                 >
                     <h1>Institution Dashboard</h1>
                 </div>
-                <table id="srd" style={{width: "1000px", margin: "10px", color: "rgb(49, 186, 176)"}}>
-                    <thead>
-                        <tr>
-                            <th>Project Id</th>
-                            <th>Project Name</th>
-                            <th>Contributors</th>
-                            <th>Total Plots</th>
-                            <th>Flagged Plots</th>
-                            <th>Analyzed Plots</th>
-                            <th>Unanalyzed Plots</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {projectList.map(project => (
-                            <tr key={project.id}>
-                                <td>{project.id}</td>
-                                <td>{project.name}</td>
-                                <td>{project.contributors}</td>
-                                <td>{project.numPlots}</td>
-                                <td>{project.flaggedPlots}</td>
-                                <td>{project.analyzedPlots}</td>
-                                <td>{project.unanalyzedPlots}</td>
+                {projectList.length > 0 && (
+                    <table id="srd" style={{width: "1000px", margin: "10px", color: "rgb(49, 186, 176)"}}>
+                        <thead>
+                            <tr style={{whiteSpace: "nowrap"}}>
+                                <th className="pr-2">Project Id</th>
+                                <th className="pr-2">Project Name</th>
+                                <th className="pr-2">Contributors</th>
+                                <th className="pr-2">Total Plots</th>
+                                <th className="pr-2">Flagged Plots</th>
+                                <th className="pr-2">Analyzed Plots</th>
+                                <th className="pr-2">Unanalyzed Plots</th>
                             </tr>
-                        ))}
-                    </tbody>
-                </table>
+                        </thead>
+                        <tbody>
+                            {projectList && projectList.map(project => (
+                                <tr key={project.id}>
+                                    <td>{project.id}</td>
+                                    <td>{project.name}</td>
+                                    <td style={{textAlign: "center"}}>{project.stats.contributors}</td>
+                                    <td style={{textAlign: "center"}}>{project.numPlots}</td>
+                                    <td style={{textAlign: "center"}}>{project.stats.flaggedPlots}</td>
+                                    <td style={{textAlign: "center"}}>{project.stats.analyzedPlots}</td>
+                                    <td style={{textAlign: "center"}}>{project.stats.unanalyzedPlots}</td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                )}
             </div>
         );
     }

--- a/src/sql/functions/project.sql
+++ b/src/sql/functions/project.sql
@@ -516,6 +516,94 @@ CREATE OR REPLACE FUNCTION select_institution_projects(_user_id integer, _instit
 
 $$ LANGUAGE SQL;
 
+CREATE OR REPLACE FUNCTION select_short_project_stats(_project_id integer)
+ RETURNS table (
+    flagged_plots       integer,
+    analyzed_plots      integer,
+    unanalyzed_plots    integer,
+    contributors        integer
+ ) AS $$
+
+    WITH project_plots AS (
+        SELECT project_uid,
+            plot_uid,
+            (CASE WHEN collection_time IS NULL OR collection_start IS NULL THEN 0
+                ELSE EXTRACT(EPOCH FROM (collection_time - collection_start)) END) as seconds,
+            (CASE WHEN collection_time IS NULL OR collection_start IS NULL THEN 0 ELSE 1 END) as timed,
+            u.email as email
+        FROM user_plots up
+        INNER JOIN plots pl
+            ON up.plot_rid = plot_uid
+        INNER JOIN projects p
+            ON pl.project_rid = project_uid
+        INNER JOIN users u
+            ON up.user_rid = user_uid
+        WHERE project_uid = _project_id
+    ), plotsum AS (
+        SELECT SUM(coalesce(flagged::int, 0)) as flagged,
+            SUM((user_plot_uid IS NOT NULL)::int) as analyzed,
+            plot_uid
+        FROM projects prj
+        INNER JOIN plots pl
+          ON project_uid = pl.project_rid
+        LEFT JOIN user_plots up
+            ON up.plot_rid = pl.plot_uid
+        GROUP BY project_uid, plot_uid
+        HAVING project_uid = _project_id
+    ), sums AS (
+        SELECT MAX(prj.created_date) as created_date,
+            MAX(prj.published_date) as published_date,
+            MAX(prj.closed_date) as closed_date,
+            MAX(prj.archived_date) as archived_date,
+            (CASE WHEN SUM(ps.flagged::int) IS NULL THEN 0 ELSE SUM(ps.flagged::int) END) as flagged,
+            (CASE WHEN SUM(ps.analyzed::int) IS NULL THEN 0 ELSE SUM(ps.analyzed::int) END) as analyzed,
+            COUNT(distinct pl.plot_uid) as plots
+        FROM projects prj
+        INNER JOIN plots pl
+          ON project_uid = pl.project_rid
+        LEFT JOIN plotsum ps
+          ON ps.plot_uid = pl.plot_uid
+        WHERE project_uid = _project_id
+    ), users_count AS (
+        SELECT COUNT (DISTINCT user_rid) as users
+        FROM projects prj
+        INNER JOIN plots pl
+          ON project_uid = pl.project_rid
+            AND project_uid = _project_id
+        LEFT JOIN user_plots up
+          ON up.plot_rid = plot_uid
+    )
+
+    SELECT CAST(flagged as int) as flagged_plots,
+        CAST(analyzed as int) analyzed_plots,
+        CAST(GREATEST(0, (plots - flagged - analyzed)) as int) as unanalyzed_plots,
+        CAST(users_count.users as int) as contributors
+    FROM sums, users_count
+
+$$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION select_institution_project_stats(_user_id integer, _institution_id integer)
+ RETURNS table (
+    project_id    integer,
+    name          text,
+    num_plots     integer,
+    stats         jsonb
+ ) AS $$
+
+    SELECT project_uid,
+        name,
+        num_plots,
+        row_to_json((SELECT select_short_project_stats(project_uid)))::jsonb
+    FROM projects as p
+    LEFT JOIN institution_users iu
+        ON user_rid = _user_id
+        AND p.institution_rid = iu.institution_rid
+    WHERE p.institution_rid = _institution_id
+        AND user_project(_user_id, role_rid, p.privacy_level, p.availability)
+    ORDER BY project_uid
+
+$$ LANGUAGE SQL;
+
 CREATE OR REPLACE FUNCTION select_template_projects(_user_id integer)
  RETURNS table (
      project_id    integer,
@@ -539,7 +627,6 @@ CREATE OR REPLACE FUNCTION select_template_projects(_user_id integer)
     ORDER BY project_uid
 
 $$ LANGUAGE SQL;
-
 
 -- Returns project statistics
 -- Overlapping queries, consider condensing. Query time is not an issue.


### PR DESCRIPTION
## Purpose
Optimize query for institution stats.  The way the stats were queried were not appropriate for institutions with more than a few projects.  Instead of calling a separate API call for each project in the list, return the entire list together.

## Related Issues
Prep for CEO-209 and CEO-288

## Submission Checklist
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
1. As an admin, And I go to the institution dashboard, the list of projects with stats loads correctly.

## Screenshots
Should look the same as before

