### PR TITLE
CEO-421 Fixing bugs with Rules when reordering questions.

### DIFF
--- a/src/js/utils/sequence.js
+++ b/src/js/utils/sequence.js
@@ -34,6 +34,20 @@ export function removeAtIndex(arr, index) {
     return arr.slice(0, index).concat(arr.slice(index + 1, arr.length));
 }
 
+/**
+* Replaces the given number in an array with a new value
+* @param {array} array
+* @param {number} numToReplace
+* @param {number} newNum
+* @returns {array}
+*/
+export function replaceNumber(arr, numToReplace, newNum) {
+    if (arr.includes(numToReplace)) {
+        const idx = arr.indexOf(numToReplace);
+        return arr.slice(0, idx).concat(newNum, arr.slice(idx + 1, arr.length));
+    } else return arr;
+}
+
 /// Set Functions ///
 
 // set.delete is in place.  This function will then return the set so it can be referenced.


### PR DESCRIPTION
## Purpose
Fixes an old bug where swapping the order of survey questions in the Project Wizards wouldn't swap the rules properly. This would break any existing rules if a survey question was reordered, since it would always point to the same question ID/index. This PR adds code such that the question IDs inside of the `surveyRules` are updated properly every time a question is reordered in the Project Wizard.

## Related Issues
Closes CEO-421

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `CEO-### <title>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
1. Create a new project with many different survey questions.
2. Create at least one rule of each type.
3. In the Project Wizard, use the up and down buttons to reorder the questions a bunch of times.
4. Each rule should stay attached to the question it is meant for.

