### PR TITLE
CEO-323 Remove QA/QC validation for CSV/SHP files

### DIFF
--- a/src/js/project/CreateProjectWizard.js
+++ b/src/js/project/CreateProjectWizard.js
@@ -291,7 +291,7 @@ export default class CreateProjectWizard extends React.Component {
                 && "All plot assignment percentages must be greater than 0%.",
             (["overlap", "sme"].includes(qaqcMethod) && percent === 0)
                 && "The assigned Quality Control percentage must be greater than 0%.",
-            (qaqcMethod === "overlap" && users.length > Math.round((totalPlots * (percent / 100)) / users.length))
+            (["random", "gridded"].includes(plotDistribution) && qaqcMethod === "overlap" && users.length > Math.round((totalPlots * (percent / 100)) / users.length))
                 && `Too few plots per user for Quality Control Overlap. Each user must have at least ${users.length} plots.`,
             (qaqcMethod === "sme" && smes.length === 0)
                 && "At least one user must be added as an SME.",


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Remove the QA/QC "Overlap" validation when using CSV/Shapfiles. CSV/Shapfiles are not parsed on the front-end, so we cannot determine the total plots.

## Related Issues
Closes CEO-323

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `CEO-### <title>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
<!-- Create a BDD style test script -->
1. Given I am a user, When I create a project using a CSV/SHP file, And I add QA/QC mode of "overlap", Then the project can be created.
