### PR TITLE
CEO-312 Require user to click copy for template, and reduce to 1 API call

### DIFF
--- a/src/clj/collect_earth_online/db/geodash.clj
+++ b/src/clj/collect_earth_online/db/geodash.clj
@@ -40,6 +40,13 @@
     (call-sql "delete_project_widget_by_widget_id" widget-id)
     (data-response (return-widgets project-id))))
 
+(defn copy-project-widgets [{:keys [params]}]
+  (let [project-id      (tc/val->int (:projectId params))
+        from-project-id (tc/val->int (:fromProjectId params))]
+    (call-sql "delete_project_widgets" project-id)
+    (call-sql "copy_project_widgets" from-project-id project-id)
+    (data-response (return-widgets project-id))))
+
 (defn gateway-request [{:keys [params json-params server-name]}]
   (let [path (:path params)
         url  (if (str/starts-with? server-name "local")

--- a/src/clj/collect_earth_online/routing.clj
+++ b/src/clj/collect_earth_online/routing.clj
@@ -161,6 +161,7 @@
                                               :auth-action :block}
    ;; GeoDash API
    [:get  "/geo-dash/get-project-widgets"]   {:handler     geodash/get-project-widgets}
+   [:post "/geo-dash/copy-project-widgets"]  {:handler     geodash/copy-project-widgets}
    [:post "/geo-dash/create-widget"]         {:handler     geodash/create-dashboard-widget-by-id}
    [:post "/geo-dash/delete-widget"]         {:handler     geodash/delete-dashboard-widget-by-id}
    [:post "/geo-dash/gateway-request"]       {:handler     geodash/gateway-request}

--- a/src/sql/functions/geodash.sql
+++ b/src/sql/functions/geodash.sql
@@ -49,6 +49,14 @@ CREATE OR REPLACE FUNCTION delete_project_widget_by_widget_id( _widget_id intege
 
 $$ LANGUAGE SQL;
 
+CREATE OR REPLACE FUNCTION delete_project_widgets(_project_id integer)
+ RETURNS void AS $$
+
+    DELETE FROM project_widgets
+    WHERE project_rid = _project_id
+
+$$ LANGUAGE SQL;
+
 CREATE OR REPLACE FUNCTION copy_project_widgets(_from_project_id integer, _to_project_id integer)
  RETURNS void AS $$
 


### PR DESCRIPTION
## Purpose
The template was designed to auto update on selection, which is poor UX.  An api call was made per old widget and per new widget, which is unnecessary. Just make one api call to copy.

## Related Issues
Closes CEO-312

## Testing
Everything should work as it had before.
