### PR TITLE
CEO-288 Update institution dash page to show stats for projects with qaqc

### DIFF
--- a/src/clj/collect_earth_online/db/projects.clj
+++ b/src/clj/collect_earth_online/db/projects.clj
@@ -73,21 +73,22 @@
                             :percentComplete pct_complete})
                          (call-sql "select_institution_projects" user-id institution-id)))))
 
-(defn get-institution-project-stats [{:keys [params]}]
+(defn get-institution-dash-projects [{:keys [params]}]
   (let [user-id        (:userId params -1)
         institution-id (tc/val->int (:institutionId params))]
-    (data-response (mapv (fn [{:keys [project_id name privacy_level pct_complete num_plots stats]}]
-                           {:id              project_id
-                            :name            name
-                            :numPlots        num_plots
-                            :privacyLevel    privacy_level
-                            :percentComplete pct_complete
-                            :stats           (-> stats
-                                                 (tc/jsonb->clj)
-                                                 (set/rename-keys {:analyzed_plots   :analyzedPlots
-                                                                   :flagged_plots    :flaggedPlots
-                                                                   :unanalyzed_plots :unanalyzedPlots}))})
-                         (call-sql "select_institution_project_stats" user-id institution-id)))))
+    (data-response (mapv (fn [{:keys [project_id name stats]}]
+                           {:id    project_id
+                            :name  name
+                            :stats (-> stats
+                                       (tc/jsonb->clj)
+                                       (set/rename-keys {:total_plots      :totalPlots
+                                                         :flagged_plots    :flaggedPlots
+                                                         :analyzed_plots   :analyzedPlots
+                                                         :partial_plots    :partialPlots
+                                                         :unanalyzed_plots :unanalyzedPlots
+                                                         :plot_assignments :plotAssignments
+                                                         :assigned_users   :assignedUsers}))})
+                         (call-sql "select_institution_dash_projects" user-id institution-id)))))
 
 (defn get-template-projects [{:keys [params]}]
   (let [user-id (:userId params -1)]

--- a/src/clj/collect_earth_online/routing.clj
+++ b/src/clj/collect_earth_online/routing.clj
@@ -86,7 +86,7 @@
                                               :auth-action :block}
    [:get  "/get-home-projects"]              {:handler     projects/get-home-projects}
    [:get  "/get-institution-projects"]       {:handler     projects/get-institution-projects}
-   [:get  "/get-institution-project-stats"]  {:handler     projects/get-institution-project-stats}
+   [:get  "/get-institution-dash-projects"]  {:handler     projects/get-institution-dash-projects}
    [:get  "/get-project-by-id"]              {:handler     projects/get-project-by-id}
    [:get  "/get-template-projects"]          {:handler     projects/get-template-projects}
    [:get  "/get-template-by-id"]             {:handler     projects/get-template-by-id}

--- a/src/js/institutionDashboard.js
+++ b/src/js/institutionDashboard.js
@@ -27,7 +27,7 @@ class InstitutionDashboard extends React.Component {
     /// API Calls
 
     getProjectList = () =>
-        fetch(`/get-institution-project-stats?institutionId=${this.props.institutionId}`)
+        fetch(`/get-institution-dash-projects?institutionId=${this.props.institutionId}`)
             .then(response => (response.ok ? response.json() : Promise.reject(response)))
             .then(data => this.setState({projectList: data}));
 
@@ -52,26 +52,32 @@ class InstitutionDashboard extends React.Component {
                 {projectList.length > 0 && (
                     <table id="srd" style={{width: "1000px", margin: "10px", color: "rgb(49, 186, 176)"}}>
                         <thead>
-                            <tr style={{whiteSpace: "nowrap"}}>
-                                <th className="pr-2">Project Id</th>
-                                <th className="pr-2">Project Name</th>
-                                <th className="pr-2">Contributors</th>
-                                <th className="pr-2">Total Plots</th>
-                                <th className="pr-2">Flagged Plots</th>
-                                <th className="pr-2">Analyzed Plots</th>
-                                <th className="pr-2">Unanalyzed Plots</th>
+                            <tr >
+                                <th style={{paddingRight: "1rem", whiteSpace: "nowrap"}}>Project Id</th>
+                                <th style={{paddingRight: "1rem", whiteSpace: "nowrap"}}>Project Name</th>
+                                <th style={{textAlign: "center", paddingRight: "1rem"}}>Assigned Users</th>
+                                <th style={{textAlign: "center", paddingRight: "1rem"}}>Contributors</th>
+                                <th style={{textAlign: "center", paddingRight: "1rem"}}>Total Plots</th>
+                                <th style={{textAlign: "center", paddingRight: "1rem"}}>Plot Assignments</th>
+                                <th style={{textAlign: "center", paddingRight: "1rem"}}>Flagged Plots</th>
+                                <th style={{textAlign: "center", paddingRight: "1rem"}}>Analyzed Plots</th>
+                                <th style={{textAlign: "center", paddingRight: "1rem"}}>Partial Plots</th>
+                                <th style={{textAlign: "center", paddingRight: "1rem"}}>Unanalyzed Plots</th>
                             </tr>
                         </thead>
                         <tbody>
-                            {projectList && projectList.map(project => (
-                                <tr key={project.id}>
-                                    <td>{project.id}</td>
-                                    <td>{project.name}</td>
-                                    <td style={{textAlign: "center"}}>{project.stats.contributors}</td>
-                                    <td style={{textAlign: "center"}}>{project.numPlots}</td>
-                                    <td style={{textAlign: "center"}}>{project.stats.flaggedPlots}</td>
-                                    <td style={{textAlign: "center"}}>{project.stats.analyzedPlots}</td>
-                                    <td style={{textAlign: "center"}}>{project.stats.unanalyzedPlots}</td>
+                            {projectList && projectList.map(({id, name, stats}) => (
+                                <tr key={id}>
+                                    <td>{id}</td>
+                                    <td style={{minWidth: "15rem"}}>{name}</td>
+                                    <td style={{textAlign: "center"}}>{stats.assignedUsers}</td>
+                                    <td style={{textAlign: "center"}}>{stats.contributors}</td>
+                                    <td style={{textAlign: "center"}}>{stats.totalPlots}</td>
+                                    <td style={{textAlign: "center"}}>{stats.plotAssignments}</td>
+                                    <td style={{textAlign: "center"}}>{stats.flaggedPlots}</td>
+                                    <td style={{textAlign: "center"}}>{stats.analyzedPlots}</td>
+                                    <td style={{textAlign: "center"}}>{stats.partialPlots}</td>
+                                    <td style={{textAlign: "center"}}>{stats.unanalyzedPlots}</td>
                                 </tr>
                             ))}
                         </tbody>

--- a/src/sql/functions/project.sql
+++ b/src/sql/functions/project.sql
@@ -553,7 +553,7 @@ CREATE OR REPLACE FUNCTION select_institution_project_stats(_project_id integer)
         GROUP BY project_rid, plot_uid
         HAVING project_rid = _project_id
     ), project_sum as (
-        SELECT count(*)::int as total,
+        SELECT count(*)::int as total_plots,
             sum(ps.flagged::int)::int as flagged_plots,
             sum((needed = analyzed)::int)::int as analyzed_plots,
             sum((needed > analyzed and analyzed > 0)::int)::int as partial_plots,
@@ -562,7 +562,7 @@ CREATE OR REPLACE FUNCTION select_institution_project_stats(_project_id integer)
         FROM plot_sum ps
     )
 
-    SELECT total,
+    SELECT total_plots,
         flagged_plots,
         analyzed_plots,
         partial_plots,


### PR DESCRIPTION
## Purpose
Update institution dash page to show stats for projects with qaqc.

## Related Issues
Closes CEO-288

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `CEO-### #review <comment>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
1. As admin, When going to the institution dashboard, the list of projects I see contains Assigned Users, Plot Assignments, and Partial Plots, in addition to the original columns

## Screenshots
![image](https://user-images.githubusercontent.com/33734037/136249377-f1ac8865-9084-4795-8861-6b9ea8e0e980.png)


