### PR TITLE
Small UI fixes (Dec testing bug fix)

### DIFF
--- a/src/js/components/FormComponents.js
+++ b/src/js/components/FormComponents.js
@@ -213,7 +213,14 @@ export function CollapsibleTitle({title, showGroup, toggleShow}) {
                 onClick={toggleShow}
                 type="button"
             >
-                {showGroup ? <SvgIcon icon="upCaret" size="0.9rem"/> : <SvgIcon icon="downCaret" size="0.9rem"/>}
+                <div
+                    style={{
+                        transition: "transform 150ms linear 0s",
+                        transform: showGroup && "rotate(-90deg)"
+                    }}
+                >
+                    <SvgIcon icon="downCaret" size="0.9rem"/>
+                </div>
             </button>
             <h3 className="ml-2" style={{marginBottom: "0"}}>{title}</h3>
         </div>

--- a/src/js/components/InstitutionEditor.js
+++ b/src/js/components/InstitutionEditor.js
@@ -13,7 +13,10 @@ export default function InstitutionEditor({
 }) {
     return (
         <div className="row justify-content-center" id="institution-details">
-            <div className="col-xl-6 col-lg-6 border pb-3 mb-2" id="institution-edit">
+            <div
+                className="card card-lightgreen col-xl-6 col-lg-6 pb-2"
+                id="institution-edit"
+            >
                 <h2 className="header">
                     {title}
                 </h2>

--- a/src/js/components/PageComponents.js
+++ b/src/js/components/PageComponents.js
@@ -242,7 +242,7 @@ export class NavigationBar extends React.Component {
                             className="ml-3"
                             onClick={() => this.setState({showHelpMenu: true})}
                         >
-                            {this.state.helpSlides.length > 0 && <SvgIcon color="purple" icon="help" size="2rem"/>}
+                            {this.state.helpSlides.length > 0 && <SvgIcon color="purple" cursor="pointer" icon="help" size="2rem"/>}
                         </div>
                     </div>
                 </nav>

--- a/src/js/home.js
+++ b/src/js/home.js
@@ -353,7 +353,7 @@ function InstitutionList({
             <ul
                 className="tree"
                 style={{
-                    overflowY: "scroll",
+                    overflowY: "auto",
                     overflowX: "hidden",
                     minHeight: "3.5rem",
                     flex: "1 1 0%",
@@ -541,7 +541,9 @@ class Institution extends React.Component {
                             transform: (props.forceInstitutionExpand || this.state.showProjectList) && "rotate(90deg)"
                         }}
                     >
-                        <SvgIcon color="white" icon="rightCaret" size="0.9rem"/>
+                        {props.projects && props.projects.length > 0 && (
+                            <SvgIcon color="white" icon="rightCaret" size="0.9rem"/>
+                        )}
                     </div>
                     <div
                         style={{


### PR DESCRIPTION
## Purpose
Added a pointer cursor to the help icon and unified the UI on the Create Institution and Edit Institution cards to be consistent with the Log In card. Fixes a bug from #1432  where the right caret would show on the home page even if there were no projects in that institution. Adds `overflowY: auto` to the home page. Changes another location with caret icons to be consistent. 

## Submission Checklist
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)


## Screenshots
### Create/edit institution cards
![Screenshot from 2021-12-23 22-34-37](https://user-images.githubusercontent.com/40574170/147318713-4f465c73-bb62-4813-a6bb-8fe13553b664.png)
### Caret consistency 
![Screenshot from 2021-12-27 06-49-23](https://user-images.githubusercontent.com/40574170/147474181-fa9de917-8c6c-4602-ab48-161817784dd9.png)
### overflowY: auto
![Screenshot from 2021-12-27 06-55-59](https://user-images.githubusercontent.com/40574170/147474189-a41b008b-545b-4df0-891e-3803f6d69de6.png)

### Caret bug 
Before:
![Screenshot from 2021-12-27 06-49-39](https://user-images.githubusercontent.com/40574170/147474113-4756b3d1-d2db-48d6-8e5a-ae6457bfb56d.png)
After:
![Screenshot from 2021-12-27 06-53-49](https://user-images.githubusercontent.com/40574170/147474140-a3f265db-4002-4175-a990-72ce20f48364.png)


