### PR TITLE
Fix sample count for plots with round shape

### DIFF
--- a/src/clj/collect_earth_online/db/projects.clj
+++ b/src/clj/collect_earth_online/db/projects.clj
@@ -391,10 +391,7 @@
                              sample-file-name
                              sample-file-base64
                              allow-drawn-samples?
-                             saved-plots))
-
-  ;; Final clean up
-  (call-sql "update_project_counts" project-id))
+                             saved-plots)))
 
 (defn create-project! [{:keys [params]}]
   (let [institution-id       (tc/val->int (:institutionId params))
@@ -478,10 +475,14 @@
                                sample-file-base64
                                allow-drawn-samples?
                                design-settings))
+      ;; Final clean up
+      (call-sql "update_project_counts" project-id)
+
       ;; Save project imagery
       (if-let [imagery-list (:projectImageryList params)]
         (insert-project-imagery! project-id imagery-list)
         (call-sql "add_all_institution_imagery" project-id)) ; API backwards compatibility
+
       ;; Copy template widgets
       ;; TODO this can be a simple SQL query once we drop the dashboard ID
       (when (and (pos? project-template) use-template-widgets)
@@ -685,6 +686,8 @@
                   survey-rules
                   project-options
                   design-settings)
+        ;; Final clean up
+        (call-sql "update_project_counts" project-id)
         (data-response "")
         (catch Exception e
           (let [causes (:causes (ex-data e))]

--- a/src/clj/collect_earth_online/generators/clj_point.clj
+++ b/src/clj/collect_earth_online/generators/clj_point.clj
@@ -102,7 +102,6 @@
                     visible-offset (-> (dec visible_id)
                                        (* samples-per-plot)
                                        (inc))]
-                (println samples-per-plot)
                 (map-indexed (fn [idx [lon lat]]
                                {:plot_rid    plot_id
                                 :visible_id  (+ idx visible-offset)

--- a/src/clj/collect_earth_online/generators/clj_point.clj
+++ b/src/clj/collect_earth_online/generators/clj_point.clj
@@ -10,9 +10,6 @@
         y-steps (+ (Math/floor (/ y-range spacing)) 1)]
     (* x-steps y-steps)))
 
-(defn- count-gridded-sample-set [plot-size sample-resolution]
-  (Math/pow (Math/floor (/ plot-size sample-resolution)) 2))
-
 ;; Create random and gridded points
 
 (defn- random-with-buffer [side size buffer]
@@ -37,7 +34,7 @@
          (map #(EPSG:3857->4326 %)))))
 
 ;; TODO Use postGIS so arbitrary bounds can be set
-(defn- create-gridded-points-in-bounds [left bottom right top spacing]
+(defn- create-gridded-plots-in-bounds [left bottom right top spacing]
   (let [x-range   (- right left)
         y-range   (- top bottom)
         x-steps   (Math/floor (/ x-range spacing))
@@ -77,8 +74,8 @@
           bottom  (- center-y radius)
           steps   (Math/floor (/ plot-size sample-resolution))
           padding (/ (- plot-size (* steps sample-resolution)) 2.0)]
-      (->> (for [x (range (+ 1 steps))
-                 y (range (+ 1 steps))]
+      (->> (for [x (range (inc steps))
+                 y (range (inc steps))]
              [(+ (* x sample-resolution) left padding) (+ (* y sample-resolution) bottom padding)])
            (filter (fn [[x y]] (or (= "square" plot-shape)
                                    (< (distance center-x center-y x y) radius))))
@@ -92,7 +89,7 @@
                               samples-per-plot
                               sample-resolution]
   (let [samples-per-plot (case sample-distribution
-                           "gridded" (count-gridded-sample-set plot-size sample-resolution)
+                           "gridded" (count (create-gridded-sample-set [45 45] plot-shape plot-size sample-resolution))
                            "random"  samples-per-plot
                            "center"  1.0
                            "none"    1.0)]
@@ -105,6 +102,7 @@
                     visible-offset (-> (dec visible_id)
                                        (* samples-per-plot)
                                        (inc))]
+                (println samples-per-plot)
                 (map-indexed (fn [idx [lon lat]]
                                {:plot_rid    plot_id
                                 :visible_id  (+ idx visible-offset)
@@ -142,5 +140,5 @@
                     :visible_id  (inc idx)
                     :plot_geom   (tc/str->pg (make-wkt-point lon lat) "geometry")})
                  (if (= "gridded" plot-distribution)
-                   (create-gridded-points-in-bounds left bottom right top plot-spacing)
+                   (create-gridded-plots-in-bounds left bottom right top plot-spacing)
                    (create-random-points-in-bounds left bottom right top num-plots)))))


### PR DESCRIPTION
## Purpose
Fix sample count for plots with round shape

## Testing
1. Create project with round plots and gridded samples
2. Download samples file.
3. Sample IDs should be sequential

