### PR TITLE
CEO-410 Replace Rule tooltip with SurveyRule

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -458,6 +458,9 @@ a:hover {
     width: 500px;
     z-index: 1;
 }
+.tooltip_content.survey_rule::after {
+  border-color: transparent transparent white transparent;
+}
 
 /*************/
 /* Home Page */

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -443,6 +443,21 @@ a:hover {
     padding: 5px 5px 5px 25px;
     width: 300px;
 }
+.tooltip_content.survey_rule {
+    visibility: hidden;
+    background-color: transparent;
+    border-radius: 0;
+    color: #000000;
+    left: 0;
+    font-weight: normal;
+    max-width: max-content;
+    text-align: start;
+    padding: 0;
+    position: absolute;
+    top: 110%;
+    width: 500px;
+    z-index: 1;
+}
 
 /*************/
 /* Home Page */

--- a/src/js/components/SurveyRule.js
+++ b/src/js/components/SurveyRule.js
@@ -2,6 +2,7 @@ import React from "react";
 import _ from "lodash";
 
 import {truncate} from "../utils/generalUtils";
+import SvgIcon from "./svg/SvgIcon";
 
 function truncjoin(qs) {
     return qs.map(q => truncate(q, 15)).join(", ");
@@ -97,7 +98,7 @@ function TextMatchRuleBody({questionId, regex, surveyQuestions}) {
     );
 }
 
-function SurveyRuleCard({inDesignMode, removeButton, ruleOptions, title, Body}) {
+function SurveyRuleCard({inDesignMode, removeFn, ruleOptions, title, Body}) {
     return (
         <div className="card" style={{width: "100%"}}>
             <div className="card-body pt-2 pb-2">
@@ -110,7 +111,16 @@ function SurveyRuleCard({inDesignMode, removeButton, ruleOptions, title, Body}) 
                     }}
                 >
                     <h3 style={{marginBottom: 0}}>{ruleOptions.id + 1}. {title}</h3>
-                    {removeButton && inDesignMode && removeButton(ruleOptions.id)}
+                    {removeFn && inDesignMode && (
+                        <button
+                            className="btn btn-sm btn-outline-red"
+                            onClick={removeFn}
+                            title="Delete Rule"
+                            type="button"
+                        >
+                            <SvgIcon icon="trash" size="1rem"/>
+                        </button>
+                    )}
                 </div>
                 <hr style={{margin: "0.5rem 0"}}/>
                 <Body/>
@@ -119,42 +129,42 @@ function SurveyRuleCard({inDesignMode, removeButton, ruleOptions, title, Body}) 
     );
 }
 
-export default function SurveyRule({inDesignMode, removeButton, ruleOptions, surveyQuestions}) {
+export default function SurveyRule({inDesignMode, removeFn, ruleOptions, surveyQuestions}) {
     return (
         <div className="d-flex flex-column mb-1" style={{flex: 1}}>
             {{
                 "text-match": <SurveyRuleCard
                     Body={() => <TextMatchRuleBody {...ruleOptions} surveyQuestions={surveyQuestions}/>}
                     inDesignMode={inDesignMode}
-                    removeButton={removeButton}
+                    removeFn={removeFn}
                     ruleOptions={ruleOptions}
                     title="Text Match"
                 />,
                 "numeric-range": <SurveyRuleCard
                     Body={() => <NumericRangeRuleBody {...ruleOptions} surveyQuestions={surveyQuestions}/>}
                     inDesignMode={inDesignMode}
-                    removeButton={removeButton}
+                    removeFn={removeFn}
                     ruleOptions={ruleOptions}
                     title="Numeric Range"
                 />,
                 "sum-of-answers": <SurveyRuleCard
                     Body={() => <SumOfAnswersRuleBody {...ruleOptions} surveyQuestions={surveyQuestions}/>}
                     inDesignMode={inDesignMode}
-                    removeButton={removeButton}
+                    removeFn={removeFn}
                     ruleOptions={ruleOptions}
                     title="Sum of Answers"
                 />,
                 "matching-sums": <SurveyRuleCard
                     Body={() => <MatchingSumsRuleBody {...ruleOptions} surveyQuestions={surveyQuestions}/>}
                     inDesignMode={inDesignMode}
-                    removeButton={removeButton}
+                    removeFn={removeFn}
                     ruleOptions={ruleOptions}
                     title="Matching Sums"
                 />,
                 "incompatible-answers": <SurveyRuleCard
                     Body={() => <IncompatibleAnswersRuleBody {...ruleOptions} surveyQuestions={surveyQuestions}/>}
                     inDesignMode={inDesignMode}
-                    removeButton={removeButton}
+                    removeFn={removeFn}
                     ruleOptions={ruleOptions}
                     title="Incompatible Answers"
                 />

--- a/src/js/components/SurveyRule.js
+++ b/src/js/components/SurveyRule.js
@@ -100,7 +100,7 @@ function TextMatchRuleBody({questionId, regex, surveyQuestions}) {
 function SurveyRuleCard({inDesignMode, removeButton, ruleOptions, title, Body}) {
     return (
         <div className="card" style={{width: "100%"}}>
-            <div className="card-body pt-2 pb-3">
+            <div className="card-body pt-2 pb-2">
                 <div
                     style={{
                         alignItems: "baseline",
@@ -110,7 +110,7 @@ function SurveyRuleCard({inDesignMode, removeButton, ruleOptions, title, Body}) 
                     }}
                 >
                     <h3 style={{marginBottom: 0}}>{ruleOptions.id + 1}. {title}</h3>
-                    {inDesignMode && removeButton(ruleOptions.id)}
+                    {removeButton && inDesignMode && removeButton(ruleOptions.id)}
                 </div>
                 <hr style={{margin: "0.5rem 0"}}/>
                 <Body/>

--- a/src/js/components/SurveyRule.js
+++ b/src/js/components/SurveyRule.js
@@ -98,7 +98,7 @@ function TextMatchRuleBody({questionId, regex, surveyQuestions}) {
     );
 }
 
-function SurveyRuleCard({inDesignMode, removeFn, ruleOptions, title, Body}) {
+function SurveyRuleCard({inDesignMode, removeRule, ruleOptions, title, Body}) {
     return (
         <div className="card" style={{width: "100%"}}>
             <div className="card-body pt-2 pb-2">
@@ -111,10 +111,10 @@ function SurveyRuleCard({inDesignMode, removeFn, ruleOptions, title, Body}) {
                     }}
                 >
                     <h3 style={{marginBottom: 0}}>{ruleOptions.id + 1}. {title}</h3>
-                    {removeFn && inDesignMode && (
+                    {removeRule && inDesignMode && (
                         <button
                             className="btn btn-sm btn-outline-red"
-                            onClick={removeFn}
+                            onClick={removeRule}
                             title="Delete Rule"
                             type="button"
                         >
@@ -129,42 +129,42 @@ function SurveyRuleCard({inDesignMode, removeFn, ruleOptions, title, Body}) {
     );
 }
 
-export default function SurveyRule({inDesignMode, removeFn, ruleOptions, surveyQuestions}) {
+export default function SurveyRule({inDesignMode, removeRule, ruleOptions, surveyQuestions}) {
     return (
         <div className="d-flex flex-column mb-1" style={{flex: 1}}>
             {{
                 "text-match": <SurveyRuleCard
                     Body={() => <TextMatchRuleBody {...ruleOptions} surveyQuestions={surveyQuestions}/>}
                     inDesignMode={inDesignMode}
-                    removeFn={removeFn}
+                    removeRule={removeRule}
                     ruleOptions={ruleOptions}
                     title="Text Match"
                 />,
                 "numeric-range": <SurveyRuleCard
                     Body={() => <NumericRangeRuleBody {...ruleOptions} surveyQuestions={surveyQuestions}/>}
                     inDesignMode={inDesignMode}
-                    removeFn={removeFn}
+                    removeRule={removeRule}
                     ruleOptions={ruleOptions}
                     title="Numeric Range"
                 />,
                 "sum-of-answers": <SurveyRuleCard
                     Body={() => <SumOfAnswersRuleBody {...ruleOptions} surveyQuestions={surveyQuestions}/>}
                     inDesignMode={inDesignMode}
-                    removeFn={removeFn}
+                    removeRule={removeRule}
                     ruleOptions={ruleOptions}
                     title="Sum of Answers"
                 />,
                 "matching-sums": <SurveyRuleCard
                     Body={() => <MatchingSumsRuleBody {...ruleOptions} surveyQuestions={surveyQuestions}/>}
                     inDesignMode={inDesignMode}
-                    removeFn={removeFn}
+                    removeRule={removeRule}
                     ruleOptions={ruleOptions}
                     title="Matching Sums"
                 />,
                 "incompatible-answers": <SurveyRuleCard
                     Body={() => <IncompatibleAnswersRuleBody {...ruleOptions} surveyQuestions={surveyQuestions}/>}
                     inDesignMode={inDesignMode}
-                    removeFn={removeFn}
+                    removeRule={removeRule}
                     ruleOptions={ruleOptions}
                     title="Incompatible Answers"
                 />

--- a/src/js/project/SurveyCardList.js
+++ b/src/js/project/SurveyCardList.js
@@ -1,6 +1,7 @@
 import React from "react";
 import _ from "lodash";
 
+import SurveyRule from "../components/SurveyRule";
 import SvgIcon from "../components/svg/SvgIcon";
 import {removeEnumerator} from "../utils/generalUtils";
 import {mapObject, mapObjectArray, filterObject} from "../utils/sequence";
@@ -62,34 +63,6 @@ class SurveyCard extends React.Component {
         return _.get(surveyQuestions, [questionId, "answers", answerId, "answer"], "");
     };
 
-    getRulesById = id => (this.props.surveyRules || [])
-        .filter(r => r.id === id)
-        .map(r => {
-            if (r.ruleType === "text-match") {
-                return `Question '${this.getSurveyQuestionText(r.questionId)}' should match the pattern: ${r.regex}.`;
-            } else if (r.ruleType === "numeric-range") {
-                return `Question '${this.getSurveyQuestionText(r.questionId)}' should be between ${r.min} and ${r.max}.`;
-            } else if (r.ruleType === "sum-of-answers") {
-                return `Questions '${r.questionIds.map(q => this.getSurveyQuestionText(q))}' should sum up to ${r.validSum}.`;
-            } else if (r.ruleType === "matching-sums") {
-                return `Sum of '[${
-                    r.questionIds1.map(q => this.getSurveyQuestionText(q)).toString()
-                }]' should be equal to sum of '[${
-                    r.questionIds2.map(q => this.getSurveyQuestionText(q)).toString()
-                }]'.`;
-            } else {
-                return `Question1: '${
-                    this.getSurveyQuestionText(r.questionId1)
-                }', Answer1: '${
-                    this.getSurveyAnswerText(r.questionId1, r.answerId1)
-                }' is not compatible with Question2: '${
-                    this.getSurveyQuestionText(r.questionId2)
-                }', Answer2: '${
-                    this.getSurveyAnswerText(r.questionId2, r.answerId2)
-                }'.`;
-            }
-        });
-
     render() {
         const {cardNumber, surveyQuestions, surveyQuestionId, inDesignMode, topLevelNodeIds} = this.props;
         const {question} = surveyQuestions[surveyQuestionId];
@@ -140,7 +113,6 @@ class SurveyCard extends React.Component {
                         <div className="SurveyCard__question-tree row d-block">
                             <SurveyQuestionTree
                                 key={this.props.surveyQuestionId}
-                                getRulesById={this.getRulesById}
                                 indentLevel={0}
                                 inDesignMode={this.props.inDesignMode}
                                 newAnswerComponent={this.props.newAnswerComponent}
@@ -166,8 +138,7 @@ function SurveyQuestionTree({
     removeQuestion,
     surveyQuestionId,
     surveyQuestions,
-    surveyRules,
-    getRulesById
+    surveyRules
 }) {
     const surveyQuestion = surveyQuestions[surveyQuestionId];
     const childNodeIds = mapObjectArray(
@@ -208,25 +179,23 @@ function SurveyQuestionTree({
                             )}
                             {surveyRules && surveyRules.length > 0 && (
                                 <li>
-                                    <span className="font-weight-bold">Rules:  </span>
-                                    <ul>
-                                        {surveyRules.map(rule =>
-                                            [rule.questionId, rule.questionId1, rule.questionId2]
-                                                .concat(rule.questionIds)
-                                                .concat(rule.questionIds1)
-                                                .concat(rule.questionIds2)
-                                                .includes(surveyQuestionId)
+                                    <b>Rules:</b>
+                                    {surveyRules.map(rule => {
+                                        const allIds = new Set([rule.questionId, rule.questionId1, rule.questionId2]
+                                            .concat(rule.questionIds)
+                                            .concat(rule.questionIds1)
+                                            .concat(rule.questionIds2));
+                                        return allIds.has(surveyQuestionId)
                                                 && (
-                                                    <li key={rule.id}>
-                                                        <div className="tooltip_wrapper">
-                                                            {`Rule ${rule.id + 1}: ${rule.ruleType}`}
-                                                            <span className="tooltip_content">
-                                                                {getRulesById(rule.id)}
-                                                            </span>
-                                                        </div>
-                                                    </li>
-                                                ))}
-                                    </ul>
+                                                    <div key={rule.id}>
+                                                        <SurveyRule
+                                                            inDesignMode={inDesignMode}
+                                                            ruleOptions={rule}
+                                                            surveyQuestions={surveyQuestions}
+                                                        />
+                                                    </div>
+                                                );
+                                    })}
                                 </li>
                             )}
                             {parentQuestion && (
@@ -267,7 +236,6 @@ function SurveyQuestionTree({
             {childNodeIds.map(childId => (
                 <SurveyQuestionTree
                     key={childId}
-                    getRulesById={getRulesById}
                     indentLevel={indentLevel + 1}
                     inDesignMode={inDesignMode}
                     newAnswerComponent={newAnswerComponent}

--- a/src/js/project/SurveyCardList.js
+++ b/src/js/project/SurveyCardList.js
@@ -118,6 +118,7 @@ class SurveyCard extends React.Component {
                                 newAnswerComponent={this.props.newAnswerComponent}
                                 removeAnswer={this.props.removeAnswer}
                                 removeQuestion={this.props.removeQuestion}
+                                setProjectDetails={this.props.setProjectDetails}
                                 surveyQuestionId={this.props.surveyQuestionId}
                                 surveyQuestions={this.props.surveyQuestions}
                                 surveyRules={this.props.surveyRules}
@@ -136,6 +137,7 @@ function SurveyQuestionTree({
     newAnswerComponent,
     removeAnswer,
     removeQuestion,
+    setProjectDetails,
     surveyQuestionId,
     surveyQuestions,
     surveyRules
@@ -146,6 +148,10 @@ function SurveyQuestionTree({
         ([key, _val]) => Number(key)
     );
     const parentQuestion = surveyQuestions[surveyQuestion.parentQuestionId];
+    const deleteSurveyRule = ruleId => {
+        const newSurveyRules = surveyRules.filter(rule => rule.id !== ruleId);
+        setProjectDetails({surveyRules: newSurveyRules});
+    };
     return (
         <>
             <div className="SurveyQuestionTree__question d-flex border-top pt-3 pb-1">
@@ -181,12 +187,12 @@ function SurveyQuestionTree({
                                 <li>
                                     <b>Rules:</b>
                                     <ul>
-                                        {surveyRules.map(rule => {
-                                            const allIds = new Set([rule.questionId, rule.questionId1, rule.questionId2]
+                                        {surveyRules.map(rule =>
+                                            [rule.questionId, rule.questionId1, rule.questionId2]
                                                 .concat(rule.questionIds)
                                                 .concat(rule.questionIds1)
-                                                .concat(rule.questionIds2));
-                                            return allIds.has(surveyQuestionId)
+                                                .concat(rule.questionIds2)
+                                                .includes(surveyQuestionId)
                                                 && (
                                                     <li key={rule.id}>
                                                         <div className="tooltip_wrapper">
@@ -194,14 +200,14 @@ function SurveyQuestionTree({
                                                             <div className="tooltip_content survey_rule">
                                                                 <SurveyRule
                                                                     inDesignMode={inDesignMode}
+                                                                    removeFn={() => deleteSurveyRule(rule.id)}
                                                                     ruleOptions={rule}
                                                                     surveyQuestions={surveyQuestions}
                                                                 />
                                                             </div>
                                                         </div>
                                                     </li>
-                                                );
-                                        })}
+                                                ))}
                                     </ul>
                                 </li>
                             )}

--- a/src/js/project/SurveyCardList.js
+++ b/src/js/project/SurveyCardList.js
@@ -180,22 +180,29 @@ function SurveyQuestionTree({
                             {surveyRules && surveyRules.length > 0 && (
                                 <li>
                                     <b>Rules:</b>
-                                    {surveyRules.map(rule => {
-                                        const allIds = new Set([rule.questionId, rule.questionId1, rule.questionId2]
-                                            .concat(rule.questionIds)
-                                            .concat(rule.questionIds1)
-                                            .concat(rule.questionIds2));
-                                        return allIds.has(surveyQuestionId)
+                                    <ul>
+                                        {surveyRules.map(rule => {
+                                            const allIds = new Set([rule.questionId, rule.questionId1, rule.questionId2]
+                                                .concat(rule.questionIds)
+                                                .concat(rule.questionIds1)
+                                                .concat(rule.questionIds2));
+                                            return allIds.has(surveyQuestionId)
                                                 && (
-                                                    <div key={rule.id}>
-                                                        <SurveyRule
-                                                            inDesignMode={inDesignMode}
-                                                            ruleOptions={rule}
-                                                            surveyQuestions={surveyQuestions}
-                                                        />
-                                                    </div>
+                                                    <li key={rule.id}>
+                                                        <div className="tooltip_wrapper">
+                                                            {`Rule ${rule.id + 1}: ${rule.ruleType}`}
+                                                            <div className="tooltip_content survey_rule">
+                                                                <SurveyRule
+                                                                    inDesignMode={inDesignMode}
+                                                                    ruleOptions={rule}
+                                                                    surveyQuestions={surveyQuestions}
+                                                                />
+                                                            </div>
+                                                        </div>
+                                                    </li>
                                                 );
-                                    })}
+                                        })}
+                                    </ul>
                                 </li>
                             )}
                             {parentQuestion && (

--- a/src/js/project/SurveyCardList.js
+++ b/src/js/project/SurveyCardList.js
@@ -200,7 +200,7 @@ function SurveyQuestionTree({
                                                             <div className="tooltip_content survey_rule">
                                                                 <SurveyRule
                                                                     inDesignMode={inDesignMode}
-                                                                    removeFn={() => deleteSurveyRule(rule.id)}
+                                                                    removeRule={() => deleteSurveyRule(rule.id)}
                                                                     ruleOptions={rule}
                                                                     surveyQuestions={surveyQuestions}
                                                                 />

--- a/src/js/project/SurveyRules.js
+++ b/src/js/project/SurveyRules.js
@@ -34,7 +34,7 @@ export class SurveyRulesList extends React.Component {
             <div key={r.id} style={{display: "flex", alignItems: "center"}}>
                 <SurveyRule
                     inDesignMode={inDesignMode}
-                    removeFn={() => this.deleteSurveyRule(r.id)}
+                    removeRule={() => this.deleteSurveyRule(r.id)}
                     ruleOptions={r}
                     surveyQuestions={surveyQuestions}
                 />

--- a/src/js/project/SurveyRules.js
+++ b/src/js/project/SurveyRules.js
@@ -28,24 +28,13 @@ export class SurveyRulesList extends React.Component {
         this.props.setProjectDetails({surveyRules: newSurveyRules});
     };
 
-    removeButton = ruleId => (
-        <button
-            className="btn btn-sm btn-outline-red"
-            onClick={() => this.deleteSurveyRule(ruleId)}
-            title="Delete Rule"
-            type="button"
-        >
-            <SvgIcon icon="trash" size="1rem"/>
-        </button>
-    );
-
     renderRuleRow = r => {
         const {inDesignMode, surveyQuestions} = this.props;
         return (
             <div key={r.id} style={{display: "flex", alignItems: "center"}}>
                 <SurveyRule
                     inDesignMode={inDesignMode}
-                    removeButton={this.removeButton}
+                    removeFn={() => this.deleteSurveyRule(r.id)}
                     ruleOptions={r}
                     surveyQuestions={surveyQuestions}
                 />


### PR DESCRIPTION
## Purpose
Replaces the tooltip content from each Survey Question Card and replaces it with a SurveyRule component. Small clean up with the logic for checking if a specific question includes a rule.
  
## Related Issues
Closes CEO-410

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `CEO-### <title>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
When looking in the "Rules" section of a survey card and hovering over a Rule, you should see the Rule Card as a tooltip.

## Screenshots

![Screenshot from 2022-01-14 14-45-35](https://user-images.githubusercontent.com/40574170/149595141-7522d5b9-0258-44bc-9a9d-94973305a160.png)



