### PR TITLE
CEO-299 CEO-355 Better method for calculating gridded and random points

### DIFF
--- a/src/clj/collect_earth_online/db/projects.clj
+++ b/src/clj/collect_earth_online/db/projects.clj
@@ -588,9 +588,33 @@
         original-project     (first (call-sql "select_project_by_id" project-id))]
     (if original-project
       (try
+        (call-sql "update_project"
+                  project-id
+                  name
+                  description
+                  privacy-level
+                  imagery-id
+                  boundary
+                  plot-distribution
+                  num-plots
+                  plot-spacing
+                  plot-shape
+                  plot-size
+                  plot-file-name
+                  sample-distribution
+                  samples-per-plot
+                  sample-resolution
+                  sample-file-name
+                  allow-drawn-samples?
+                  survey-questions
+                  survey-rules
+                  project-options
+                  design-settings)
+
         (when-let [imagery-list (:projectImageryList params)]
           (call-sql "delete_project_imagery" project-id)
           (insert-project-imagery! project-id imagery-list))
+
         (cond
           (not= "unpublished" (:availability original-project))
           nil
@@ -650,28 +674,7 @@
           (or update-survey
               (and (:allow_drawn_samples original-project) (not allow-drawn-samples?)))
           (reset-collected-samples! project-id))
-        (call-sql "update_project"
-                  project-id
-                  name
-                  description
-                  privacy-level
-                  imagery-id
-                  boundary
-                  plot-distribution
-                  num-plots
-                  plot-spacing
-                  plot-shape
-                  plot-size
-                  plot-file-name
-                  sample-distribution
-                  samples-per-plot
-                  sample-resolution
-                  sample-file-name
-                  allow-drawn-samples?
-                  survey-questions
-                  survey-rules
-                  project-options
-                  design-settings)
+
         ;; Final clean up
         (call-sql "update_project_counts" project-id)
         (data-response "")

--- a/src/clj/collect_earth_online/generators/clj_point.clj
+++ b/src/clj/collect_earth_online/generators/clj_point.clj
@@ -1,21 +1,10 @@
 (ns collect-earth-online.generators.clj-point
   (:require [triangulum.type-conversion :as tc]
-            [collect-earth-online.utils.project :refer [check-plot-limits check-sample-limits]]
-            [collect-earth-online.utils.geom    :refer [make-wkt-point EPSG:3857->4326 EPSG:4326->3857]]))
+            [collect-earth-online.utils.project    :refer [check-plot-limits check-sample-limits]]
+            [collect-earth-online.utils.geom       :refer [make-wkt-point EPSG:3857->4326 EPSG:4326->3857]]
+            [collect-earth-online.utils.part-utils :refer [init-throw]]))
 
-(defn- count-gridded-points [left bottom right top spacing]
-  (let [x-range (- right left)
-        y-range (- top bottom)
-        x-steps (+ (Math/floor (/ x-range spacing)) 1)
-        y-steps (+ (Math/floor (/ y-range spacing)) 1)]
-    (* x-steps y-steps)))
-
-;; Create random and gridded points
-
-(defn- random-with-buffer [side size buffer]
-  (+ side
-     (* (Math/floor (* (Math/random) size (/ buffer))) buffer)
-     (/ buffer 2.0)))
+;;; Helpers
 
 (defn- distance [x1 y1 x2 y2]
   (Math/sqrt (+ (Math/pow (- x2 x1) 2.0)
@@ -24,62 +13,108 @@
 (defn- pad-bounds [left bottom right top buffer]
   [(+ left buffer) (+ bottom buffer) (- right buffer) (- top buffer)])
 
-;; TODO Use postGIS so arbitrary bounds can be uploaded
-(defn- create-random-points-in-bounds [left bottom right top num-points]
+(defn- filter-circle [circle? center-x center-y radius buffer coll]
+  (if circle?
+    (filter (fn [[x y]]
+              (< (distance center-x center-y x y)
+                 (- radius buffer)))
+            coll)
+    coll))
+
+(defn- random-num [offset size]
+  (+ offset
+     (* (Math/random) size)))
+
+;;; Gridded
+
+(defn- count-gridded-points [left bottom right top spacing]
   (let [x-range (- right left)
         y-range (- top bottom)
-        buffer  (/ x-range 50.0)]
-    (->> (repeatedly (fn [] [(random-with-buffer left x-range buffer) (random-with-buffer bottom y-range buffer)]))
-         (take num-points)
-         (map #(EPSG:3857->4326 %)))))
+        x-steps (+ (Math/floor (/ x-range spacing)) 1)
+        y-steps (+ (Math/floor (/ y-range spacing)) 1)]
+    (* x-steps y-steps)))
 
-;; TODO Use postGIS so arbitrary bounds can be set
-(defn- create-gridded-plots-in-bounds [left bottom right top spacing]
+(defn- get-all-gridded-points [left bottom right top spacing]
   (let [x-range   (- right left)
         y-range   (- top bottom)
         x-steps   (Math/floor (/ x-range spacing))
         y-steps   (Math/floor (/ y-range spacing))
         x-padding (/ (- x-range (* x-steps spacing)) 2.0)
         y-padding (/ (- y-range (* y-steps spacing)) 2.0)]
-    (->> (for [x (range (+ 1 x-steps))
-               y (range (+ 1 y-steps))]
-           [(+ (* x spacing) left x-padding) (+ (* y spacing) bottom y-padding)])
-         (map #(EPSG:3857->4326 %)))))
+    (for [x (range (+ 1 x-steps))
+          y (range (+ 1 y-steps))]
+      [(+ (* x spacing) left x-padding) (+ (* y spacing) bottom y-padding)])))
 
-;; TODO Use postGIS so can be done with shp files
-(defn- create-random-sample-set [plot-center plot-shape plot-size samples-per-plot]
-  (let [[center-x center-y] (EPSG:4326->3857 plot-center)
-        radius (/ plot-size 2.0)
-        left   (- center-x radius)
-        right  (+ center-x radius)
-        top    (+ center-y radius)
-        bottom (- center-y radius)
-        buffer (/ radius 50.0)]
-    (if (= "circle" plot-shape)
-      (->> (repeatedly (fn [] [(random-with-buffer left plot-size buffer) (random-with-buffer bottom plot-size buffer)]))
-           (take (* 10 samples-per-plot)) ; just as a safety net, so no thread can get stuck
-           (filter (fn [[x y]]
-                     (< (distance center-x center-y x y)
-                        (- radius (/ buffer 2.0)))))
-           (take samples-per-plot)
-           (map #(EPSG:3857->4326 %)))
-      (create-random-points-in-bounds left bottom right top samples-per-plot))))
+(defn- create-gridded-plots-in-bounds [left bottom right top spacing]
+  (->> (get-all-gridded-points left bottom right top spacing)
+       (map EPSG:3857->4326)))
 
-(defn- create-gridded-sample-set [plot-center plot-shape plot-size sample-resolution]
-  (if (>= sample-resolution plot-size)
-    [plot-center]
-    (let [[center-x center-y] (EPSG:4326->3857 plot-center)
-          radius  (/ plot-size 2.0)
-          left    (- center-x radius)
-          bottom  (- center-y radius)
-          steps   (Math/floor (/ plot-size sample-resolution))
-          padding (/ (- plot-size (* steps sample-resolution)) 2.0)]
-      (->> (for [x (range (inc steps))
-                 y (range (inc steps))]
-             [(+ (* x sample-resolution) left padding) (+ (* y sample-resolution) bottom padding)])
-           (filter (fn [[x y]] (or (= "square" plot-shape)
-                                   (< (distance center-x center-y x y) radius))))
-           (map #(EPSG:3857->4326 %))))))
+(defn- create-gridded-sample-set [circle? radius buffer sample-resolution center-x center-y]
+  (let [[left bottom right top] (pad-bounds (- center-x radius)
+                                            (- center-y radius)
+                                            (+ center-x radius)
+                                            (+ center-y radius)
+                                            buffer)]
+    (->> (get-all-gridded-points left bottom right top sample-resolution)
+         (filter-circle circle? center-x center-y radius buffer)
+         (map EPSG:3857->4326))))
+
+;;; Random
+
+(defn- random-point-in-bounds [left bottom right top]
+  [(random-num left (- right left)) (random-num bottom (- top bottom))])
+
+(defn- random-point-in-circle [center-x center-y radius]
+  (let [r     (* radius (Math/sqrt (Math/random)))
+        theta (* (Math/random) 2 Math/PI)]
+    [(+ center-x (* r (Math/cos theta))) (+ center-y (* r (Math/sin theta)))]))
+
+(defn- gen-random-points [num-plots buffer & opts]
+  (let [{:keys [left bottom right top center-x center-y radius circle?]} opts
+        max-iterations (* 2 num-plots)]
+    (loop [points     []
+           iterations 0]
+      (cond
+        (>= (count points) num-plots)
+        points
+
+        (> iterations max-iterations)
+        (init-throw "Unable to generate random plots.  Try a lower number of plots, smaller plot size, or bigger area.")
+
+        :else
+        (let [test-point (if circle?
+                           (random-point-in-circle center-x center-y radius)
+                           (random-point-in-bounds left bottom right top))]
+          (recur (if (some (fn [[x1 y1]]
+                             (let [[x2 y2] test-point
+                                   dist (distance x1 y1 x2 y2)]
+                               (< dist buffer)))
+                           points)
+                   points
+                   (conj points test-point))
+                 (inc iterations)))))))
+
+(defn- create-random-plots-in-bounds [left bottom right top plot-size num-plots]
+  (->> (gen-random-points num-plots
+                          (* 2.0 plot-size)
+                          :left left
+                          :bottom bottom
+                          :right right
+                          :top top)
+       (map EPSG:3857->4326)))
+
+(defn- create-random-sample-set [circle? radius buffer samples-per-plot center-x center-y]
+  (->> (gen-random-points samples-per-plot
+                          buffer
+                          :circle? circle?
+                          :left (- center-x radius)
+                          :bottom (- center-y radius)
+                          :right (+ center-x radius)
+                          :top (+ center-y radius)
+                          :center-x center-x
+                          :center-y center-y
+                          :radius (- radius buffer))
+       (map EPSG:3857->4326)))
 
 (defn generate-point-samples [plots
                               plot-count
@@ -88,8 +123,19 @@
                               sample-distribution
                               samples-per-plot
                               sample-resolution]
-  (let [samples-per-plot (case sample-distribution
-                           "gridded" (count (create-gridded-sample-set [45 45] plot-shape plot-size sample-resolution))
+  (let [center?          (or (= "center" sample-distribution)
+                             (>= sample-resolution plot-size))
+        circle?          (= plot-shape "circle")
+        radius           (/ plot-size 2.0)
+        buffer           (/ radius 25.0)
+        samples-per-plot (case sample-distribution
+                           "gridded" (count (create-gridded-sample-set
+                                             circle?
+                                             radius
+                                             buffer
+                                             sample-resolution
+                                             45
+                                             45))
                            "random"  samples-per-plot
                            "center"  1.0
                            "none"    1.0)]
@@ -98,25 +144,25 @@
                          samples-per-plot
                          200.0)
     (mapcat (fn [{:keys [plot_id visible_id lon lat]}]
-              (let [plot-center    [lon lat]
-                    visible-offset (-> (dec visible_id)
-                                       (* samples-per-plot)
-                                       (inc))]
-                (map-indexed (fn [idx [lon lat]]
+              (let [[center-x center-y] (EPSG:4326->3857 [lon lat])
+                    visible-offset      (-> (dec visible_id)
+                                            (* samples-per-plot)
+                                            (inc))]
+                (map-indexed (fn [idx [sample-lon sample-lat]]
                                {:plot_rid    plot_id
                                 :visible_id  (+ idx visible-offset)
-                                :sample_geom (tc/str->pg (make-wkt-point lon lat) "geometry")})
-                             (case sample-distribution
-                               "center"
-                               [plot-center]
+                                :sample_geom (tc/str->pg (make-wkt-point sample-lon sample-lat) "geometry")})
+                             (cond
+                               center?
+                               [[lon lat]]
 
-                               "random"
-                               (create-random-sample-set plot-center plot-shape plot-size samples-per-plot)
+                               (= "random" sample-distribution)
+                               (create-random-sample-set circle? radius buffer samples-per-plot center-x center-y)
 
-                               "gridded"
-                               (create-gridded-sample-set plot-center plot-shape plot-size sample-resolution)
+                               (= "gridded" sample-distribution)
+                               (create-gridded-sample-set circle? radius buffer sample-resolution center-x center-y)
 
-                               []))))
+                               :else []))))
             plots)))
 
 (defn generate-point-plots [project-id
@@ -131,7 +177,7 @@
   (let [[[left bottom] [right top]] (EPSG:4326->3857 [lon-min lat-min] [lon-max lat-max])
         [left bottom right top]     (pad-bounds left bottom right top (/ plot-size 2.0))]
     (check-plot-limits (if (= "gridded" plot-distribution)
-                         (count-gridded-points left bottom right top plot-spacing)
+                         (count-gridded-points left bottom right top (* 2.0 plot-size))
                          num-plots)
                        5000.0)
     (map-indexed (fn [idx [lon lat]]
@@ -140,4 +186,4 @@
                     :plot_geom   (tc/str->pg (make-wkt-point lon lat) "geometry")})
                  (if (= "gridded" plot-distribution)
                    (create-gridded-plots-in-bounds left bottom right top plot-spacing)
-                   (create-random-points-in-bounds left bottom right top num-plots)))))
+                   (create-random-plots-in-bounds left bottom right top plot-size num-plots)))))

--- a/src/sql/functions/plots.sql
+++ b/src/sql/functions/plots.sql
@@ -491,7 +491,9 @@ $$ LANGUAGE SQL;
 CREATE OR REPLACE FUNCTION delete_plots_by_project(_project_id integer)
  RETURNS void AS $$
 
-    DELETE FROM plots WHERE project_rid = _project_id
+    DELETE FROM plots WHERE project_rid = _project_id;
+
+    ANALYZE plots;
 
 $$ LANGUAGE SQL;
 


### PR DESCRIPTION
## Purpose
There were a few errors generating random plots, and one with the samples.  
1. Some plots were out of bounds
2. The spacing was based on size of boundary so they were not generated close enough for larger projects.
3. Random plots could generated in the same location

Simplified some calcs with better reusability. 

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `CEO-### <title>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
Basically every test for gridded/random samples/plots.