### PR TITLE
Optimization level 1: get all plot samples once for filter

### DIFF
--- a/src/clj/collect_earth_online/db/plots.clj
+++ b/src/clj/collect_earth_online/db/plots.clj
@@ -101,22 +101,21 @@
                     sample-answers))
     -1))
 
-
 (defn- filter-plot-disagreement [project-id grouped-plots threshold]
   (let [survey-questions (get-survey-questions project-id)]
     (filterm (fn [[_ plots]]
                (let [plot-id       (-> plots (first) :plot_id)
-                     users-samples (keep (fn [plot]
-                                           (when-let [user-id (:user_id plot)]
-                                             (get-samples-answer-array plot-id user-id)))
-                                         plots)]
-                 (->> survey-questions
-                      (map (fn [{:keys [question]}]
-                             (->> question
-                                  (users-samples->answers users-samples)
-                                  (question-disagreement))))
-                      (apply max)
-                      (<= threshold))))
+                     users-samples (->> (call-sql "select_qaqc_plot_samples" {:log? false} plot-id)
+                                        (group-by :user_id)
+                                        (mapv (fn [[_ samples]]
+                                                (map (fn [{:keys [:saved_answers]}] (jsonb->clj-str saved_answers))
+                                                     samples))))]
+                 (some (fn [{:keys [question]}]
+                         (->> question
+                              (users-samples->answers users-samples)
+                              (question-disagreement)
+                              (<= threshold)))
+                       survey-questions)))
              grouped-plots)))
 
 (defn get-plot-disagreement
@@ -165,7 +164,7 @@
           {:id           sample_id
            :sampleGeom   sample_geom
            :savedAnswers (tc/jsonb->clj saved_answers)})
-        (call-sql "select_plot_samples" plot-id user-id)))
+        (call-sql "select_plot_samples" {:log? false} plot-id user-id)))
 
 (defn- build-collection-plot [plot-info user-id review-mode?]
   (let [{:keys [plot_id
@@ -217,7 +216,7 @@
                           [])
         grouped-plots   (into (sorted-map) (group-by :visible_id proj-plots))
         final-plots     (if (= navigation-mode "qaqc")
-                          (filter-plot-disagreement project-id grouped-plots threshold)
+                          (time (filter-plot-disagreement project-id grouped-plots threshold))
                           grouped-plots)
         plots-info      (case direction
                           "next"     (or (some (fn [[visible-id plots]]

--- a/src/sql/functions/plots.sql
+++ b/src/sql/functions/plots.sql
@@ -340,6 +340,28 @@ CREATE OR REPLACE FUNCTION select_plot_samples(_plot_id integer, _user_id intege
 
 $$ LANGUAGE SQL;
 
+-- Select samples for a plot.
+CREATE OR REPLACE FUNCTION select_qaqc_plot_samples(_plot_id integer)
+ RETURNS table (
+    user_id          integer,
+    sample_id        integer,
+    saved_answers    jsonb
+ ) AS $$
+
+
+    SELECT up.user_rid,
+        sample_uid,
+        (CASE WHEN sv.saved_answers IS NULL THEN '{}' ELSE sv.saved_answers END)
+    FROM samples s
+    LEFT JOIN user_plots up
+        ON s.plot_rid = up.plot_rid
+    LEFT JOIN sample_values sv
+        ON sample_uid = sv.sample_rid
+        AND user_plot_uid = sv.user_plot_rid
+    WHERE s.plot_rid = _plot_id
+
+$$ LANGUAGE SQL;
+
 -- Select just sample geoms.
 CREATE OR REPLACE FUNCTION select_plot_sample_geoms(_plot_id integer)
  RETURNS table (sample_geom text) AS $$


### PR DESCRIPTION
## Purpose
Optimize the qaqc nav route by getting all of the samples for the plot at once and grouping in memory.  This can be optimized further, but this is sufficient for now.

## Submission Checklist
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)
