### PR TITLE
CEO-372 Use a cookie store in ring for persistent log in

### DIFF
--- a/config.default.edn
+++ b/config.default.edn
@@ -1,15 +1,16 @@
-{:database {:host     "localhost"
-            :port     5432
-            :dbname   "ceo"
-            :user     "ceo"
-            :password "ceo"}
- :mail     {:host     "smtp.gmail.com"
-            :user     "<email>"
-            :pass     "<pass>"
-            :tls      true
-            :port     587
-            :base-url "https://my.domain/"}
- :server   {:http-port 8080
-            :mode      "prod"
-            :log-dir   "logs"}
- :ga-id    nil}
+{:database    {:host     "localhost"
+               :port     5432
+               :dbname   "ceo"
+               :user     "ceo"
+               :password "ceo"}
+ :mail        {:host     "smtp.gmail.com"
+               :user     "<email>"
+               :pass     "<pass>"
+               :tls      true
+               :port     587
+               :base-url "https://my.domain/"}
+ :server      {:http-port 8080
+               :mode      "prod"
+               :log-dir   "logs"}
+ :ga-id       nil
+ :session-key "1234567890qwerty"}

--- a/deps.edn
+++ b/deps.edn
@@ -16,7 +16,7 @@
         ring/ring-json            {:mvn/version "0.5.0"}
         seancorfield/next.jdbc    {:mvn/version "1.1.613"}
         sig-gis/triangulum        {:git/url "https://github.com/sig-gis/triangulum"
-                                   :sha     "860ec407230c062218ddd3e6f48caf9f5c18af65"}}
+                                   :sha     "eca491ec19149da885624b692a0cc2a476dd19ec"}}
 
  :aliases {:build-db         {:main-opts ["-m" "triangulum.build-db"]}
            :https            {:main-opts ["-m" "triangulum.https"]}

--- a/src/clj/collect_earth_online/handler.clj
+++ b/src/clj/collect_earth_online/handler.clj
@@ -16,11 +16,13 @@
             [ring.middleware.resource           :refer [wrap-resource]]
             [ring.middleware.reload             :refer [wrap-reload]]
             [ring.middleware.session            :refer [wrap-session]]
+            [ring.middleware.session.cookie     :refer [cookie-store]]
             [ring.middleware.ssl                :refer [wrap-ssl-redirect]]
             [ring.middleware.x-headers          :refer [wrap-frame-options wrap-content-type-options wrap-xss-protection]]
             [ring.util.response                 :refer [redirect]]
             [ring.util.codec                    :refer [url-encode url-decode]]
-            [triangulum.logging :refer [log-str]]
+            [triangulum.logging                 :refer [log-str]]
+            [triangulum.config                  :refer [get-config]]
             [triangulum.type-conversion :as tc]
             [collect-earth-online.routing          :refer [routes]]
             [collect-earth-online.views            :refer [not-found-page data-response]]
@@ -161,6 +163,8 @@
     (mw handler)
     handler))
 
+(defn- string-to-bytes [s] (.getBytes s))
+
 (defn create-handler-stack [ssl? reload?]
   (-> authenticated-routing-handler
       (optional-middleware wrap-ssl-redirect ssl?)
@@ -172,7 +176,7 @@
       wrap-nested-params
       wrap-multipart-params
       wrap-params
-      wrap-session
+      (wrap-session {:store (cookie-store {:key (string-to-bytes (get-config :session-key))})})
       wrap-absolute-redirects
       (wrap-resource "public")
       wrap-content-type


### PR DESCRIPTION
## Purpose
Use a cookie store in ring for persistent log in.  This should limit disruptions for quick deployments.  Also its nice in dev when you are restarting the server every once in a while.

Note, im not sure why redis was recommended as it is a memory database and would reboot with the server.

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `CEO-### <title>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
1. Log in
2. Restart the server
3. Refresh the page
4. You should still be logged in