### PR TITLE
CEO-358 FIX User plots are not cleared when samples are rebuilt

### DIFF
--- a/src/clj/collect_earth_online/db/projects.clj
+++ b/src/clj/collect_earth_online/db/projects.clj
@@ -646,6 +646,7 @@
                 (or (not= samples-per-plot (:samples_per_plot original-project))
                     (not= sample-resolution (:sample_resolution original-project)))))
           (do
+            (call-sql "delete_user_plots_by_project" project-id)
             (call-sql "delete_all_samples_by_project" project-id)
             (create-project-samples! project-id
                                      plot-shape

--- a/src/sql/tables/all.sql
+++ b/src/sql/tables/all.sql
@@ -102,7 +102,7 @@ CREATE TABLE project_imagery (
 );
 
 --            1 project -> many |plots ->                                       many samples|
---                              |plots -> many user_plots -> 1 sample_values many <- samples|
+--                              |plots -> many user_plots -> many sample_values 1 <- samples|
 --  1 users -> many plot_assignments -^            ^- many users
 
 -- Stores plot information, including a reference to external plot data if it exists


### PR DESCRIPTION
## Purpose
Fix bug.  We must explicitly remove from user_plots because there is no FK constraint on user_samples

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `CEO-### <title>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
1. Create a project
2. Collect in unpublished mode
3. Make changes to only the samples
4. After saving, the plot overview map should be all yellow dots again.

