### PR TITLE
CEO-396 Display uploaded logo filename to the UI 

### DIFF
--- a/src/clj/collect_earth_online/db/institutions.clj
+++ b/src/clj/collect_earth_online/db/institutions.clj
@@ -26,8 +26,9 @@
   (let [institution-id (tc/val->int (:institutionId params))
         user-id        (:userId params -1)]
     (if-let [institution (first (call-sql "select_institution_by_id" institution-id user-id))]
-      (data-response (let [{:keys [name base64_image url description institution_admin]} institution]
+      (data-response (let [{:keys [name image_name base64_image url description institution_admin]} institution]
                        {:name             name
+                        :imageName        image_name
                         :url              url
                         :description      description
                         :institutionAdmin institution_admin
@@ -55,13 +56,14 @@
 (defn create-institution [{:keys [params]}]
   (let [user-id      (:userId params -1)
         name         (:name params)
+        image-name   (:imageName params)
         base64-image (:base64Image params)
         url          (:url params)
         description  (:description params)]
     (if-let [error-message (or (get-common-errors name description)
                                (get-create-errors name))]
       (data-response error-message)
-      (if-let [institution-id (sql-primitive (call-sql "add_institution" name url description))]
+      (if-let [institution-id (sql-primitive (call-sql "add_institution" name image-name url description))]
         (do
           (when (pos? (count base64-image))
             (call-sql "update_institution_logo" {:log? false} institution-id (second (str/split base64-image #","))))
@@ -82,6 +84,7 @@
   (let [user-id        (:userId params -1)
         institution-id (tc/val->int (:institutionId params))
         name           (:name params)
+        image-name     (:imageName params)
         base64-image   (:base64Image params)
         url            (:url params)
         description    (:description params)]
@@ -89,7 +92,7 @@
                                (get-update-errors institution-id user-id name))]
       (data-response error-message)
       (do
-        (call-sql "update_institution" institution-id name url description)
+        (call-sql "update_institution" institution-id name image-name url description)
         (when (pos? (count base64-image))
           (call-sql "update_institution_logo" {:log? false} institution-id (second (str/split base64-image #","))))
         (data-response "")))))

--- a/src/js/components/InstitutionEditor.js
+++ b/src/js/components/InstitutionEditor.js
@@ -55,7 +55,7 @@ export default function InstitutionEditor({
                             type="file"
                         />
                         <label className="custom-file-label" htmlFor="institution-logo">
-                            {imageName === "" || imageName === null ? "Choose image..." : imageName}
+                            {imageName === "" ? "Choose image..." : imageName}
                         </label>
                     </div>
                 </div>

--- a/src/js/components/InstitutionEditor.js
+++ b/src/js/components/InstitutionEditor.js
@@ -6,6 +6,7 @@ export default function InstitutionEditor({
     title,
     name,
     description,
+    imageName,
     url,
     acceptTOS,
     buttonGroup,
@@ -48,12 +49,14 @@ export default function InstitutionEditor({
                             className="custom-file-input mb-1 mr-sm-2"
                             id="institution-logo"
                             onChange={e => {
-                                setInstitutionDetails("logo", e.target.files[0].name);
+                                setInstitutionDetails("imageName", e.target.files[0].name);
                                 encodeFileAsBase64(e.target.files[0], r => setInstitutionDetails("base64Image", r));
                             }}
                             type="file"
                         />
-                        <label className="custom-file-label" htmlFor="institution-logo">Choose image...</label>
+                        <label className="custom-file-label" htmlFor="institution-logo">
+                            {imageName === "" || imageName === null ? "Choose image..." : imageName}
+                        </label>
                     </div>
                 </div>
                 <div className="mb-3">

--- a/src/js/createInstitution.js
+++ b/src/js/createInstitution.js
@@ -11,6 +11,7 @@ class CreateInstitution extends React.Component {
             newInstitutionDetails: {
                 name: "",
                 base64Image: "",
+                imageName: "",
                 url: "",
                 description: "",
                 acceptTOS: false
@@ -38,6 +39,7 @@ class CreateInstitution extends React.Component {
                       body: JSON.stringify({
                           name: this.state.newInstitutionDetails.name,
                           base64Image: this.state.newInstitutionDetails.base64Image,
+                          imageName: this.state.newInstitutionDetails.imageName,
                           url: this.state.newInstitutionDetails.url,
                           description: this.state.newInstitutionDetails.description
                       })
@@ -79,6 +81,7 @@ class CreateInstitution extends React.Component {
                 acceptTOS={this.state.newInstitutionDetails.acceptTOS}
                 buttonGroup={this.renderButtonGroup}
                 description={this.state.newInstitutionDetails.description}
+                imageName={this.state.newInstitutionDetails.imageName}
                 name={this.state.newInstitutionDetails.name}
                 setInstitutionDetails={this.setInstitutionDetails}
                 title="Create New Institution"

--- a/src/js/reviewInstitution.js
+++ b/src/js/reviewInstitution.js
@@ -342,14 +342,21 @@ class InstitutionDescription extends React.Component {
                     <div className="col-8" id="institution-view">
                         <div className="row mb-4">
                             <div className="col-md-3" id="institution-logo-container">
-                                <img
-                                    alt={this.state.institutionDetails.name}
-                                    onClick={() => window.open(this.httpAddress(this.state.institutionDetails.url))}
-                                    src={safeLength(this.state.institutionDetails.base64Image) > 1
-                                        ? `data:*/*;base64,${this.state.institutionDetails.base64Image}`
-                                        : "/img/ceo-logo.png"}
-                                    style={{maxWidth: "100%"}}
-                                />
+                                <a
+                                    href={this.state.institutionDetails.url === ""
+                                        ? "/"
+                                        : this.httpAddress(this.state.institutionDetails.url)}
+                                    rel="noreferrer"
+                                    target="_blank"
+                                >
+                                    <img
+                                        alt={this.state.institutionDetails.name}
+                                        src={safeLength(this.state.institutionDetails.base64Image) > 1
+                                            ? `data:*/*;base64,${this.state.institutionDetails.base64Image}`
+                                            : "/img/ceo-logo.png"}
+                                        style={{maxWidth: "100%"}}
+                                    />
+                                </a>
                             </div>
                             <div className="col-md-8">
                                 <h1>

--- a/src/js/reviewInstitution.js
+++ b/src/js/reviewInstitution.js
@@ -161,6 +161,7 @@ class InstitutionDescription extends React.Component {
             institutionDetails: {
                 name: "",
                 base64Image: "",
+                imageName: "",
                 url: "",
                 description: "",
                 institutionAdmin: false
@@ -168,6 +169,7 @@ class InstitutionDescription extends React.Component {
             newInstitutionDetails: {
                 name: "",
                 base64Image: "",
+                imageName: "",
                 url: "",
                 description: ""
             },
@@ -187,6 +189,7 @@ class InstitutionDescription extends React.Component {
                     institutionDetails: data,
                     newInstitutionDetails: {
                         name: data.name,
+                        imageName: data.imageName,
                         url: data.url,
                         description: data.description,
                         base64Image: ""
@@ -219,6 +222,7 @@ class InstitutionDescription extends React.Component {
                     body: JSON.stringify({
                         institutionId: this.props.institutionId,
                         name: this.state.newInstitutionDetails.name,
+                        imageName: this.state.newInstitutionDetails.imageName,
                         base64Image: this.state.newInstitutionDetails.base64Image,
                         url: this.state.newInstitutionDetails.url,
                         description: this.state.newInstitutionDetails.description
@@ -327,6 +331,7 @@ class InstitutionDescription extends React.Component {
                 <InstitutionEditor
                     buttonGroup={this.renderEditButtonGroup}
                     description={this.state.newInstitutionDetails.description}
+                    imageName={this.state.newInstitutionDetails.imageName}
                     name={this.state.newInstitutionDetails.name}
                     setInstitutionDetails={this.updateNewInstitutionDetails}
                     title="Edit Institution"

--- a/src/sql/changes/update_2022-01-11_add_image_name.sql
+++ b/src/sql/changes/update_2022-01-11_add_image_name.sql
@@ -1,0 +1,7 @@
+ALTER TABLE institutions ADD COLUMN image_name text DEFAULT '';
+
+UPDATE institutions SET image_name = 'Image Uploaded'
+WHERE logo_data IS NOT NULL;
+
+UPDATE institutions SET image_name = ''
+WHERE logo_data IS NULL;

--- a/src/sql/functions/member.sql
+++ b/src/sql/functions/member.sql
@@ -269,13 +269,13 @@ CREATE OR REPLACE FUNCTION institution_name_taken(_name text, _institution_id_to
 $$ LANGUAGE SQL;
 
 -- Adds a new institution to the database
-CREATE OR REPLACE FUNCTION add_institution(_name text, _url text, _description text)
+CREATE OR REPLACE FUNCTION add_institution(_name text, _image_name text, _url text, _description text)
  RETURNS integer AS $$
 
     INSERT INTO institutions
-        (name, url, description, archived)
+        (name, image_name, url, description, archived)
     VALUES
-        (_name, _url, _description, FALSE)
+        (_name, _image_name, _url, _description, FALSE)
     RETURNING institution_uid
 
 $$ LANGUAGE SQL;
@@ -322,6 +322,7 @@ CREATE OR REPLACE FUNCTION select_institution_by_id(_institution_id integer, _us
  RETURNS table (
     institution_id       integer,
     name                 text,
+    image_name           text,
     base64_image         text,
     url                  text,
     description          text,
@@ -330,6 +331,7 @@ CREATE OR REPLACE FUNCTION select_institution_by_id(_institution_id integer, _us
 
     SELECT institution_uid,
         name,
+        image_name,
         encode(logo_data, 'base64'),
         url,
         description,
@@ -341,11 +343,12 @@ CREATE OR REPLACE FUNCTION select_institution_by_id(_institution_id integer, _us
 $$ LANGUAGE SQL;
 
 -- Updates institution details
-CREATE OR REPLACE FUNCTION update_institution(_institution_id integer, _name text, _url text, _description text)
+CREATE OR REPLACE FUNCTION update_institution(_institution_id integer, _name text, _image_name text, _url text, _description text)
  RETURNS integer AS $$
 
     UPDATE institutions
     SET name = _name,
+        image_name = _image_name,
         url = _url,
         description = _description
     WHERE institution_uid = _institution_id

--- a/src/sql/tables/all.sql
+++ b/src/sql/tables/all.sql
@@ -19,6 +19,7 @@ CREATE TABLE users (
 CREATE TABLE institutions (
     institution_uid    SERIAL PRIMARY KEY,
     name               text NOT NULL,
+    image_name         text DEFAULT NULL,
     logo_data          bytea,
     description        text NOT NULL,
     url                text NOT NULL,

--- a/src/sql/tables/all.sql
+++ b/src/sql/tables/all.sql
@@ -19,7 +19,7 @@ CREATE TABLE users (
 CREATE TABLE institutions (
     institution_uid    SERIAL PRIMARY KEY,
     name               text NOT NULL,
-    image_name         text DEFAULT NULL,
+    image_name         text DEFAULT '',
     logo_data          bytea,
     description        text NOT NULL,
     url                text NOT NULL,


### PR DESCRIPTION
## Purpose
Adds an `image_name` column to the `institutions` database so that the file name of the logo that's uploaded can be displayed to the user. If no file has been uploaded, then "Choose image..." is displayed to the user.

## Related Issues
Closes CEO-396

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `CEO-### <title>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
1. Create an institution.
2. Upload a logo.
3. You should be able to see the file name in the UI.
4. Go to the edit institution page. 
5. The same file name should still be there.
6. Change the logo to something else.
7. The new file name should be there the next time you go to edit the institution.

1. Create an institution without a logo.
2. Go to the edit institution page.
3. The UI should say "Choose image..."


## Screenshots
![Screenshot from 2021-12-28 11-20-30](https://user-images.githubusercontent.com/40574170/147591286-2d96d299-da74-4ddd-843f-3d9b05241995.png)
![Screenshot from 2021-12-28 11-18-11](https://user-images.githubusercontent.com/40574170/147591298-fd3f0ab5-11b9-49bc-9ecf-f0b9adc8c09b.png)
![Screenshot from 2021-12-28 11-20-10](https://user-images.githubusercontent.com/40574170/147591305-27e73224-dc39-4439-bd61-00ad58682eeb.png)


