### PR TITLE
CEO-392 Add ellipsis to project title component (Dec testing bug fix)

### DIFF
--- a/src/js/collection.js
+++ b/src/js/collection.js
@@ -1565,16 +1565,11 @@ class ProjectTitle extends React.Component {
                     <SvgIcon color="#ffffff" cursor="pointer" icon="info" size="1.25rem"/>
                 </div>
                 <div
-                    style={{cursor: "default", flex: 1, height: "3rem"}}
+                    style={{cursor: "default", flex: 1, height: "3rem", minWidth: 0}}
                 >
                     <h2
-                        className="header overflow-hidden text-truncate"
-                        style={{
-                            display: "flex",
-                            height: "100%",
-                            justifyContent: "center",
-                            margin: "0"
-                        }}
+                        className="header text-truncate"
+                        style={{height: "100%", margin: "0"}}
                         title={projectName}
                     >
                         {projectName}


### PR DESCRIPTION
## Purpose
Adds ellipsis for longer project titles in the collection sidebar.

## Related Issues
Closes CEO-392

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `CEO-### <title>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
1. Create a project with a long title.
2. Go to the collection page.
3. The project title should be cut off with ellipsis.

## Screenshots

![Screenshot from 2021-12-27 19-03-03](https://user-images.githubusercontent.com/40574170/147516813-b4acc7fa-4be7-4f40-9fae-fc2508a4e8f9.png)

