### PR TITLE
CEO-407 Use airbnb-prop-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
         "@babel/plugin-transform-runtime": "^7.16.0",
         "@ckeditor/ckeditor5-build-classic": "^19.0.0",
         "@ckeditor/ckeditor5-react": "^2.1.0",
+        "airbnb-prop-types": "^2.16.0",
         "highcharts": "^9.1.0",
         "highcharts-react-official": "^3.0.0",
         "lodash": "^4.17.20",
@@ -67,8 +68,7 @@
         "prop-types": "^15.7.2",
         "react": "^16.13.1",
         "react-dom": "^16.13.1",
-        "react-grid-layout": "^1.3.0",
-        "react-required-if": "^1.0.3"
+        "react-grid-layout": "^1.3.0"
     },
     "devDependencies": {
         "@babel/core": "^7.11.6",

--- a/src/js/components/Modal.js
+++ b/src/js/components/Modal.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import requiredIf from "react-required-if";
+import {requiredBy} from "airbnb-prop-types";
 
 /**
  * Component for a generic modal.
@@ -74,7 +74,7 @@ export default function Modal({title, danger, children, closeText, confirmText, 
 
 Modal.propTypes = {
     closeText: PropTypes.string,
-    confirmText: requiredIf(PropTypes.string, props => typeof props.onConfirm === "function"),
+    confirmText: requiredBy("onConfirm", PropTypes.string),
     onClose: PropTypes.func.isRequired,
     onConfirm: PropTypes.func,
     title: PropTypes.string.isRequired


### PR DESCRIPTION
## Purpose
Gets rid of `react-required-if` in place of `airbnb-prop-types`. Note that using the `airbnb-prop-types` package doesn't change our use of `PropTypes`. It simply adds a nice suite of custom `PropType` validators.  

## Related Issues
Closes CEO-407

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `CEO-### <title>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
Delete the `confirmText` prop from `reviewInstitution.js/showDeleteImageryWarning` (line 525). Then try to delete an imagery. You should get an error in the console complaining about the prop type.

