### PR TITLE
CEO-361 Animate the help button on page load.

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -751,3 +751,16 @@ input:checked + .switch-slider:before {
   -ms-transform: translateX(16px);
   transform: translateX(16px);
 }
+
+/***********************/
+/* Help Icon Animation */
+/***********************/
+
+@keyframes glow {
+  from {
+    box-shadow: 0 0 15px -5px purple;
+  }
+  to {
+    box-shadow: 0 0 15px 5px purple;
+  }
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -757,8 +757,8 @@ input:checked + .switch-slider:before {
 /***********************/
 
 @keyframes glow {
-  from {
-    box-shadow: 0 0 15px -5px purple;
+  from, 50% {
+    box-shadow: none;
   }
   to {
     box-shadow: 0 0 15px 5px purple;

--- a/src/js/components/PageComponents.js
+++ b/src/js/components/PageComponents.js
@@ -246,7 +246,8 @@ export class NavigationBar extends React.Component {
                                 <div
                                     className="tooltip_wrapper"
                                     style={{
-                                        animation: "glow 1s 4 alternate",
+                                        animation: "glow 2s 6 alternate",
+                                        animationDelay: "1s",
                                         borderRadius: "2rem"
                                     }}
                                 >

--- a/src/js/components/PageComponents.js
+++ b/src/js/components/PageComponents.js
@@ -242,7 +242,23 @@ export class NavigationBar extends React.Component {
                             className="ml-3"
                             onClick={() => this.setState({showHelpMenu: true})}
                         >
-                            {this.state.helpSlides.length > 0 && <SvgIcon color="purple" cursor="pointer" icon="help" size="2rem"/>}
+                            {this.state.helpSlides.length > 0 && (
+                                <div
+                                    className="tooltip_wrapper"
+                                    style={{
+                                        animation: "glow 1s 4 alternate",
+                                        borderRadius: "2rem"
+                                    }}
+                                >
+                                    <SvgIcon
+                                        color="purple"
+                                        cursor="pointer"
+                                        icon="help"
+                                        size="2rem"
+                                    />
+                                    <span className="tooltip_content">Help</span>
+                                </div>
+                            )}
                         </div>
                     </div>
                 </nav>


### PR DESCRIPTION
## Purpose
Adds a glow animation to the help button on page load. The icon will "glow" 2 times.

## Related Issues
Closes CEO-361

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `CEO-### <title>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
Load a page with the help button. The button should "glow". 

## Screenshots
![Screenshot from 2022-01-07 10-21-36](https://user-images.githubusercontent.com/40574170/148589195-36a8dd94-3d39-46b5-80ad-efb1d3cc5573.png)


