### PR TITLE
CEO-398 Fix the number of plots in the Project Dashboard (Dec testing bug fix)

### DIFF
--- a/src/js/projectDashboard.js
+++ b/src/js/projectDashboard.js
@@ -219,7 +219,7 @@ function ProjectStats(props) {
                                     analysisTime={user.timedPlots > 0
                                         ? (user.seconds / user.timedPlots / 1.0).toFixed(2)
                                         : 0}
-                                    plots={user.plots}
+                                    plots={user.analyzed + user.flagged}
                                     title={(isProjectAdmin || user.email === userName)
                                         ? `${idx + 1}. ${user.email}`
                                         : `User ${idx + 1}`}
@@ -231,7 +231,7 @@ function ProjectStats(props) {
                                         / userStats.reduce((p, c) => p + c.timedPlots, 0)
                                         / 1.0).toFixed(2)
                                     : 0}
-                                plots={userStats.reduce((p, c) => p + c.plots, 0)}
+                                plots={analyzedPlots}
                                 title="Total"
                             />
                         </div>


### PR DESCRIPTION

## Purpose
The number of plots on the Plot Dashboard didn't work. This PR fixes the logic.

## Related Issues
Closes CEO-###

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `CEO-### <title>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
1. Create a project.
2. Collect with more than one user, flag some of the plots you collect.
3. Go to the project dashboard.
4. The number of plots you analyzed for each user (including those you flagged) and the total number of plots analyzed should all be correct.

## Screenshots
Before:
![Screenshot from 2021-12-27 17-58-50](https://user-images.githubusercontent.com/40574170/147514933-dc88a86b-f24d-42b3-84c2-9a5e45b54387.png)

After:
![Screenshot from 2021-12-27 18-08-45](https://user-images.githubusercontent.com/40574170/147514939-018accd1-6644-4c81-a8f2-42396a59fed9.png)


