### PR TITLE
CEO-375 Add prop types and default props to SvgIcon.

### DIFF
--- a/src/js/components/svg/SvgIcon.js
+++ b/src/js/components/svg/SvgIcon.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import {alertIcon} from "./alertIcon";
 import {cancelIcon} from "./cancelIcon";
 import {checkIcon} from "./checkIcon";
@@ -59,7 +60,7 @@ const iconMap = {
     "zoomIn": zoomInIcon
 };
 
-export default function SvgIcon({icon, color = "currentColor", cursor, size}) {
+function SvgIcon({icon, color, cursor, size}) {
     return (
         <div
             className="svg-icon"
@@ -77,3 +78,17 @@ export default function SvgIcon({icon, color = "currentColor", cursor, size}) {
         </div>
     );
 }
+
+SvgIcon.propTypes = {
+    color: PropTypes.string,
+    cursor: PropTypes.string,
+    icon: PropTypes.string.isRequired,
+    size: PropTypes.string.isRequired
+};
+
+SvgIcon.defaultProps = {
+    color: "currentColor",
+    cursor: null
+};
+
+export default SvgIcon;

--- a/src/js/components/svg/SvgIcon.js
+++ b/src/js/components/svg/SvgIcon.js
@@ -88,7 +88,7 @@ SvgIcon.propTypes = {
 
 SvgIcon.defaultProps = {
     color: "currentColor",
-    cursor: null
+    cursor: "unset"
 };
 
 export default SvgIcon;

--- a/src/js/project/ReviewForm.js
+++ b/src/js/project/ReviewForm.js
@@ -40,10 +40,9 @@ export default function ReviewForm() {
             <button
                 className="btn btn-sm btn-outline-info"
                 onClick={() => context.setContextState({designMode: "wizard", wizardStep: step})}
-                style={{padding: "0.2rem 0.4rem 0.7rem"}}
                 type="button"
             >
-                <SvgIcon color="white" icon="edit" size="1rem"/>
+                <SvgIcon color="white" icon="edit" size="1.1rem"/>
             </button>
         </div>
     );


### PR DESCRIPTION
## Purpose
Adds prop types and default props to the SvgIcon component. Fixes an issue where the default value of `vertical-align: middle` conflicted with padding that was being added to the edit SVG in the review project page.

## Related Issues
Closes CEO-375

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `CEO-### <title>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
All SVGs should look as they normally do.


