### PR TITLE
CEO-348 Pass through visible id so user drawn samples can maintain existing id

### DIFF
--- a/src/clj/collect_earth_online/db/plots.clj
+++ b/src/clj/collect_earth_online/db/plots.clj
@@ -158,10 +158,11 @@
   (data-response ""))
 
 (defn- prepare-samples-array [plot-id user-id]
-  (mapv (fn [{:keys [sample_id sample_geom saved_answers]}]
+  (mapv (fn [{:keys [sample_id sample_geom saved_answers visible_id]}]
           {:id           sample_id
            :sampleGeom   sample_geom
-           :savedAnswers (tc/jsonb->clj saved_answers)})
+           :savedAnswers (tc/jsonb->clj saved_answers)
+           :visibleId    visible_id})
         (call-sql "select_plot_samples" {:log? false} plot-id user-id)))
 
 (defn- build-collection-plot [plot-info user-id review-mode?]
@@ -274,10 +275,11 @@
         id-translation   (when new-plot-samples
                            (call-sql "delete_user_plot_by_plot" plot-id user-id)
                            (call-sql "delete_samples_by_plot" plot-id)
-                           (reduce (fn [acc {:keys [id sampleGeom]}]
+                           (reduce (fn [acc {:keys [id visibleId sampleGeom]}]
                                      (let [new-id (sql-primitive (call-sql "create_project_plot_sample"
                                                                            {:log? false}
                                                                            plot-id
+                                                                           visibleId
                                                                            (tc/json->jsonb sampleGeom)))]
                                        (assoc acc (str id) (str new-id))))
                                    {}

--- a/src/js/utils/mercator.js
+++ b/src/js/utils/mercator.js
@@ -1222,6 +1222,7 @@ mercator.samplesToVectorSource = samples =>
         features: samples.map(
             sample => new Feature({
                 sampleId: sample.id,
+                visibleId: sample.visibleId,
                 geometry: mercator.parseGeoJson(sample.sampleGeom, true)
             })
         )

--- a/src/sql/functions/plots.sql
+++ b/src/sql/functions/plots.sql
@@ -297,14 +297,27 @@ $$ LANGUAGE SQL;
 --  SAMPLE FUNCTIONS
 --
 
+CREATE OR REPLACE FUNCTION get_next_sample_id(_plot_id integer)
+ RETURNS integer AS $$
+
+    SELECT max(s.visible_id) + 1
+    FROM samples s, plots
+    WHERE plot_uid = plot_rid
+        AND project_rid = (SELECT project_rid FROM plots WHERE plot_uid = _plot_id)
+
+$$ LANGUAGE SQL;
+
 -- Create project plot sample with no external file data
-CREATE OR REPLACE FUNCTION create_project_plot_sample(_plot_id integer, _sample_geom jsonb)
+CREATE OR REPLACE FUNCTION create_project_plot_sample(_plot_id integer, _visible_id integer, _sample_geom jsonb)
  RETURNS integer AS $$
 
     INSERT INTO samples
-        (plot_rid, sample_geom)
-    VALUES
-        (_plot_id, ST_SetSRID(ST_GeomFromGeoJSON(_sample_geom), 4326))
+        (plot_rid, visible_id, sample_geom)
+    VALUES (
+        _plot_id,
+        coalesce(_visible_id, (SELECT get_next_sample_id(_plot_id))),
+        ST_SetSRID(ST_GeomFromGeoJSON(_sample_geom), 4326)
+    )
     RETURNING sample_uid
 
 $$ LANGUAGE SQL;
@@ -313,6 +326,7 @@ $$ LANGUAGE SQL;
 CREATE OR REPLACE FUNCTION select_plot_samples(_plot_id integer, _user_id integer)
  RETURNS table (
     sample_id        integer,
+    visible_id       integer,
     sample_geom      text,
     saved_answers    jsonb
  ) AS $$
@@ -324,6 +338,7 @@ CREATE OR REPLACE FUNCTION select_plot_samples(_plot_id integer, _user_id intege
     )
 
     SELECT sample_uid,
+        visible_id,
         ST_AsGeoJSON(sample_geom) AS sample_geom,
         (CASE WHEN sv.saved_answers IS NULL THEN '{}' ELSE sv.saved_answers END)
     FROM samples s


### PR DESCRIPTION
## Purpose
The uploaded or generated sample visibleId field would turn blank after saving a plot

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `CEO-### <title>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
1. Create a project with random or gridded samples. Allow user drawn samples,
2. Download the sample file and take note of the highest original sample id number (e.g. 1000 in a project with 100 plots and 10 samples per plot).
3. Collect, save one plot without drawing custom points and one with drawing custom points.
4. Download the sample data again.
5. Take a look at the sampleid column. All existing sample ids should keep their original id number while any newly drawn points should have ids that start with a number sequentially higher than the highest original sample id from step 2 (e.g. 1001 in our example).


