### PR TITLE
CEO-395 Remove Edit button from Survey Questions when project is pulished (Dec testing bug fix)

### DIFF
--- a/src/js/project/ReviewForm.js
+++ b/src/js/project/ReviewForm.js
@@ -96,7 +96,7 @@ export default function ReviewForm() {
                         </div>
                     )}
             </div>
-            {renderSectionHeader("Survey Questions", "questions", context.publishedDate === "")}
+            {renderSectionHeader("Survey Questions", "questions", context.availability === "unpublished")}
             <div id="survey-review">
                 <SurveyCardList {...context} inDesignMode={false}/>
                 <SurveyRulesList {...context} inDesignMode={false}/>

--- a/src/js/project/ReviewForm.js
+++ b/src/js/project/ReviewForm.js
@@ -15,7 +15,7 @@ import {ProjectContext} from "./constants";
 
 export default function ReviewForm() {
     const context = React.useContext(ProjectContext);
-    const renderSectionHeader = (title, step) => (
+    const renderSectionHeader = (title, step, showEditIcon) => (
         <div
             className="header my-2 p-2 d-flex flex-row justify-content-center align-items-center"
             style={{
@@ -37,22 +37,24 @@ export default function ReviewForm() {
             >
                 {title}
             </h2>
-            <button
-                className="btn btn-sm btn-outline-info"
-                onClick={() => context.setContextState({designMode: "wizard", wizardStep: step})}
-                type="button"
-            >
-                <SvgIcon color="white" icon="edit" size="1.1rem"/>
-            </button>
+            {showEditIcon ? (
+                <button
+                    className="btn btn-sm btn-outline-info"
+                    onClick={() => context.setContextState({designMode: "wizard", wizardStep: step})}
+                    type="button"
+                >
+                    <SvgIcon color="white" icon="edit" size="1.1rem"/>
+                </button>
+            ) : null}
         </div>
     );
 
     return (
         <div className="px-2 pb-2" id="project-design-form">
-            {renderSectionHeader("Overview", "overview")}
+            {renderSectionHeader("Overview", "overview", true)}
             <OverviewReview/>
             <div id="collection-review">
-                {renderSectionHeader("Collection Design", "imagery")}
+                {renderSectionHeader("Collection Design", "imagery", true)}
                 <AOIMap canDrag={false} context={context}/>
                 <div className="row" style={{borderBottom: "1px solid lightgray"}}>
                     <div className="col-6 pt-3" style={{borderRight: "1px solid lightgray"}}>
@@ -94,7 +96,7 @@ export default function ReviewForm() {
                         </div>
                     )}
             </div>
-            {renderSectionHeader("Survey Questions", "questions")}
+            {renderSectionHeader("Survey Questions", "questions", context.publishedDate === "")}
             <div id="survey-review">
                 <SurveyCardList {...context} inDesignMode={false}/>
                 <SurveyRulesList {...context} inDesignMode={false}/>

--- a/src/sql/dev_data/dev_data.sql
+++ b/src/sql/dev_data/dev_data.sql
@@ -58,7 +58,7 @@ INSERT INTO projects (
 ) VALUES (
     1,
     1,
-    'published',
+    'unpublished',
     'Test Project',
     'This project is a default project for development testing.',
     'public',

--- a/src/sql/dev_data/dev_data.sql
+++ b/src/sql/dev_data/dev_data.sql
@@ -39,6 +39,7 @@ INSERT INTO projects (
     project_uid,
     institution_rid,
     availability,
+    published_date,
     name,
     description,
     privacy_level,
@@ -58,7 +59,8 @@ INSERT INTO projects (
 ) VALUES (
     1,
     1,
-    'unpublished',
+    'published',
+    Now(),
     'Test Project',
     'This project is a default project for development testing.',
     'public',


### PR DESCRIPTION


## Purpose
Removes the Edit button from Survey Questions under Project Review when a project is published. 

## Related Issues
Closes CEO-395

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `CEO-### <title>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
### Test 1
1. Create a project and don't publish it.
2. Go to the Project Review page and click on the edit button underneath Survey Questions.
3. It should take you to the proper page in the Project Wizard.

### Test 2
1. Create a project and publish it.
2. Go to the Project Review page and scroll down to the Survey Questions section.
3. There shouldn't be any edit button for you to click.

