### PR TITLE
CEO-322 Fix error where SME's could not be added

### DIFF
--- a/src/js/project/CreateProjectWizard.js
+++ b/src/js/project/CreateProjectWizard.js
@@ -301,7 +301,7 @@ export default class CreateProjectWizard extends React.Component {
                 && "# of Reviews must be at least 2.",
             (qaqcMethod === "overlap" && timesToReview > users.length && users.length > 1)
                 && "# of Reviews cannot be greater than the number of assigned users.",
-            (userMethod !== "none" && qaqcMethod === "sme" && (_.union(users, smes)).length > 0)
+            (userMethod !== "none" && qaqcMethod === "sme" && (_.intersection(users, smes)).length > 0)
                 && "Users cannot be an Assigned User and an SME. Please remove the duplicate users."
 
         ];


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Use `intersection` rather than `union` to determine if there are common assigned users and SME's.

## Related Issues
Closes CEO-322

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `CEO-### <title>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
<!-- Create a BDD style test script -->
1. Given I am an admin, When I am creating a project, Then I cannot assign someone as both an assigned user and an SME.
