### PR TITLE
CEO-270 Add card outline to selected question

### DIFF
--- a/src/js/collection.js
+++ b/src/js/collection.js
@@ -1248,7 +1248,14 @@ class PlotNavigation extends React.Component {
         } = this.props;
         return (
             <div className="mt-2">
-                <div className="p-1" style={{border: "1px solid lightgray", borderRadius: "0.2rem"}}>
+                <div
+                    className="p-1"
+                    style={{
+                        border: "1px solid lightgray",
+                        borderRadius: "6px",
+                        boxShadow: "0 0 2px 1px rgba(0, 0, 0, 0.15)"
+                    }}
+                >
                     <div className="row my-2">
                         <div className="col-5 text-right">
                             <label htmlFor="navigate">Navigate:</label>

--- a/src/js/components/SurveyCollection.js
+++ b/src/js/components/SurveyCollection.js
@@ -338,8 +338,8 @@ export class SurveyCollection extends React.Component {
                                     style={{
                                         boxShadow:
                                     `${(i === this.state.currentNodeIndex)
-                                        ? "0px 0px 2px 2px black inset,"
-                                        : ""}
+                                        ? "0 0 4px 2px rgba(0, 0, 0, 1), "
+                                        : "0 0 2px 1px rgba(0, 0, 0, 0.1), "}
                                     ${this.getTopColor(this.getNodeById(nodeId))}`
                                     }}
                                     title={removeEnumerator(this.getNodeById(nodeId).question)}
@@ -480,20 +480,22 @@ export class SurveyCollection extends React.Component {
                                     ? this.renderQuestions()
                                     : this.renderDrawTools()}
                                 {this.props.collectConfidence && !this.props.flagged && (
-                                    <div className="row mb-3">
-                                        <div className="col-12">
-                                            <div className="slide-container">
-                                                <input
-                                                    className="slider"
-                                                    max="100"
-                                                    min="0"
-                                                    onChange={e => this.props.setConfidence(parseInt(e.target.value))}
-                                                    type="range"
-                                                    value={this.props.confidence}
-                                                />
-                                                <label>Plot Confidence: {this.props.confidence}</label>
-                                            </div>
-                                        </div>
+                                    <div
+                                        className="row mb-3 mx-1 slide-container py-3"
+                                        style={{
+                                            borderRadius: "6px",
+                                            boxShadow: "0 0 2px 1px rgba(0, 0, 0, 0.15)"
+                                        }}
+                                    >
+                                        <input
+                                            className="slider"
+                                            max="100"
+                                            min="0"
+                                            onChange={e => this.props.setConfidence(parseInt(e.target.value))}
+                                            type="range"
+                                            value={this.props.confidence}
+                                        />
+                                        <label>Plot Confidence: {this.props.confidence}</label>
                                     </div>
                                 )}
                                 {this.renderFlagClearButtons()}
@@ -537,17 +539,17 @@ class SurveyQuestionTree extends React.Component {
                 ? "0px 0px 6px 5px #3bb9d6 inset"
                 : "0px 0px 6px 4px yellow inset";
 
-        const isSelected = (surveyNode.id === selectedQuestion.id);
-
         return (
             <>
                 <fieldset
-                    className="mb-1 justify-content-center text-center"
+                    className="justify-content-center text-center"
                     style={{
                         border: "1px solid rgba(0, 0, 0, 0.2)",
                         borderRadius: "6px",
-                        boxShadow: `0 0 2px 1px rgba(0, 0, 0, ${isSelected ? "1" : "0.2"})`,
-                        margin: ".5rem",
+                        boxShadow: surveyNode.id === selectedQuestion.id
+                            ? "0 0 4px 2px rgba(0, 0, 0, 1)"
+                            : "0 0 2px 1px rgba(0, 0, 0, 0.15)",
+                        margin: "1rem 0",
                         padding: ".5rem"
                     }}
                 >
@@ -605,7 +607,7 @@ class SurveyQuestionTree extends React.Component {
 
 function AnswerButton({surveyNode, surveyNode: {answers, answered}, selectedSampleId, validateAndSetCurrentValue}) {
     return (
-        <ul className="samplevalue justify-content-center">
+        <ul className="samplevalue justify-content-center my-1">
             {answers.map(ans => (
                 <li key={ans.id} className="mb-1">
                     <button


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Adds the card styling to questions on the collection page, and darkens the outline when that particular question is selected.

## Related Issues
Closes CEO-270

## Submission Checklist
- [x] Commits include the JIRA issue and the `#review` hashtag (e.g. `CEO-### #review <comment>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
<!-- Create a BDD style test script -->
1. Given I am a user, When I am collecting, And I select a question, Then the border darkens to show I have selected that question.

## Screenshots
<!-- Add a screen shot when UI changes are included -->
![Screen Shot 2021-10-12 at 9 40 45 AM](https://user-images.githubusercontent.com/1829313/136996172-64eb5ca6-b38e-4903-b436-f3331c4b21b5.png)

