### PR TITLE
CEO-271 Update admin save alert to prevent partial saving in review mode

### DIFF
--- a/src/js/collection.js
+++ b/src/js/collection.js
@@ -909,7 +909,6 @@ class Collection extends React.Component {
                 <SideBar
                     answerMode={this.state.answerMode}
                     currentPlot={this.state.currentPlot}
-                    isProjectAdmin={this.state.currentProject.isProjectAdmin}
                     inReviewMode={this.state.inReviewMode}
                     postValuesToDB={this.postValuesToDB}
                     projectId={this.props.projectId}
@@ -1030,7 +1029,7 @@ function ImageAnalysisPane({imageryAttribution}) {
 
 class SideBar extends React.Component {
     checkCanSave = () => {
-        const {answerMode, currentPlot, isProjectAdmin, inReviewMode, surveyQuestions} = this.props;
+        const {answerMode, currentPlot, inReviewMode, surveyQuestions} = this.props;
         const noneAnswered = surveyQuestions.every(sq => safeLength(sq.answered) === 0);
         const hasSamples = safeLength(currentPlot.samples) > 0;
         const allAnswered = surveyQuestions.every(sq => safeLength(sq.visible) === safeLength(sq.answered));


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Require that admins in "Review Mode" must answer all questions before saving a plot.

## Related Issues
Closes CEO-271

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `CEO-### #review <comment>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
<!-- Create a BDD style test script -->
1. Given I am an admin, When am collecting, I enable review mode, Then I can only save a plot if all answers have been saved.

