### PR TITLE
CEO-261 Add disagreement query param, hide Q's lower than disagreement

### DIFF
--- a/src/js/collection.js
+++ b/src/js/collection.js
@@ -1283,7 +1283,7 @@ class PlotNavigation extends React.Component {
                                 className="btn btn-secondary btn-sm"
                                 onClick={() =>
                                     window.open(
-                                        `/user-disagreement?projectId=${projectId}&plotId=${currentPlot.id}`,
+                                        `/user-disagreement?projectId=${projectId}&plotId=${currentPlot.id}&threshold=${threshold}`,
                                         `disagreement_${projectId}`
                                     )}
                                 type="button"

--- a/src/js/userDisagreement.js
+++ b/src/js/userDisagreement.js
@@ -77,6 +77,7 @@ class UserDisagreement extends React.Component {
 
     renderQuestion = thisQuestion => {
         const {question, answers, disagreement, answerFrequencies} = thisQuestion;
+        const {threshold} = this.props;
         return (
             <div
                 key={question}
@@ -88,7 +89,7 @@ class UserDisagreement extends React.Component {
                 }}
             >
                 <CollapsibleSectionBlock
-                    showContent
+                    showContent={disagreement >= threshold}
                     title={`${question } - ${disagreement < 0 ? "N/A" : disagreement + "%"}`}
                 >
                     <div style={{display: "flex", flexWrap: "wrap", background: "white"}}>
@@ -121,6 +122,7 @@ export function pageInit(args) {
             <UserDisagreement
                 plotId={args.plotId}
                 projectId={args.projectId}
+                threshold={args.threshold}
                 visibleId={args.visibleId}
             />
         </NavigationBar>,


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Adds disagreement query parameter to `/user-disagreement` page, hide questions that have a disagreement lower than the provided value.

## Related Issues
Closes CEO-261

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `CEO-### #review <comment>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
<!-- Create a BDD style test script -->
1. Given I am an admin, When I am reviewing a project, And I enable QA/QC mode, And I set the disagreement threshold to 50%, And I view the Disagreement page, Then only questions with a disagreement higher than the 50% are shown.
