### PR TITLE
CEO-283 Default to review mode when project is closed

### DIFF
--- a/src/js/collection.js
+++ b/src/js/collection.js
@@ -208,7 +208,8 @@ class Collection extends React.Component {
             if (project.id > 0 && project.availability !== "archived") {
                 this.setState({currentProject: project});
                 const {inReviewMode} = getProjectPreferences(project.id);
-                this.setReviewMode(project.isProjectAdmin && (inReviewMode || (project.availability === "published" && inReviewMode !== false)));
+                this.setReviewMode(project.isProjectAdmin
+                    && (inReviewMode || (project.availability === "closed" && inReviewMode !== false)));
                 return Promise.resolve("resolved");
             } else {
                 return Promise.reject(


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
EOM

## Related Issues
Closes CEO-283

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `CEO-### #review <comment>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
<!-- Create a BDD style test script -->
1. Given I am an admin, When I view a closed project, Then review mode is enabled by default.
