### PR TITLE
CEO-397 Clean up the user assignment (Dec testing bug fix)

### DIFF
--- a/src/js/reviewInstitution.js
+++ b/src/js/reviewInstitution.js
@@ -1322,8 +1322,7 @@ class User extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            userRole: props.user.institutionRole,
-            didRoleUpdate: false
+            userRole: props.user.institutionRole
         };
     }
 
@@ -1354,19 +1353,7 @@ class User extends React.Component {
                         <div className="col-2 mb-1 pl-0">
                             <select
                                 className="custom-select custom-select-sm"
-                                onChange={e => {
-                                    if (this.props.user.institutionRole !== e.target.value) {
-                                        this.setState({
-                                            userRole: e.target.value,
-                                            didRoleUpdate: true
-                                        });
-                                    } else {
-                                        this.setState({
-                                            userRole: e.target.value,
-                                            didRoleUpdate: false
-                                        });
-                                    }
-                                }}
+                                onChange={e => this.setState({userRole: e.target.value})}
                                 size="1"
                                 value={this.state.userRole}
                             >
@@ -1377,13 +1364,15 @@ class User extends React.Component {
                         </div>
                         <div className="col-2 mb-1 pl-0">
                             <button
-                                className={this.state.didRoleUpdate
-                                    ? "btn btn-sm btn-outline-yellow btn-block"
-                                    : "disabled-group btn btn-sm btn-outline-yellow btn-block"}
+                                className="btn btn-sm btn-outline-yellow btn-block"
                                 onClick={() => {
-                                    if (this.state.didRoleUpdate) {
+                                    const {userRole} = this.state;
+                                    const {institutionRole} = this.props.user;
+                                    if (userRole === institutionRole) {
+                                        alert("You must change the role of a user in order to update it.");
+                                    } else {
                                         const confirmBox = window.confirm("Do you really want to update the role of this user?");
-                                        if (confirmBox) updateUserInstitutionRole(user.id, null, this.state.userRole);
+                                        if (confirmBox) updateUserInstitutionRole(user.id, null, userRole);
                                     }
                                 }}
                                 type="button"

--- a/src/js/reviewInstitution.js
+++ b/src/js/reviewInstitution.js
@@ -1322,7 +1322,8 @@ class User extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            userRole: props.user.institutionRole
+            userRole: props.user.institutionRole,
+            didRoleUpdate: false
         };
     }
 
@@ -1353,7 +1354,19 @@ class User extends React.Component {
                         <div className="col-2 mb-1 pl-0">
                             <select
                                 className="custom-select custom-select-sm"
-                                onChange={e => this.setState({userRole: e.target.value})}
+                                onChange={e => {
+                                    if (this.props.user.institutionRole !== e.target.value) {
+                                        this.setState({
+                                            userRole: e.target.value,
+                                            didRoleUpdate: true
+                                        });
+                                    } else {
+                                        this.setState({
+                                            userRole: e.target.value,
+                                            didRoleUpdate: false
+                                        });
+                                    }
+                                }}
                                 size="1"
                                 value={this.state.userRole}
                             >
@@ -1364,10 +1377,14 @@ class User extends React.Component {
                         </div>
                         <div className="col-2 mb-1 pl-0">
                             <button
-                                className="btn btn-sm btn-outline-yellow btn-block"
+                                className={this.state.didRoleUpdate
+                                    ? "btn btn-sm btn-outline-yellow btn-block"
+                                    : "disabled-group btn btn-sm btn-outline-yellow btn-block"}
                                 onClick={() => {
-                                    const confirmBox = window.confirm("Do you really want to update the role of this user?");
-                                    if (confirmBox) updateUserInstitutionRole(user.id, null, this.state.userRole);
+                                    if (this.state.didRoleUpdate) {
+                                        const confirmBox = window.confirm("Do you really want to update the role of this user?");
+                                        if (confirmBox) updateUserInstitutionRole(user.id, null, this.state.userRole);
+                                    }
                                 }}
                                 type="button"
                             >


### PR DESCRIPTION
## Purpose
Doesn't allow for a user's role to be updated if the user's role hasn't changed in the input.

## Related Issues
Closes CEO-397

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `CEO-### <title>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
1. Go to the Users tab of an institution. 
2. Change the role of a user to a different role.
3. Change the role of that user back to its original value.
4. Try to click the Update button for that user.
5. An alert warning you that you must change the user's role should pop up when clicking on it.

## Screenshots
![Screenshot from 2021-12-28 15-21-08](https://user-images.githubusercontent.com/40574170/147608422-d0f0da13-ffb5-46c4-9b5d-3b00c49c50f2.png)



