### PR TITLE
Fixed a bug where Incompatible Answers rules didn't work.

### DIFF
--- a/src/js/project/SurveyRules.js
+++ b/src/js/project/SurveyRules.js
@@ -480,9 +480,9 @@ class IncompatibleAnswersForm extends React.Component {
                 + conflictingRule.id
                 + ")",
             (questionId1 === questionId2) && "You must select two different questions.",
-            questionId1 < 1 && "You must select a valid first question.",
-            questionId2 < 1 && "You must select a valid second question.",
-            (answerId1 < 1 || answerId2 < 1) && "You must select an answer for each question."
+            questionId1 < 0 && "You must select a valid first question.",
+            questionId2 < 0 && "You must select a valid second question.",
+            (answerId1 < 0 || answerId2 < 0) && "You must select an answer for each question."
         ].filter(m => m);
         if (errorMessages.length > 0) {
             alert(errorMessages.map(s => "- " + s).join("\n"));
@@ -501,8 +501,8 @@ class IncompatibleAnswersForm extends React.Component {
     };
 
     safeFindAnswers = questionId => {
-        const {question} = this.context.surveyQuestions[questionId];
-        return question.answers || {};
+        const {surveyQuestions} = this.context;
+        return questionId in surveyQuestions ? surveyQuestions[questionId].answers : {};
     };
 
     render() {


### PR DESCRIPTION
## Purpose
There were a few bugs with Incompatible Answers rules. The `IncompatibleAnswersForm` crashed the website when selected from the New Rule dropdown. You were also unable to create an Incompatible Answers rule with the first question that you had made (since it had an ID of 0).

## Submission Checklist
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
You should be able to create an Incompatible Answers rule now.


