### PR TITLE
CEO-290 For natural mode, go to first unanlyzed button from "go to first"

### DIFF
--- a/src/js/collection.js
+++ b/src/js/collection.js
@@ -319,7 +319,7 @@ class Collection extends React.Component {
         }
     };
 
-    getPlotData = (visibleId, direction) => {
+    getPlotData = (visibleId, direction, forcedNavMode = null) => {
         const {currentUserId, navigationMode, inReviewMode, threshold} = this.state;
         const {projectId} = this.props;
         this.processModal(
@@ -327,7 +327,7 @@ class Collection extends React.Component {
             () => fetch("/get-collection-plot?" + getQueryString({
                 visibleId,
                 projectId,
-                navigationMode,
+                navigationMode: forcedNavMode || navigationMode,
                 direction,
                 inReviewMode,
                 threshold,
@@ -370,7 +370,11 @@ class Collection extends React.Component {
     confirmUnsaved = () => !this.hasChanged()
         || confirm("You have unsaved changes. Any unsaved responses will be lost. Are you sure you want to continue?");
 
-    navToFirstPlot = () => this.getPlotData(-10000000, "next");
+    navToFirstPlot = () => this.getPlotData(
+        -10000000,
+        "next",
+        this.state.navigationMode === "natural" && "unanalyzed"
+    );
 
     navToNextPlot = ignoreCheck => {
         if (ignoreCheck || this.confirmUnsaved()) {


### PR DESCRIPTION
## Purpose
For natural mode, go to first unanlyzed button from "go to first plot" 

## Testing
1. When first on the collection page, in collect mode, click go to first plot, and the first plot should be unanlyzed.

Side note, it the much rarer case that all the plots have been answered, the user will get a message saying to plots are available to go to.  This issue outweighs the confusion of going to plot 1 every time when collecting a long survey.