### PR TITLE
CEO-368 Show running total for percent plot assignments.

### DIFF
--- a/README.org
+++ b/README.org
@@ -174,8 +174,8 @@ View the [[https://github.com/sig-gis/triangulum#triangulumhttps][Triangulum HTT
 For production it is recommended that you use a service account with a key file. You can obtain your key file by logging into your service account, navigating to the account menu, and clicking "Create key > JSON". Then, download that JSON key file and place it in the root directory of CEO. Set the email for your service account and key path in the ~:gee~ section of config.edn.
 
 #+begin_src text
-`:gee {:ee-account  "example@gmail.com"
-       :ee-key-path "ceo-gee-key.json"}
+:gee {:ee-account  "example@gmail.com"
+      :ee-key-path "ceo-gee-key.json"}
 #+end_src
 
 *** Launching the Web Server

--- a/src/js/project/AssignPlots.js
+++ b/src/js/project/AssignPlots.js
@@ -6,7 +6,7 @@ import UserSelect from "../components/UserSelect";
 import SvgIcon from "../components/svg/SvgIcon";
 
 import {formatNumberWithCommas} from "../utils/generalUtils";
-import {removeAtIndex} from "../utils/sequence";
+import {removeAtIndex, sumArray} from "../utils/sequence";
 
 // TODO, two arrays for user and percent is probably not the best data structure.
 //      Originally we had the percent array only added for by percent assignments.
@@ -124,7 +124,7 @@ export default class AssignPlots extends React.Component {
             {id: -1, email: "Select user..."},
             ...institutionUserList.filter(u => !users.includes(u.id) && (qaqcMethod !== "sme" || !smes.includes(u.id)))
         ];
-        const runningTotalPercents = percents.reduce((prev, current) => prev + current, 0);
+        const runningTotalPercents = sumArray(percents);
 
         return (
             <div className="col-6">

--- a/src/js/project/AssignPlots.js
+++ b/src/js/project/AssignPlots.js
@@ -124,6 +124,7 @@ export default class AssignPlots extends React.Component {
             {id: -1, email: "Select user..."},
             ...institutionUserList.filter(u => !users.includes(u.id) && (qaqcMethod !== "sme" || !smes.includes(u.id)))
         ];
+        const runningTotalPercents = percents.reduce((prev, current) => prev + current, 0);
 
         return (
             <div className="col-6">
@@ -158,6 +159,14 @@ export default class AssignPlots extends React.Component {
                                 );
                             })}
                         </div>
+                        {userMethod === "percent" && users.length > 0 && (
+                            <p
+                                className="font-italic ml-2 mt-2 small"
+                                style={{color: runningTotalPercents !== 100 ? "#8B0000" : "#006400"}}
+                            >
+                                {runningTotalPercents}% of the plots are assigned.
+                            </p>
+                        )}
                         {userMethod === "equal" && users.length > 0 && (
                             <p className="font-italic ml-2 mt-2 small">
                                 {["shp", "csv"].includes(plotDistribution)

--- a/src/js/utils/sequence.js
+++ b/src/js/utils/sequence.js
@@ -36,7 +36,7 @@ export function removeAtIndex(arr, index) {
 
 /**
 * Replaces the given number in an array with a new value
-* @param {array} array
+* @param {array} arr
 * @param {number} numToReplace
 * @param {number} newNum
 * @returns {array}
@@ -46,6 +46,15 @@ export function replaceNumber(arr, numToReplace, newNum) {
         const idx = arr.indexOf(numToReplace);
         return arr.slice(0, idx).concat(newNum, arr.slice(idx + 1, arr.length));
     } else return arr;
+}
+
+/**
+* Sums up all of the numbers in an array.
+* @param {array} arr
+* @returns {number}
+*/
+export function sumArray(arr) {
+    return arr.reduce((acc, cur) => acc + cur, 0);
 }
 
 /// Set Functions ///


### PR DESCRIPTION
## Purpose
Shows the running total percent of plots assigned in the Plot Design. The text is red if the percents don't add up to 100%, and green if they do. 

## Related Issues
Closes CEO-368

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `CEO-### <title>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
1. Create a project.
2. Assign at least two users using the "Percentage of plots" method.
3. Mess around with their percentages.
4. The running total percent should be visible at the bottom of the last user and the text should only be green once the total percent is 100.

## Screenshots
![Screenshot from 2022-01-25 10-18-18](https://user-images.githubusercontent.com/40574170/151035908-27f37ea0-b20c-4d98-a908-0642547e2fb6.png)
![Screenshot from 2022-01-25 10-18-35](https://user-images.githubusercontent.com/40574170/151035911-540724fe-710e-41e6-8488-73b0410aa824.png)


