### PR TITLE
CEO-324 Fix QA/QC Overlap slider

### DIFF
--- a/src/js/project/QualityControl.js
+++ b/src/js/project/QualityControl.js
@@ -120,7 +120,6 @@ export default class QualityControl extends React.Component {
                             <label className="col-5" htmlFor="percent">Percent:</label>
                             <div className="col-5 d-flex align-items-center">
                                 <input
-                                    className="form-control"
                                     id="percent"
                                     max="100"
                                     min="0"


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Slider can now go to the ends without weird spacing issue.

## Related Issues
Closes CEO-324

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `CEO-### <title>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Screenshots
<!-- Add a screen shot when UI changes are included -->
100%
![Screen Shot 2021-11-08 at 2 59 01 PM](https://user-images.githubusercontent.com/1829313/140831633-ba4939e2-4206-4e5e-b489-063d35d34781.png)

0%
![Screen Shot 2021-11-08 at 2 58 47 PM](https://user-images.githubusercontent.com/1829313/140831606-f93822ee-10f4-4f29-b18b-7705da65fe0f.png)

