### PR TITLE
CEO-393 Fix the positioning of Project Stats (Dec testing bug fix)

### DIFF
--- a/src/js/collection.js
+++ b/src/js/collection.js
@@ -1700,9 +1700,10 @@ class ProjectStats extends React.Component {
                     backgroundColor: "#f1f1f1",
                     boxShadow: "0px 8px 16px 0px rgba(0,0,0,0.2)",
                     cursor: "default",
-                    marginLeft: "1rem",
+                    left: "0",
+                    margin: "0 1rem",
                     overflow: "auto",
-                    padding: ".5rem",
+                    padding: "0 .5rem .5rem .5rem",
                     position: "absolute",
                     zIndex: "10"
                 }}

--- a/src/js/collection.js
+++ b/src/js/collection.js
@@ -1558,11 +1558,19 @@ class ProjectTitle extends React.Component {
                     marginRight: "-15px"
                 }}
             >
-                <div
-                    onClick={() => this.setState({showStats: !this.state.showStats})}
-                    style={{flex: 0, marginLeft: "1rem"}}
-                >
-                    <SvgIcon color="#ffffff" cursor="pointer" icon="info" size="1.25rem"/>
+                <div>
+                    <div
+                        onClick={() => this.setState({showStats: !this.state.showStats})}
+                        style={{flex: 0, marginLeft: "1rem"}}
+                    >
+                        <SvgIcon color="#ffffff" cursor="pointer" icon="info" size="1.25rem"/>
+                    </div>
+                    {this.state.showStats && (
+                        <ProjectStats
+                            projectId={projectId}
+                            userName={userName}
+                        />
+                    )}
                 </div>
                 <div
                     style={{cursor: "default", flex: 1, height: "3rem"}}
@@ -1579,12 +1587,6 @@ class ProjectTitle extends React.Component {
                     >
                         {projectName}
                     </h2>
-                    {this.state.showStats && (
-                        <ProjectStats
-                            projectId={projectId}
-                            userName={userName}
-                        />
-                    )}
                 </div>
             </div>
         );
@@ -1700,8 +1702,7 @@ class ProjectStats extends React.Component {
                     backgroundColor: "#f1f1f1",
                     boxShadow: "0px 8px 16px 0px rgba(0,0,0,0.2)",
                     cursor: "default",
-                    left: "0",
-                    margin: "0 1rem",
+                    margin: ".75rem 1rem 0 1rem",
                     overflow: "auto",
                     padding: "0 .5rem .5rem .5rem",
                     position: "absolute",


### PR DESCRIPTION
## Purpose
Moves the Project Stats section underneath the new location of the info icon.

## Related Issues
Closes CEO-393

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `CEO-### <title>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Screenshots
![Screenshot from 2021-12-28 10-11-46](https://user-images.githubusercontent.com/40574170/147585462-ed87d41c-b8ce-47b0-9554-76913f6867a9.png)


