### PR TITLE
CEO-100 Allow users to select multiple parent answers

### DIFF
--- a/src/js/collection.js
+++ b/src/js/collection.js
@@ -802,7 +802,7 @@ class Collection extends React.Component {
 
     calcVisibleSamples = currentQuestionId => {
         const {currentProject: {surveyQuestions}, userSamples} = this.state;
-        const {parentQuestionId, parentAnswerId} = surveyQuestions[currentQuestionId];
+        const {parentQuestionId, parentAnswerIds} = surveyQuestions[currentQuestionId];
 
         if (parentQuestionId === -1) {
             return this.state.currentPlot.samples;
@@ -810,7 +810,8 @@ class Collection extends React.Component {
             return this.calcVisibleSamples(parentQuestionId)
                 .filter(sample => {
                     const sampleAnswerId = _.get(userSamples, [sample.id, parentQuestionId, "answerId"]);
-                    return sampleAnswerId != null && (parentAnswerId === -1 || parentAnswerId === sampleAnswerId);
+                    return sampleAnswerId != null
+                        && (parentAnswerIds.length === 0 || parentAnswerIds.includes(sampleAnswerId));
                 });
         }
     };

--- a/src/js/simpleCollection.js
+++ b/src/js/simpleCollection.js
@@ -572,7 +572,7 @@ class SimpleCollection extends React.Component {
 
     calcVisibleSamples = currentQuestionId => {
         const {currentProject: {surveyQuestions}, userSamples} = this.state;
-        const {parentQuestionId, parentAnswerId} = surveyQuestions[currentQuestionId];
+        const {parentQuestionId, parentAnswerIds} = surveyQuestions[currentQuestionId];
 
         if (parentQuestionId === -1) {
             return this.state.currentPlot.samples;
@@ -580,7 +580,8 @@ class SimpleCollection extends React.Component {
             return this.calcVisibleSamples(parentQuestionId)
                 .filter(sample => {
                     const sampleAnswerId = _.get(userSamples, [sample.id, parentQuestionId, "answerId"]);
-                    return sampleAnswerId && (parentAnswerId === -1 || parentAnswerId === sampleAnswerId);
+                    return sampleAnswerId != null
+                        && (parentAnswerIds.length === 0 || parentAnswerIds.includes(sampleAnswerId));
                 });
         }
     };

--- a/src/js/survey/AnswerDesigner.js
+++ b/src/js/survey/AnswerDesigner.js
@@ -19,7 +19,7 @@ export default class AnswerDesigner extends React.Component {
         const {surveyQuestions, setProjectDetails} = this.context;
         const matchingQuestion = findObject(
             surveyQuestions,
-            ([_id, sq]) => sq.parentQuestionId === surveyQuestionId && sq.parentAnswerId === answerId
+            ([_id, sq]) => sq.parentQuestionId === surveyQuestionId && sq.parentAnswerIds.includes(answerId)
         );
         if (matchingQuestion) {
             alert(

--- a/src/js/survey/NewQuestionDesigner.js
+++ b/src/js/survey/NewQuestionDesigner.js
@@ -22,7 +22,7 @@ export default class NewQuestionDesigner extends React.Component {
         ];
 
         this.state = {
-            selectedAnswerId: -1,
+            selectedAnswerIds: [],
             selectedParentId: -1,
             selectedType: 0,
             newQuestionText: ""
@@ -39,13 +39,13 @@ export default class NewQuestionDesigner extends React.Component {
 
         if (this.state.selectedParentId !== prevState.selectedParentId) {
             // eslint-disable-next-line react/no-did-update-set-state
-            this.setState({selectedAnswerId: -1});
+            this.setState({selectedAnswerIds: []});
         }
     }
 
     addSurveyQuestion = () => {
         if (this.state.newQuestionText !== "") {
-            const {selectedType, newQuestionText, selectedParentId, selectedAnswerId} = this.state;
+            const {selectedType, newQuestionText, selectedParentId, selectedAnswerIds} = this.state;
             const {surveyQuestions, setProjectDetails} = this.props;
             const {dataType, componentType} = this.componentTypes[selectedType];
             const repeatedQuestions = lengthObject(filterObject(
@@ -63,12 +63,12 @@ export default class NewQuestionDesigner extends React.Component {
                         : newQuestionText,
                     answers: {},
                     parentQuestionId: selectedParentId,
-                    parentAnswerId: selectedAnswerId,
+                    parentAnswerIds: selectedAnswerIds,
                     dataType,
                     componentType
                 };
                 setProjectDetails({surveyQuestions: {...surveyQuestions, [newId]: newQuestion}});
-                this.setState({selectedAnswerId: -1, newQuestionText: ""});
+                this.setState({selectedAnswerIds: [], newQuestionText: ""});
             }
         } else {
             alert("Please enter a survey question first.");
@@ -132,17 +132,17 @@ export default class NewQuestionDesigner extends React.Component {
                     </tr>
                     <tr>
                         <td>
-                            <label htmlFor="value-answer">Parent Answer:</label>
+                            <label htmlFor="value-answer">Parent Answers:</label>
                         </td>
                         <td>
                             <select
-                                className="form-control form-control-sm"
-                                id="value-answer"
-                                onChange={e => this.setState({selectedAnswerId: parseInt(e.target.value)})}
-                                size="1"
-                                value={this.state.selectedAnswerId}
+                                className="form-control form-control-sm overflow-auto"
+                                multiple="multiple"
+                                onChange={e => this.setState({
+                                    selectedAnswerIds: Array.from(e.target.selectedOptions, i => Number(i.value))
+                                })}
+                                value={this.state.selectedAnswerIds}
                             >
-                                <option key={-1} value={-1}>Any</option>
                                 {mapObjectArray(
                                     parentAnswers,
                                     ([answerId, answer]) => (

--- a/src/js/survey/SurveyCollectionPreview.js
+++ b/src/js/survey/SurveyCollectionPreview.js
@@ -46,7 +46,7 @@ export default class SurveyCollectionPreview extends React.Component {
     calcVisibleSamples = currentQuestionId => {
         const {surveyQuestions} = this.context;
         const {userSamples} = this.state;
-        const {parentQuestionId, parentAnswerId} = surveyQuestions[currentQuestionId];
+        const {parentQuestionId, parentAnswerIds} = surveyQuestions[currentQuestionId];
 
         if (parentQuestionId === -1) {
             return [{id: 1}];
@@ -54,7 +54,8 @@ export default class SurveyCollectionPreview extends React.Component {
             return this.calcVisibleSamples(parentQuestionId)
                 .filter(sample => {
                     const sampleAnswerId = _.get(userSamples, [sample.id, parentQuestionId, "answerId"]);
-                    return sampleAnswerId != null && (parentAnswerId === -1 || parentAnswerId === sampleAnswerId);
+                    return sampleAnswerId != null
+                        && (parentAnswerIds.length === 0 || parentAnswerIds.includes(sampleAnswerId));
                 });
         }
     };

--- a/src/js/survey/SurveyDesignQuestion.js
+++ b/src/js/survey/SurveyDesignQuestion.js
@@ -145,10 +145,12 @@ export default function SurveyDesignQuestion({indentLevel, inDesignMode, surveyQ
                                             : removeEnumerator(parentQuestion.question)}
                                     </li>
                                     <li>
-                                        <span className="font-weight-bold">Parent Answer: </span>
-                                        {surveyQuestion.parentAnswerId === -1
+                                        <span className="font-weight-bold">Parent Answers: </span>
+                                        {surveyQuestion.parentAnswerIds.length === 0
                                             ? "Any"
-                                            : parentQuestion.answers[surveyQuestion.parentAnswerId].answer}
+                                            : surveyQuestion.parentAnswerIds
+                                                .map(paId => parentQuestion.answers[paId].answer)
+                                                .join(", ")}
                                     </li>
                                 </>
                             )}

--- a/src/sql/changes/update_2022-01-24_parent_answers_array.sql
+++ b/src/sql/changes/update_2022-01-24_parent_answers_array.sql
@@ -1,0 +1,24 @@
+CREATE OR REPLACE FUNCTION survey_answer_array(_questions jsonb)
+ RETURNS jsonb AS $$
+
+    SELECT jsonb_object_agg(
+        key, jsonb_set(
+            value,
+            '{"parentAnswerId"}',
+            CASE WHEN value->>'parentAnswerId' = '-1' THEN
+                '[]'::jsonb
+            ELSE
+                jsonb_build_array(value->'parentAnswerId')
+            END
+        )
+    )
+    FROM (
+        SELECT key, value
+        FROM jsonb_each(_questions)
+    ) a
+
+$$ LANGUAGE SQL;
+
+UPDATE projects SET survey_questions = survey_answer_array(survey_questions);
+
+UPDATE projects SET survey_questions = survey_rename_key(survey_questions, 'parentAnswerId', 'parentAnswerIds');


### PR DESCRIPTION
## Purpose
Allow users to select multiple parent answers

## Testing
1. Create a project
2. Add a question with many answers
3. Add a child question and select some but not all of the answers
4. The survey preview and the collection survey should only show the child question for the selected parent answers

## Screenshots
![image](https://user-images.githubusercontent.com/33734037/150883280-057e0581-3c29-4b24-932e-5bdeb99ad57d.png)
![image](https://user-images.githubusercontent.com/33734037/150883307-19f1e9ab-d675-4d1d-8d69-7dc257c43866.png)


