### PR TITLE
Use "id" for id keys

### DIFF
--- a/src/js/collection.js
+++ b/src/js/collection.js
@@ -455,7 +455,7 @@ class Collection extends React.Component {
             : {},
         selectedQuestionId: Number(findObject(
             this.state.currentProject.surveyQuestions,
-            ([_id, sq]) => sq.parentQuestion === -1
+            ([_id, sq]) => sq.parentQuestionId === -1
         )[0]),
         collectionStart: Date.now(),
         unansweredColor: "black"
@@ -687,7 +687,7 @@ class Collection extends React.Component {
     getChildQuestionIds = currentQuestionId => {
         const {surveyQuestions} = this.state.currentProject;
         const childQuestionIds = mapObjectArray(
-            filterObject(surveyQuestions, ([_id, val]) => val.parentQuestion === currentQuestionId),
+            filterObject(surveyQuestions, ([_id, val]) => val.parentQuestionId === currentQuestionId),
             ([key, _val]) => Number(key)
         );
 
@@ -810,15 +810,15 @@ class Collection extends React.Component {
 
     calcVisibleSamples = currentQuestionId => {
         const {currentProject: {surveyQuestions}, userSamples} = this.state;
-        const {parentQuestion, parentAnswer} = surveyQuestions[currentQuestionId];
+        const {parentQuestionId, parentAnswerId} = surveyQuestions[currentQuestionId];
 
-        if (parentQuestion === -1) {
+        if (parentQuestionId === -1) {
             return this.state.currentPlot.samples;
         } else {
-            return this.calcVisibleSamples(parentQuestion)
+            return this.calcVisibleSamples(parentQuestionId)
                 .filter(sample => {
-                    const sampleAnswerId = _.get(userSamples, [sample.id, parentQuestion, "answerId"]);
-                    return sampleAnswerId && (parentAnswer === -1 || parentAnswer === sampleAnswerId);
+                    const sampleAnswerId = _.get(userSamples, [sample.id, parentQuestionId, "answerId"]);
+                    return sampleAnswerId && (parentAnswerId === -1 || parentAnswerId === sampleAnswerId);
                 });
         }
     };

--- a/src/js/components/SurveyCollection.js
+++ b/src/js/components/SurveyCollection.js
@@ -31,8 +31,8 @@ export class SurveyCollection extends React.Component {
 
         // This happens when the selected question is set back to the beginning after switching from draw to question mode.
         if (this.props.selectedQuestionId !== prevProps.selectedQuestionId) {
-            const {parentQuestion} = this.props.surveyQuestions[this.props.selectedQuestionId];
-            if (parentQuestion === -1) {
+            const {parentQuestionId} = this.props.surveyQuestions[this.props.selectedQuestionId];
+            if (parentQuestionId === -1) {
                 this.setState({currentNodeIndex: this.state.topLevelNodeIds.indexOf(this.props.selectedQuestionId)});
             }
         }
@@ -46,7 +46,7 @@ export class SurveyCollection extends React.Component {
         const {surveyQuestions} = this.props;
         this.setState({
             topLevelNodeIds: mapObjectArray(
-                filterObject(surveyQuestions, ([_id, sq]) => sq.parentQuestion === -1),
+                filterObject(surveyQuestions, ([_id, sq]) => sq.parentQuestionId === -1),
                 ([nodeId, _node]) => Number(nodeId)
             )
         });
@@ -77,7 +77,7 @@ export class SurveyCollection extends React.Component {
         const {surveyQuestions} = this.props;
         const {visible, answered} = this.getNodeById(currentQuestionId);
         const childQuestionIds = mapObjectArray(
-            filterObject(surveyQuestions, ([_id, sq]) => sq.parentQuestion === currentQuestionId),
+            filterObject(surveyQuestions, ([_id, sq]) => sq.parentQuestionId === currentQuestionId),
             ([key, _val]) => Number(key)
         );
         return visible.length === answered.length
@@ -556,7 +556,7 @@ class SurveyQuestionTree extends React.Component {
             validateAndSetCurrentValue
         } = this.props;
         const {showAnswers} = this.state;
-        const childNodes = filterObject(surveyQuestions, ([_id, sq]) => sq.parentQuestion === surveyNodeId);
+        const childNodes = filterObject(surveyQuestions, ([_id, sq]) => sq.parentQuestionId === surveyNodeId);
         const nodeQuestion = surveyQuestions[surveyNodeId];
         return (
             <>

--- a/src/js/project/SurveyCardList.js
+++ b/src/js/project/SurveyCardList.js
@@ -6,7 +6,7 @@ import {mapObject, mapObjectArray, filterObject} from "../utils/sequence";
 
 export default function SurveyCardList(props) {
     const topLevelNodes = mapObjectArray(
-        filterObject(props.surveyQuestions, ([_id, sq]) => sq.parentQuestion === -1),
+        filterObject(props.surveyQuestions, ([_id, sq]) => sq.parentQuestionId === -1),
         ([id, _sq]) => Number(id)
     );
     return topLevelNodes.map((nodeId, idx) => (
@@ -46,7 +46,7 @@ class SurveyCard extends React.Component {
         this.props.setProjectDetails({
             surveyQuestions: mapObject(surveyQuestions, ([key, val]) => [
                 this.swapId(Number(key), surveyQuestionId, newId),
-                {...val, parentQuestion: this.swapId(val.parentQuestion, surveyQuestionId, newId)}
+                {...val, parentQuestionId: this.swapId(val.parentQuestionId, surveyQuestionId, newId)}
             ])
         });
     };
@@ -144,10 +144,10 @@ function SurveyQuestionTree({
 }) {
     const surveyQuestion = surveyQuestions[surveyQuestionId];
     const childNodeIds = mapObjectArray(
-        filterObject(surveyQuestions, ([_id, sq]) => sq.parentQuestion === surveyQuestionId),
+        filterObject(surveyQuestions, ([_id, sq]) => sq.parentQuestionId === surveyQuestionId),
         ([key, _val]) => Number(key)
     );
-    const parentQuestion = surveyQuestions[surveyQuestion.parentQuestion];
+    const parentQuestion = surveyQuestions[surveyQuestion.parentQuestionId];
     return (
         <>
             <div className="SurveyQuestionTree__question d-flex border-top pt-3 pb-1">
@@ -202,7 +202,7 @@ function SurveyQuestionTree({
                                     </ul>
                                 </li>
                             )}
-                            {surveyQuestion.parentQuestion > -1 && (
+                            {parentQuestion && (
                                 <>
                                     <li>
                                         <span className="font-weight-bold">Parent Question:  </span>
@@ -212,9 +212,9 @@ function SurveyQuestionTree({
                                     </li>
                                     <li>
                                         <span className="font-weight-bold">Parent Answer:  </span>
-                                        {surveyQuestion.parentAnswer === -1
+                                        {surveyQuestion.parentAnswerId === -1
                                             ? "Any"
-                                            : parentQuestion.answers[surveyQuestion.parentAnswer].answer}
+                                            : parentQuestion.answers[surveyQuestion.parentAnswerId].answer}
                                     </li>
                                 </>
                             )}

--- a/src/js/project/SurveyQuestions.js
+++ b/src/js/project/SurveyQuestions.js
@@ -13,7 +13,7 @@ export class SurveyQuestionDesign extends React.Component {
     getChildQuestionIds = questionId => {
         const {surveyQuestions} = this.context;
         const childQuestionIds = mapObjectArray(
-            filterObject(surveyQuestions, ([_sqId, sq]) => sq.parentQuestion === questionId),
+            filterObject(surveyQuestions, ([_sqId, sq]) => sq.parentQuestionId === questionId),
             ([key, _val]) => Number(key)
         );
         return childQuestionIds.length === 0
@@ -33,7 +33,7 @@ export class SurveyQuestionDesign extends React.Component {
         const {surveyQuestions, setProjectDetails} = this.context;
         const matchingQuestion = findObject(
             surveyQuestions,
-            ([_id, sq]) => sq.parentQuestion === questionId && sq.parentAnswer === answerId
+            ([_id, sq]) => sq.parentQuestionId === questionId && sq.parentAnswerId === answerId
         )[1];
         if (matchingQuestion) {
             alert(
@@ -146,8 +146,8 @@ class NewQuestionDesigner extends React.Component {
                         ? newQuestionText + ` (${repeatedQuestions})`
                         : newQuestionText,
                     answers: {},
-                    parentQuestion: selectedParent,
-                    parentAnswer: selectedAnswer,
+                    parentQuestionId: selectedParent,
+                    parentAnswerId: selectedAnswer,
                     dataType,
                     componentType
                 };
@@ -383,7 +383,7 @@ export class SurveyQuestionHelp extends React.Component {
     getChildQuestionIds = currentQuestionId => {
         const {surveyQuestions} = this.context;
         const childQuestionIds = mapObjectArray(
-            filterObject(surveyQuestions, ([_id, val]) => val.parentQuestion === currentQuestionId),
+            filterObject(surveyQuestions, ([_id, val]) => val.parentQuestionId === currentQuestionId),
             ([key, _val]) => Number(key)
         );
         return childQuestionIds.length
@@ -395,15 +395,15 @@ export class SurveyQuestionHelp extends React.Component {
     calcVisibleSamples = currentQuestionId => {
         const {surveyQuestions} = this.context;
         const {userSamples} = this.state;
-        const {parentQuestion, parentAnswer} = surveyQuestions[currentQuestionId];
+        const {parentQuestionId, parentAnswerId} = surveyQuestions[currentQuestionId];
 
-        if (parentQuestion === -1) {
+        if (parentQuestionId === -1) {
             return [{id: 1}];
         } else {
-            return this.calcVisibleSamples(parentQuestion)
+            return this.calcVisibleSamples(parentQuestionId)
                 .filter(sample => {
-                    const sampleAnswerId = _.get(userSamples, [sample.id, parentQuestion, "answerId"]);
-                    return sampleAnswerId && (parentAnswer === -1 || parentAnswer === sampleAnswerId);
+                    const sampleAnswerId = _.get(userSamples, [sample.id, parentQuestionId, "answerId"]);
+                    return sampleAnswerId && (parentAnswerId === -1 || parentAnswerId === sampleAnswerId);
                 });
         }
     };

--- a/src/js/simpleCollection.js
+++ b/src/js/simpleCollection.js
@@ -359,7 +359,7 @@ class SimpleCollection extends React.Component {
             : {},
         selectedQuestionId: Number(findObject(
             this.state.currentProject.surveyQuestions,
-            ([_id, sq]) => sq.parentQuestion === -1
+            ([_id, sq]) => sq.parentQuestionId === -1
         )[0]),
         collectionStart: Date.now(),
         unansweredColor: "black"
@@ -457,7 +457,7 @@ class SimpleCollection extends React.Component {
     getChildQuestionIds = currentQuestionId => {
         const {surveyQuestions} = this.state.currentProject;
         const childQuestionIds = mapObjectArray(
-            filterObject(surveyQuestions, ([_id, val]) => val.parentQuestion === currentQuestionId),
+            filterObject(surveyQuestions, ([_id, val]) => val.parentQuestionId === currentQuestionId),
             ([key, _val]) => Number(key)
         );
 
@@ -578,15 +578,15 @@ class SimpleCollection extends React.Component {
 
     calcVisibleSamples = currentQuestionId => {
         const {currentProject: {surveyQuestions}, userSamples} = this.state;
-        const {parentQuestion, parentAnswer} = surveyQuestions[currentQuestionId];
+        const {parentQuestionId, parentAnswerId} = surveyQuestions[currentQuestionId];
 
-        if (parentQuestion === -1) {
+        if (parentQuestionId === -1) {
             return this.state.currentPlot.samples;
         } else {
-            return this.calcVisibleSamples(parentQuestion)
+            return this.calcVisibleSamples(parentQuestionId)
                 .filter(sample => {
-                    const sampleAnswerId = _.get(userSamples, [sample.id, parentQuestion, "answerId"]);
-                    return sampleAnswerId && (parentAnswer === -1 || parentAnswer === sampleAnswerId);
+                    const sampleAnswerId = _.get(userSamples, [sample.id, parentQuestionId, "answerId"]);
+                    return sampleAnswerId && (parentAnswerId === -1 || parentAnswerId === sampleAnswerId);
                 });
         }
     };

--- a/src/sql/changes/update_2021-12-23_transform_survey_questions.sql
+++ b/src/sql/changes/update_2021-12-23_transform_survey_questions.sql
@@ -48,19 +48,3 @@ $$ LANGUAGE SQL;
 ALTER TABLE projects ADD COLUMN sq_bk jsonb;
 UPDATE projects SET sq_bk = survey_questions;
 UPDATE projects SET survey_questions = survey_reduce(survey_questions);
-
-CREATE OR REPLACE FUNCTION survey_rename_key(_questions jsonb, _from text, _to text)
- RETURNS jsonb AS $$
-
-    SELECT jsonb_object_agg(
-        key, jsonb_set(value, ('{"' || _to || '"}')::text[], value->_from) - _from
-    )
-    FROM (
-        SELECT key, value
-        FROM jsonb_each(_questions)
-    ) a
-
-$$ LANGUAGE SQL;
-
-UPDATE projects SET survey_questions = survey_rename_key(survey_questions, 'parentQuestion', 'parentQuestionId');
-UPDATE projects SET survey_questions = survey_rename_key(survey_questions, 'parentAnswer', 'parentAnswerId');

--- a/src/sql/changes/update_2021-12-23_transform_survey_questions.sql
+++ b/src/sql/changes/update_2021-12-23_transform_survey_questions.sql
@@ -48,3 +48,19 @@ $$ LANGUAGE SQL;
 ALTER TABLE projects ADD COLUMN sq_bk jsonb;
 UPDATE projects SET sq_bk = survey_questions;
 UPDATE projects SET survey_questions = survey_reduce(survey_questions);
+
+CREATE OR REPLACE FUNCTION survey_rename_key(_questions jsonb, _from text, _to text)
+ RETURNS jsonb AS $$
+
+    SELECT jsonb_object_agg(
+        key, jsonb_set(value, ('{"' || _to || '"}')::text[], value->_from) - _from
+    )
+    FROM (
+        SELECT key, value
+        FROM jsonb_each(_questions)
+    ) a
+
+$$ LANGUAGE SQL;
+
+UPDATE projects SET survey_questions = survey_rename_key(survey_questions, 'parentQuestion', 'parentQuestionId');
+UPDATE projects SET survey_questions = survey_rename_key(survey_questions, 'parentAnswer', 'parentAnswerId');

--- a/src/sql/changes/update_2021-12-29_rename_survey_keys.sql
+++ b/src/sql/changes/update_2021-12-29_rename_survey_keys.sql
@@ -1,0 +1,15 @@
+CREATE OR REPLACE FUNCTION survey_rename_key(_questions jsonb, _from text, _to text)
+ RETURNS jsonb AS $$
+
+    SELECT jsonb_object_agg(
+        key, jsonb_set(value, ('{"' || _to || '"}')::text[], value->_from) - _from
+    )
+    FROM (
+        SELECT key, value
+        FROM jsonb_each(_questions)
+    ) a
+
+$$ LANGUAGE SQL;
+
+UPDATE projects SET survey_questions = survey_rename_key(survey_questions, 'parentQuestion', 'parentQuestionId');
+UPDATE projects SET survey_questions = survey_rename_key(survey_questions, 'parentAnswer', 'parentAnswerId');


### PR DESCRIPTION
## Purpose
We reference "parentQuestion" as a question object, which conflicts with the key "parentQuestion" in the question object. Using "parentQuestionId" for the key will clear confusion.

## Testing
All survey pieces should work.

