### PR TITLE
Getting rid of the query params in GA

### DIFF
--- a/src/clj/collect_earth_online/views.clj
+++ b/src/clj/collect_earth_online/views.clj
@@ -23,7 +23,7 @@
    [:link {:rel "shortcut icon" :href "favicon.ico"}]
    (when-let [ga-id (get-config :ga-id)]
      (list [:script {:async true :src (str "https://www.googletagmanager.com/gtag/js?id=" ga-id)}]
-           [:script (str "window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', '" ga-id "');")]))
+           [:script (str "window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', '" ga-id "', {'page_location': location.host + location.pathname});")]))
    (include-css "/css/bootstrap.min.css")
    (apply include-js
           "/js/jquery-3.5.1.slim.min.js"


### PR DESCRIPTION
## Purpose
Gets rid of the query params in Google Analytics.
 

## Submission Checklist 
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
I added the GA ID for collect.earth to my local `config.edn` file and visited the institution review page a few times. I now see `/review-institution` as its own row: 
![Screenshot from 2022-01-13 14-43-32](https://user-images.githubusercontent.com/40574170/149420672-097c5e3a-5fef-4e7f-b96a-03da7c953d35.png)


