### PR TITLE
WIP CEO-360 Tour demo using React Joyride.

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
         "react": "^16.13.1",
         "react-dom": "^16.13.1",
         "react-grid-layout": "^1.3.0",
+        "react-joyride": "^2.3.2",
         "react-required-if": "^1.0.3"
     },
     "devDependencies": {

--- a/src/js/components/PageComponents.js
+++ b/src/js/components/PageComponents.js
@@ -245,6 +245,7 @@ export class NavigationBar extends React.Component {
                             {this.state.helpSlides.length > 0 && (
                                 <div
                                     className="tooltip_wrapper"
+                                    id="helpButton"
                                     style={{
                                         animation: "glow 2s 6 alternate",
                                         animationDelay: "1s",

--- a/src/js/home.js
+++ b/src/js/home.js
@@ -1,5 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom";
+import Joyride from "react-joyride";
 import {LoadingModal, NavigationBar} from "./components/PageComponents";
 import {mercator} from "./utils/mercator";
 import {sortAlphabetically} from "./utils/generalUtils";
@@ -244,7 +245,7 @@ class SideBar extends React.Component {
     render() {
         return this.props.showSidePanel && (
             <div
-                className="col-lg-3 pr-0 pl-0 overflow-hidden full-height d-flex flex-column"
+                className="first-step col-lg-3 pr-0 pl-0 overflow-hidden full-height d-flex flex-column"
                 id="lPanel"
             >
                 {(this.props.userRole === "admin" || this.props.userId === -1) && (
@@ -696,17 +697,65 @@ class ProjectPopup extends React.Component {
 }
 
 export function pageInit(args) {
+    const steps = [
+        {
+            target: "body",
+            placement: "center",
+            title: "React Joyride",
+            content: "Welcome to the tour of CEO!",
+            locale: {skip: <strong aria-label="skip">Skip Tour</strong>}
+        },
+        {
+            target: "#filter-institution",
+            styles: {
+                options: {
+                    backgroundColor: "#31bab0"
+                }
+            },
+            content: (
+                <div>
+                    <h2>Step Number 2</h2>
+                    <span>
+                    You can imbed
+                        <b> JSX </b>
+                    inside the content of each step, such as:
+                        <ul>
+                            <li>Lists</li>
+                            <li>
+                                <a href="/" style={{color: "blue"}}>Links</a>
+                            </li>
+                            <li><i>And more!</i></li>
+                        </ul>
+                    </span>
+                </div>
+            )
+        },
+        {
+            target: "#helpButton",
+            content: "Here's the help button!",
+            title: "Last Step"
+        }
+    ];
+
     ReactDOM.render(
-        <NavigationBar
-            userId={args.userId}
-            userName={args.userName}
-            version={args.version}
-        >
-            <Home
-                userId={args.userId || -1}
-                userRole={args.userRole || ""}
+        <>
+            <Joyride
+                continuous
+                showProgress
+                showSkipButton
+                steps={steps}
             />
-        </NavigationBar>,
+            <NavigationBar
+                userId={args.userId}
+                userName={args.userName}
+                version={args.version}
+            >
+                <Home
+                    userId={args.userId || -1}
+                    userRole={args.userRole || ""}
+                />
+            </NavigationBar>
+        </>,
         document.getElementById("app")
     );
 }


### PR DESCRIPTION
## Purpose
Adds a basic demo of using the React Joyride package. Including this plugin adds exactly 100kb to the `home` page (697kb -> 797kb). [React Joyride](https://github.com/gilbarbara/react-joyride) uses the MIT license. This package is great because you can include JSX as the content of each step, which many other packages do not offer. You also have lots of control over custom styling of the tour. Note that this tour runs automatically when you open the home page, but you can also have it run after a custom event. See the [React Joyride demo website](https://react-joyride.com/) for more options.

## Related Issues
Closes CEO-360

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `CEO-### <title>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
The tour should load upon visiting the home page.

## Screenshots
![Screenshot from 2022-01-19 18-27-53](https://user-images.githubusercontent.com/40574170/150262247-7979549c-2332-47f2-b6e5-3e820c255d52.png)


![Screenshot from 2022-01-19 18-27-57](https://user-images.githubusercontent.com/40574170/150262212-e7df50f7-e06e-459a-a863-43fd73754945.png)

![Screenshot from 2022-01-19 18-28-03](https://user-images.githubusercontent.com/40574170/150262712-dde343b1-1660-4c81-bb44-62e3cf6c3d8b.png)

