### PR TITLE
CEO-366 Add Google Analytics.

### DIFF
--- a/config.default.edn
+++ b/config.default.edn
@@ -11,4 +11,5 @@
             :base-url "https://my.domain/"}
  :server   {:http-port 8080
             :mode      "prod"
-            :log-dir   "logs"}}
+            :log-dir   "logs"}
+ :ga-id    null}

--- a/src/clj/collect_earth_online/views.clj
+++ b/src/clj/collect_earth_online/views.clj
@@ -20,6 +20,8 @@
    [:meta {:name "keywords"    :content "collect earth online image analysis crowdsourcing platform openforis SIG spatial informatics group"}]
    [:meta {:name "viewport"    :content "width=device-width, user-scalable=no"}] ; prevent touch zoom on mobile
    [:link {:rel "shortcut icon" :href "favicon.ico"}]
+   [:script {:async true :src "https://www.googletagmanager.com/gtag/js?id=G-NT7YQRX0H8"}]
+   [:script "window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'G-NT7YQRX0H8');"]
    (include-css "/css/bootstrap.min.css")
    (apply include-js
           "/js/jquery-3.5.1.slim.min.js"

--- a/src/clj/collect_earth_online/views.clj
+++ b/src/clj/collect_earth_online/views.clj
@@ -4,7 +4,8 @@
             [clojure.java.io   :as io]
             [cognitect.transit :as transit]
             [hiccup.page :refer [html5 include-js include-css]]
-            [collect-earth-online.git :refer [current-version]])
+            [collect-earth-online.git :refer [current-version]]
+            [triangulum.config  :refer [get-config]])
   (:import java.io.ByteArrayOutputStream))
 
 (defn kebab->camel [kebab]
@@ -20,8 +21,9 @@
    [:meta {:name "keywords"    :content "collect earth online image analysis crowdsourcing platform openforis SIG spatial informatics group"}]
    [:meta {:name "viewport"    :content "width=device-width, user-scalable=no"}] ; prevent touch zoom on mobile
    [:link {:rel "shortcut icon" :href "favicon.ico"}]
-   [:script {:async true :src "https://www.googletagmanager.com/gtag/js?id=G-NT7YQRX0H8"}]
-   [:script "window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'G-NT7YQRX0H8');"]
+   (when-let [ga-id (get-config :ga-id)]
+     [:script {:async true :src (str "https://www.googletagmanager.com/gtag/js?id=" ga-id)}]
+     [:script (str "window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', '" ga-id "');")])
    (include-css "/css/bootstrap.min.css")
    (apply include-js
           "/js/jquery-3.5.1.slim.min.js"


### PR DESCRIPTION
## Purpose
Add the Google Analytics tag to the site. You can find the scripts that I included on the Google Analytics website by navigating to Admin -> Data Streams -> ceo -> Add new on-age tag -> Global site tag (gtag.js)

## Related Issues
Closes CEO-366

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `CEO-### <title>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
This is hard to properly test until deployed to production, but on the Reports Snapshot GA page I can see one user (myself) from using the site on localhost. We might need to figure out how to only track the actual production website since I wouldn't expect my visit to count.


