### PR TITLE
Update server.clj to allow args to be passed from config.edn

### DIFF
--- a/README.org
+++ b/README.org
@@ -140,11 +140,12 @@ project directory and run:
 npm install
 npm run webpack-dev
 clojure -M:build-db functions
-clojure -M:run-server -m dev [-p 8080] [-P 8443]
+clojure -M:server start [-m dev] [-p 8080] [-P 8443]
 #+end_src
 
 The website will then be available at http://localhost:8080 unless a
-port is specified. An http port can be specified with -p and an https
+port is specified. These can also be configured using the ~:server~ section in
+your ~config.edn~ file. An http port can be specified with -p and an https
 port can be specified with -P. In dev mode, server-side exceptions
 will be displayed in the browser and Clojure source files will be
 reloaded whenever you refresh the page.
@@ -198,11 +199,12 @@ project directory and run:
 npm install
 npm run webpack-prod
 clojure -M:build-db functions -d ceo
-clojure -M:run-server -m [dev|prod] [-p 8080] [-P 8443]
+clojure -M:server start -m [dev|prod] [-p 8080] [-P 8443]
 #+end_src
 
 The website will then be available at http://localhost:8080 unless a
-port is specified. An http port can be specified with -p and an https
+port is specified. These can also be configured using the ~:server~ section in
+your ~config.edn~ file. An http port can be specified with -p and an https
 port can be specified with -P. In dev mode, server-side exceptions
 will be displayed in the browser and Clojure source files will be
 reloaded whenever you refresh the page. These features are disabled in

--- a/config.default.edn
+++ b/config.default.edn
@@ -8,4 +8,8 @@
             :pass     "<pass>"
             :tls      true
             :port     587
-            :base-url "https://my.domain/"}}
+            :base-url "https://my.domain/"}
+ :server   {:port       8080
+            :https-port nil
+            :mode       "prod"
+            :output-dir "logs"}}

--- a/deps.edn
+++ b/deps.edn
@@ -20,11 +20,11 @@
 
  :aliases {:build-db         {:main-opts ["-m" "triangulum.build-db"]}
            :https            {:main-opts ["-m" "triangulum.https"]}
+           :server           {:main-opts ["-m" "collect-earth-online.server"]}
            :systemd          {:main-opts ["-m" "triangulum.systemd"]}
            :rebel            {:extra-deps {com.bhauman/rebel-readline {:mvn/version "0.1.4"}}
                               :main-opts  ["-m" "rebel-readline.main"]}
            :show-config      {:jvm-opts  ["-XX:+PrintFlagsFinal"]}
-           :run-server       {:main-opts ["-m" "collect-earth-online.server"]}
            :check-reflection {:main-opts ["-e" "(do,(set!,*warn-on-reflection*,true),nil)"
                                           "-e" "(require,'collect-earth-online.server)"]}
            :check-deps       {:extra-deps {olical/depot {:mvn/version "1.8.4"}}

--- a/src/clj/collect_earth_online/server.clj
+++ b/src/clj/collect_earth_online/server.clj
@@ -1,8 +1,9 @@
 (ns collect-earth-online.server
   (:require [clojure.java.io :as io]
             [clojure.string :as str]
-            [clojure.tools.cli  :refer [parse-opts]]
             [ring.adapter.jetty :refer [run-jetty]]
+            [triangulum.cli     :refer [get-cli-options]]
+            [triangulum.config  :refer [get-config]]
             [triangulum.logging :refer [log-str set-log-path!]]
             [collect-earth-online.handler :refer [create-handler-stack]]))
 
@@ -34,49 +35,44 @@
       (try (delete-tmp)
            (catch Exception _)))))
 
-(def cli-options
-  [["-p" "--http-port PORT" "Port for http, default 8080"
-    :default 8080
-    :parse-fn #(if (int? %) % (Integer/parseInt %))
-    :validate [#(< 0 % 0x10000) "Must be a number between 0 and 65536"]]
-   ["-P" "--https-port PORT" "Port for https (e.g. 8443)"
-    :parse-fn #(if (int? %) % (Integer/parseInt %))
-    :validate [#(< 0 % 0x10000) "Must be a number between 0 and 65536"]]
-   ["-m" "--mode MODE" "Production (prod) or development (dev) mode, default prod"
-    :default "prod"
-    :validate [#{"prod" "dev"} "Must be \"prod\" or \"dev\""]]
-   ["-o" "--output-dir DIR" "Output directory for log files. When a directory is not provided, output will be to stdout."
-    :default ""]])
+(def ^:private cli-options
+  {:port       ["-p" "--http-port PORT"   "Port for http, default 8080" :parse-fn #(if (int? %) % (Integer/parseInt %))]
+   :https-port ["-P" "--https-port PORT"  "Port for https (e.g. 8443)"  :parse-fn #(if (int? %) % (Integer/parseInt %))]
 
-(defn start-server! [& args]
-  (let [{:keys [options summary errors]} (parse-opts args cli-options)]
-    (if (seq errors)
+   :mode       ["-m" "--mode MODE"        "Production (prod) or development (dev) mode, default prod"
+                :default "prod"
+                :validate [#{"prod" "dev"} "Must be \"prod\" or \"dev\""]]
+
+   :output-dir ["-o" "--output-dir DIR" "Output directory for log files. When a directory is not provided, output will be to stdout."
+                :default ""]})
+
+(def ^:private cli-actions
+  {:start {:description "Starts the server."
+           :requires    [:port]}
+   :stop  {:description "Stops the server."}})
+
+(defn start-server! [{:keys [port https-port mode output-dir]}]
+  (let [has-key?   (.exists (io/file "./.key/keystore.pkcs12"))
+        ssl?       (and has-key? https-port)
+        handler    (create-handler-stack ssl? (= mode "dev"))
+        config     (merge
+                     {:port  port
+                      :join? false}
+                     (when ssl?
+                       {:ssl?                   true
+                        :ssl-port               https-port
+                        :keystore               "./.key/keystore.pkcs12"
+                        :keystore-type          "pkcs12"
+                        :keystore-scan-interval keystore-scan-interval
+                        :key-password           "foobar"}))]
+    (if (and (not has-key?) https-port)
+      (println "ERROR:\n"
+               "  An SSL key is required if an HTTPS port is specified.\n"
+               "  Create an SSL key for HTTPS or run without the --https-port (-P) option.")
       (do
-        (run! println errors)
-        (println (str "Usage:\n" summary)))
-      (let [mode       (:mode options)
-            has-key?   (.exists (io/file "./.key/keystore.pkcs12"))
-            https-port (:https-port options)
-            ssl?       (and has-key? https-port)
-            handler    (create-handler-stack ssl? (= mode "dev"))
-            config     (merge
-                        {:port  (:http-port options)
-                         :join? false}
-                        (when ssl?
-                          {:ssl?                   true
-                           :ssl-port               https-port
-                           :keystore               "./.key/keystore.pkcs12"
-                           :keystore-type          "pkcs12"
-                           :keystore-scan-interval keystore-scan-interval
-                           :key-password           "foobar"}))]
-        (if (and (not has-key?) https-port)
-          (println "ERROR:\n"
-                   "  An SSL key is required if an HTTPS port is specified.\n"
-                   "  Create an SSL key for HTTPS or run without the --https-port (-P) option.")
-          (do
-            (reset! server (run-jetty handler config))
-            (reset! clean-up-service (start-clean-up-service!))
-            (set-log-path! (:output-dir options))))))))
+        (reset! server (run-jetty handler config))
+        (reset! clean-up-service (start-clean-up-service!))
+        (set-log-path! output-dir)))))
 
 (defn stop-server! []
   (set-log-path! "")
@@ -87,4 +83,8 @@
     (.stop @server)
     (reset! server nil)))
 
-(def -main start-server!)
+(defn -main [& args]
+  (let [{:keys [action options]} (get-cli-options args cli-options cli-actions "server" (get-config :server))]
+    (case action
+      :start (start-server! options)
+      :stop  (stop-server!))))


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Enable the server to take in arguments from `config.edn` to reduce command line headaches.

## Related Issues
Closes TRI-69

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `CEO-### <title>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
<!-- Create a BDD style test script -->
Server can be started and stopped using the following commands:
- Start: `nohup clj -M:server start &`
- Stop: `clj -M:server stop`
