### PR TITLE
CEO-209 Update stats for project dashboard to include assignment information

### DIFF
--- a/src/clj/collect_earth_online/db/projects.clj
+++ b/src/clj/collect_earth_online/db/projects.clj
@@ -87,7 +87,7 @@
                                                          :partial_plots    :partialPlots
                                                          :unanalyzed_plots :unanalyzedPlots
                                                          :plot_assignments :plotAssignments
-                                                         :assigned_users   :assignedUsers}))})
+                                                         :users_assigned   :usersAssigned}))})
                          (call-sql "select_institution_dash_projects" user-id institution-id)))))
 
 (defn get-template-projects [{:keys [params]}]
@@ -155,14 +155,19 @@
 (defn get-project-stats [{:keys [params]}]
   (let [project-id (tc/val->int (:projectId params))
         stats      (first (call-sql "select_project_statistics" project-id))]
-    (data-response {:flaggedPlots    (:flagged_plots stats)
+    (data-response {:totalPlots      (:total_plots stats)
+                    :plotAssignments (:plot_assignments stats)
+                    :usersAssigned   (:users_assigned stats)
+                    :flaggedPlots    (:flagged_plots stats)
+                    :partialPlots    (:partial_plots stats)
                     :analyzedPlots   (:analyzed_plots stats)
                     :unanalyzedPlots (:unanalyzed_plots stats)
-                    :contributors    (:contributors stats)
                     :createdDate     (str (:created_date stats))
                     :publishedDate   (str (:published_date stats))
                     :closedDate      (str (:closed_date stats))
-                    :userStats       (tc/jsonb->clj (:user_stats stats))})))
+                    :userStats       (->> (:user_stats stats)
+                                          (tc/jsonb->clj)
+                                          (map #(set/rename-keys % {:timed_plots :timedPlots})))})))
 
 ;;;
 ;;; Create project helper functions

--- a/src/js/institutionDashboard.js
+++ b/src/js/institutionDashboard.js
@@ -55,7 +55,7 @@ class InstitutionDashboard extends React.Component {
                             <tr >
                                 <th style={{paddingRight: "1rem", whiteSpace: "nowrap"}}>Project Id</th>
                                 <th style={{paddingRight: "1rem", whiteSpace: "nowrap"}}>Project Name</th>
-                                <th style={{textAlign: "center", paddingRight: "1rem"}}>Assigned Users</th>
+                                <th style={{textAlign: "center", paddingRight: "1rem"}}>Users Assigned</th>
                                 <th style={{textAlign: "center", paddingRight: "1rem"}}>Contributors</th>
                                 <th style={{textAlign: "center", paddingRight: "1rem"}}>Total Plots</th>
                                 <th style={{textAlign: "center", paddingRight: "1rem"}}>Plot Assignments</th>
@@ -70,7 +70,7 @@ class InstitutionDashboard extends React.Component {
                                 <tr key={id}>
                                     <td>{id}</td>
                                     <td style={{minWidth: "15rem"}}>{name}</td>
-                                    <td style={{textAlign: "center"}}>{stats.assignedUsers}</td>
+                                    <td style={{textAlign: "center"}}>{stats.usersAssigned}</td>
                                     <td style={{textAlign: "center"}}>{stats.contributors}</td>
                                     <td style={{textAlign: "center"}}>{stats.totalPlots}</td>
                                     <td style={{textAlign: "center"}}>{stats.plotAssignments}</td>

--- a/src/js/projectDashboard.js
+++ b/src/js/projectDashboard.js
@@ -151,19 +151,21 @@ class ProjectDashboard extends React.Component {
 function ProjectStats(props) {
     const {
         stats: {
+            totalPlots,
+            plotAssignments,
+            usersAssigned,
             analyzedPlots,
+            partialPlots,
+            unanalyzedPlots,
+            flaggedPlots,
             closedDate,
             createdDate,
-            flaggedPlots,
             publishedDate,
-            unanalyzedPlots,
             userStats
         },
         isProjectAdmin,
         userName
     } = props;
-
-    const numPlots = flaggedPlots + analyzedPlots + unanalyzedPlots;
 
     const renderDate = (title, date) => (
         <div style={{alignItems: "center", display: "flex", marginRight: "1rem"}}>
@@ -183,7 +185,7 @@ function ProjectStats(props) {
     return (
         <div className="d-flex flex-column">
             <h2 className="header px-0">Project Stats</h2>
-            {analyzedPlots && (
+            {totalPlots > 0 && (
                 <div className="p-1" id="project-stats">
                     <div className="mb-4">
                         <h3>Project Dates:</h3>
@@ -196,9 +198,12 @@ function ProjectStats(props) {
                     <div className="mb-2">
                         <h3>Plot Stats:</h3>
                         <div style={{display: "flex", flexWrap: "wrap", padding: "0 .5rem"}}>
-                            {renderStat("Total Plots", numPlots)}
+                            {renderStat("Total Plots", totalPlots)}
+                            {plotAssignments > 0 && renderStat("Plot Assignments", plotAssignments)}
+                            {plotAssignments > 0 && renderStat("Users Assigned", usersAssigned)}
                             {renderStat("Flagged", flaggedPlots)}
                             {renderStat("Analyzed", analyzedPlots)}
+                            {plotAssignments > 0 && renderStat("Partial Plots", partialPlots)}
                             {renderStat("Unanalyzed", unanalyzedPlots)}
                         </div>
                     </div>
@@ -207,13 +212,13 @@ function ProjectStats(props) {
                             <h3>User Completed:</h3>
                             {userStats.map((user, idx) => (
                                 <StatsRow
-                                    key={user.user}
+                                    key={user.email}
                                     analysisTime={user.timedPlots > 0
                                         ? (user.seconds / user.timedPlots / 1.0).toFixed(2)
                                         : 0}
                                     plots={user.plots}
-                                    title={(isProjectAdmin || user.user === userName)
-                                        ? `${idx + 1}. ${user.user}`
+                                    title={(isProjectAdmin || user.email === userName)
+                                        ? `${idx + 1}. ${user.email}`
                                         : `User ${idx + 1}`}
                                 />
                             ))}


### PR DESCRIPTION
## Purpose
Update stats for project dashboard to include assignment information

## Related Issues
Closes CEO-209

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `CEO-### #review <comment>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
1. As and admin, when I go to the project dashboard of a project with QC, Plot Assignments and Users Assigned shows in addition to the previous data.

## Screenshots
![image](https://user-images.githubusercontent.com/33734037/136288876-60cb717e-c68b-4a80-b22e-1d33573793d1.png)

