### PR TITLE
CEO-267 Set max timesToReview to number of assigned users

### DIFF
--- a/src/js/project/QualityControl.js
+++ b/src/js/project/QualityControl.js
@@ -146,7 +146,7 @@ export default class QualityControl extends React.Component {
                             <input
                                 className="form-control form-control-sm ml-3"
                                 id="reviews"
-                                max="100"
+                                max={Math.max(users.length, 2)}
                                 min="2"
                                 onChange={e => this.setTimesToReview(parseInt(e.target.value))}
                                 type="number"


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
EOM

## Related Issues
Closes CEO-267

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `CEO-### #review <comment>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
<!-- Create a BDD style test script -->
1. Given I am a project admin, When I am creating a project, And I enable assigned users, And I set Quality Control to "Overlap", Then I can only set the # of reviewers to the number of assigned users.

