### PR TITLE
CEO-263 CEO-264 CEO-265 Styling for disagreement page

### DIFF
--- a/src/js/components/FormComponents.js
+++ b/src/js/components/FormComponents.js
@@ -1,5 +1,4 @@
 import React from "react";
-import _ from "lodash";
 import {UnicodeIcon} from "../utils/generalUtils";
 
 export function FormLayout({title, children}) {
@@ -30,7 +29,7 @@ export class CollapsibleSectionBlock extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            showContent: _.defaultTo(props.showContent, false),
+            showContent: props.showContent || false,
             height: props.showContent ? "auto" : "0px",
             myRef: null
         };

--- a/src/js/userDisagreement.js
+++ b/src/js/userDisagreement.js
@@ -8,8 +8,7 @@ class UserDisagreement extends React.Component {
         super(props);
         this.state = {
             questions: [],
-            plotters: [],
-            showQuestions: {}
+            plotters: []
         };
     }
 
@@ -23,7 +22,7 @@ class UserDisagreement extends React.Component {
         return fetch(`/get-plot-disagreement?projectId=${projectId}&plotId=${plotId}`)
             .then(response => (response.ok ? response.json() : Promise.reject(response)))
             .then(questions => {
-                this.setState({questions, showQuestions: Object.fromEntries(questions.map(q => [q.id, true]))});
+                this.setState({questions});
                 return Promise.resolve("resolved");
             });
     };
@@ -77,7 +76,7 @@ class UserDisagreement extends React.Component {
     };
 
     renderQuestion = thisQuestion => {
-        const {id, question, answers, disagreement, answerFrequencies} = thisQuestion;
+        const {question, answers, disagreement, answerFrequencies} = thisQuestion;
         return (
             <div
                 key={question}
@@ -89,7 +88,7 @@ class UserDisagreement extends React.Component {
                 }}
             >
                 <CollapsibleSectionBlock
-                    showContent={this.state.showQuestions[id]}
+                    showContent
                     title={`${question } - ${disagreement < 0 ? "N/A" : disagreement + "%"}`}
                 >
                     <div style={{display: "flex", flexWrap: "wrap", background: "white"}}>


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Adds colors to user answers, collapsible sections, make each section flex wrapped.

## Related Issues
Closes:
* CEO-263
* CEO-264
* CEO-265

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `CEO-### #review <comment>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Screenshots
<!-- Add a screen shot when UI changes are included -->
<img width="753" alt="Screen Shot 2021-10-06 at 2 30 58 PM" src="https://user-images.githubusercontent.com/1829313/136286151-8b7106c8-0a57-4d2d-8c3f-ea5e14c677ae.png">

