### PR TITLE
CEO-343 Use distribution to check for fname

### DIFF
--- a/src/js/project/PlotDesign.js
+++ b/src/js/project/PlotDesign.js
@@ -404,7 +404,7 @@ export function PlotReview() {
                                             </tr>
                                         </>
                                     )}
-                                    {["shp", "csv"].contains(plotDistribution) && (
+                                    {["shp", "csv"].includes(plotDistribution) && (
                                         <tr>
                                             <td className="w-80">Plot file</td>
                                             <td className="w-20 text-center">

--- a/src/js/project/PlotDesign.js
+++ b/src/js/project/PlotDesign.js
@@ -404,7 +404,7 @@ export function PlotReview() {
                                             </tr>
                                         </>
                                     )}
-                                    {plotFileName && (
+                                    {["shp", "csv"].contains(plotDistribution) && (
                                         <tr>
                                             <td className="w-80">Plot file</td>
                                             <td className="w-20 text-center">

--- a/src/js/project/SampleDesign.js
+++ b/src/js/project/SampleDesign.js
@@ -294,7 +294,7 @@ export function SampleReview() {
                                                     </td>
                                                 </tr>
                                             )}
-                                            {["shp", "csv"].contains(sampleDistribution) && (
+                                            {["shp", "csv"].includes(sampleDistribution) && (
                                                 <tr>
                                                     <td className="w-80">Sample File</td>
                                                     <td className="w-20 text-center">

--- a/src/js/project/SampleDesign.js
+++ b/src/js/project/SampleDesign.js
@@ -294,7 +294,7 @@ export function SampleReview() {
                                                     </td>
                                                 </tr>
                                             )}
-                                            {sampleFileName && (
+                                            {["shp", "csv"].contains(sampleDistribution) && (
                                                 <tr>
                                                     <td className="w-80">Sample File</td>
                                                     <td className="w-20 text-center">


### PR DESCRIPTION
## Purpose
Template file names were being displayed even if the user changed the distribution type.

## Testing
1. Create a project with shp files
2. Create a new project with that as a template
3. Change distribution type to random
4. On the review page you should not see a file name.

