### PR TITLE
CEO-394 Add an error message for incorrect sample spacing with circle plots and gridded samples (Dec testing bug fix)

### DIFF
--- a/src/js/project/CreateProjectWizard.js
+++ b/src/js/project/CreateProjectWizard.js
@@ -343,7 +343,7 @@ export default class CreateProjectWizard extends React.Component {
             (sampleDistribution === "gridded"
                 && plotShape === "circle"
                 && sampleResolution >= plotSize / Math.sqrt(2))
-                && "The sample spacing must be less than plot diameter divided by the square root of 2.",
+                && `You must use a sample spacing that is less than ${Math.round((plotSize / Math.sqrt(2)) * 100) / 100} meters.`,
             (sampleDistribution === "gridded"
                 && plotShape === "square"
                 && sampleResolution >= plotSize)

--- a/src/js/project/SampleDesign.js
+++ b/src/js/project/SampleDesign.js
@@ -72,7 +72,10 @@ export class SampleDesign extends React.Component {
             allowDrawnSamples,
             designSettings: {sampleGeometries, qaqcAssignment: {qaqcMethod}},
             plotDistribution,
+            plotShape,
+            plotSize,
             sampleDistribution,
+            sampleResolution,
             setProjectDetails
         } = this.context;
         const totalPlots = this.props.getTotalPlots();
@@ -177,7 +180,11 @@ export class SampleDesign extends React.Component {
                 <p
                     className="font-italic ml-2"
                     style={{
-                        color: (samplesPerPlot > perPlotLimit || samplesPerPlot * totalPlots > sampleLimit)
+                        color: (samplesPerPlot > perPlotLimit
+                                 || samplesPerPlot * totalPlots > sampleLimit
+                                 || (sampleDistribution === "gridded"
+                                      && plotShape === "circle"
+                                      && sampleResolution >= plotSize / Math.sqrt(2)))
                             ? "#8B0000"
                             : "#006400",
                         fontSize: "1rem",
@@ -194,6 +201,10 @@ export class SampleDesign extends React.Component {
                         && `\n* The maximum allowed for the selected sample distribution is ${formatNumberWithCommas(perPlotLimit)} samples per plot.`}
                     {totalPlots > 0 && samplesPerPlot > 0 && samplesPerPlot * totalPlots > sampleLimit
                         && `\n* The maximum allowed samples per project is ${formatNumberWithCommas(sampleLimit)}.`}
+                    {sampleDistribution === "gridded"
+                        && plotShape === "circle"
+                        && sampleResolution >= plotSize / Math.sqrt(2)
+                        && `\n* You must use a sample spacing that is less than ${Math.round((plotSize / Math.sqrt(2)) * 100) / 100} meters.`}
                 </p>
                 <div className="mb-3">
                     <div className="form-check form-check-inline">


### PR DESCRIPTION
## Purpose
Adds an error message directly in the Project Wizard UI when the sample spacing is too large for circle plots with gridded samples. 

## Related Issues
Closes CEO-394

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `CEO-### <title>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
1. Create a project with circle plots and gridded samples.
2. Mess around with the sample spacing -- starting with a low number so that you don't get any error messages.
3. Now, change the sample spacing to be a large number.
4. You should get an error message in red telling you what the sample spacing needs to be and you shouldn't be able to proceed to the next Project Wizard step.
5. Change the sample spacing to be just below that number.
6. The text should be green now and you should be allowed to proceed.

## Screenshots

![Screenshot from 2021-12-28 09-43-08](https://user-images.githubusercontent.com/40574170/147583513-acb473d3-e68f-48fa-af87-d646ef752876.png)

