### PR TITLE
CEO-101 Add rule IDs and remove button to SurveyRuleCard.

### DIFF
--- a/src/js/components/SurveyRule.js
+++ b/src/js/components/SurveyRule.js
@@ -97,11 +97,21 @@ function TextMatchRuleBody({questionId, regex, surveyQuestions}) {
     );
 }
 
-function SurveyRuleCard({title, Body}) {
+function SurveyRuleCard({inDesignMode, removeButton, ruleOptions, title, Body}) {
     return (
         <div className="card" style={{width: "100%"}}>
             <div className="card-body pt-2 pb-3">
-                <h3>{title}</h3>
+                <div
+                    style={{
+                        alignItems: "baseline",
+                        display: "flex",
+                        flexDirection: "row",
+                        justifyContent: "space-between"
+                    }}
+                >
+                    <h3 style={{marginBottom: 0}}>{ruleOptions.id + 1}. {title}</h3>
+                    {inDesignMode && removeButton(ruleOptions.id)}
+                </div>
                 <hr style={{margin: "0.5rem 0"}}/>
                 <Body/>
             </div>
@@ -109,28 +119,43 @@ function SurveyRuleCard({title, Body}) {
     );
 }
 
-export default function SurveyRule({ruleOptions, surveyQuestions}) {
+export default function SurveyRule({inDesignMode, removeButton, ruleOptions, surveyQuestions}) {
     return (
         <div className="d-flex flex-column mb-1" style={{flex: 1}}>
             {{
                 "text-match": <SurveyRuleCard
                     Body={() => <TextMatchRuleBody {...ruleOptions} surveyQuestions={surveyQuestions}/>}
+                    inDesignMode={inDesignMode}
+                    removeButton={removeButton}
+                    ruleOptions={ruleOptions}
                     title="Text Match"
                 />,
                 "numeric-range": <SurveyRuleCard
                     Body={() => <NumericRangeRuleBody {...ruleOptions} surveyQuestions={surveyQuestions}/>}
+                    inDesignMode={inDesignMode}
+                    removeButton={removeButton}
+                    ruleOptions={ruleOptions}
                     title="Numeric Range"
                 />,
                 "sum-of-answers": <SurveyRuleCard
                     Body={() => <SumOfAnswersRuleBody {...ruleOptions} surveyQuestions={surveyQuestions}/>}
+                    inDesignMode={inDesignMode}
+                    removeButton={removeButton}
+                    ruleOptions={ruleOptions}
                     title="Sum of Answers"
                 />,
                 "matching-sums": <SurveyRuleCard
                     Body={() => <MatchingSumsRuleBody {...ruleOptions} surveyQuestions={surveyQuestions}/>}
+                    inDesignMode={inDesignMode}
+                    removeButton={removeButton}
+                    ruleOptions={ruleOptions}
                     title="Matching Sums"
                 />,
                 "incompatible-answers": <SurveyRuleCard
                     Body={() => <IncompatibleAnswersRuleBody {...ruleOptions} surveyQuestions={surveyQuestions}/>}
+                    inDesignMode={inDesignMode}
+                    removeButton={removeButton}
+                    ruleOptions={ruleOptions}
                     title="Incompatible Answers"
                 />
             }[ruleOptions.ruleType]}

--- a/src/js/project/SurveyCardList.js
+++ b/src/js/project/SurveyCardList.js
@@ -219,7 +219,7 @@ function SurveyQuestionTree({
                                                 && (
                                                     <li key={rule.id}>
                                                         <div className="tooltip_wrapper">
-                                                            {"Rule " + rule.id + ": " + rule.ruleType}
+                                                            {`Rule ${rule.id + 1}: ${rule.ruleType}`}
                                                             <span className="tooltip_content">
                                                                 {getRulesById(rule.id)}
                                                             </span>

--- a/src/js/project/SurveyRules.js
+++ b/src/js/project/SurveyRules.js
@@ -30,12 +30,12 @@ export class SurveyRulesList extends React.Component {
 
     removeButton = ruleId => (
         <button
-            className="btn btn-sm btn-outline-red mt-0 mr-3 mb-3"
+            className="btn btn-sm btn-outline-red"
             onClick={() => this.deleteSurveyRule(ruleId)}
             title="Delete Rule"
             type="button"
         >
-            <SvgIcon icon="trash" size="1.25rem"/>
+            <SvgIcon icon="trash" size="1rem"/>
         </button>
     );
 
@@ -43,8 +43,12 @@ export class SurveyRulesList extends React.Component {
         const {inDesignMode, surveyQuestions} = this.props;
         return (
             <div key={r.id} style={{display: "flex", alignItems: "center"}}>
-                {inDesignMode && this.removeButton(r.id)}
-                <SurveyRule ruleOptions={r} surveyQuestions={surveyQuestions}/>
+                <SurveyRule
+                    inDesignMode={inDesignMode}
+                    removeButton={this.removeButton}
+                    ruleOptions={r}
+                    surveyQuestions={surveyQuestions}
+                />
             </div>
         );
     };


### PR DESCRIPTION
## Purpose
Adds in rule IDs and an optional remove button the `SurveyRuleCard` component.

## Related Issues
Closes CEO-101

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `CEO-### <title>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
The remove button should only show up in the Project Wizard and it should work normally. Without moving around the questions after creating rules, the Rule number for each survey question should line up with the Rule IDs in each card in the Project Review page.

## Screenshots
![Screenshot from 2022-01-14 09-49-24](https://user-images.githubusercontent.com/40574170/149562179-9012f563-3110-4dd3-815e-4e1bb7a4de65.png)
![Screenshot from 2022-01-14 09-49-30](https://user-images.githubusercontent.com/40574170/149562183-8ae715d0-106e-4976-ac35-6cec5816fd79.png)


