### PR TITLE
CEO-430 Move the widget title below the widget type selection.

### DIFF
--- a/src/js/geoDashHelp.js
+++ b/src/js/geoDashHelp.js
@@ -41,8 +41,8 @@ class GeoDashHelp extends React.Component {
                             {this.expandableImageWrapper("/img/geodash/create_degradation_widget.png")}
                             <ol>
                                 <li>{lngObject.click_add_widget}</li>
-                                <li>{lngObject.give_title}</li>
                                 <li>{lngObject.select_degradation}</li>
+                                <li>{lngObject.give_title}</li>
                                 <li>{lngObject.choose_basemap}</li>
                                 <li>{lngObject.choose_band}</li>
                                 <li>{lngObject.click_create}</li>
@@ -52,8 +52,8 @@ class GeoDashHelp extends React.Component {
                             {this.expandableImageWrapper("/img/geodash/create_dual_imagery_widget.png")}
                             <ol>
                                 <li>{lngObject.click_add_widget}</li>
-                                <li>{lngObject.give_title}</li>
                                 <li>{lngObject.select_dual_image_collection}</li>
+                                <li>{lngObject.give_title}</li>
                                 <li>{lngObject.choose_basemap}</li>
                                 <li>{lngObject.select_imagery_type}</li>
                                 <li>{lngObject.select_remaining_imagery}</li>
@@ -65,8 +65,8 @@ class GeoDashHelp extends React.Component {
                             {this.expandableImageWrapper("/img/geodash/create_image_asset_widget.png")}
                             <ol>
                                 <li>{lngObject.click_add_widget}</li>
-                                <li>{lngObject.give_title}</li>
                                 <li>{lngObject.select_image_asset}</li>
+                                <li>{lngObject.give_title}</li>
                                 <li>{lngObject.choose_basemap}</li>
                                 <li>
                                     {lngObject.enter_image_asset + " (e.g. users/billyz313/carbon_monoxide)."}
@@ -82,8 +82,8 @@ class GeoDashHelp extends React.Component {
                             {this.expandableImageWrapper("/img/geodash/create_image_collection_asset_widget.png")}
                             <ol>
                                 <li>{lngObject.click_add_widget}</li>
-                                <li>{lngObject.give_title}</li>
                                 <li>{lngObject.select_image_collection_asset}</li>
+                                <li>{lngObject.give_title}</li>
                                 <li>{lngObject.choose_basemap}</li>
                                 <li>
                                     {lngObject.enter_image_asset + " (e.g. users/billyz313/carbon_monoxide)."}
@@ -100,8 +100,8 @@ class GeoDashHelp extends React.Component {
                             {this.expandableImageWrapper("/img/geodash/create_polygon_compare_widget.png")}
                             <ol>
                                 <li>{lngObject.click_add_widget}</li>
-                                <li>{lngObject.give_title}</li>
                                 <li>{lngObject.select_polygon_compare}</li>
+                                <li>{lngObject.give_title}</li>
                                 <li>{lngObject.fill_remaining_fields}</li>
                                 <li>{lngObject.click_create}</li>
                             </ol>
@@ -110,8 +110,8 @@ class GeoDashHelp extends React.Component {
                             {this.expandableImageWrapper("/img/geodash/create_preloaded_image_collections_widget.png")}
                             <ol>
                                 <li>{lngObject.click_add_widget}</li>
-                                <li>{lngObject.give_title}</li>
                                 <li>{lngObject.select_preloaded_image_collections}</li>
+                                <li>{lngObject.give_title}</li>
                                 <li>{lngObject.choose_basemap}</li>
                                 <li>{lngObject.select_data_type_preloaded}</li>
                                 <li>{lngObject.select_date_range}</li>
@@ -122,8 +122,8 @@ class GeoDashHelp extends React.Component {
                             {this.expandableImageWrapper("/img/geodash/create_statistics_widget.png")}
                             <ol>
                                 <li>{lngObject.click_add_widget}</li>
-                                <li>{lngObject.give_title}</li>
                                 <li>{lngObject.select_stats}</li>
+                                <li>{lngObject.give_title}</li>
                                 <li>{lngObject.click_create}</li>
                             </ol>
                         </CollapsibleSectionBlock>
@@ -131,8 +131,8 @@ class GeoDashHelp extends React.Component {
                             {this.expandableImageWrapper("/img/geodash/create_time_series_graph_widget.png")}
                             <ol>
                                 <li>{lngObject.click_add_widget}</li>
-                                <li>{lngObject.give_title}</li>
                                 <li>{lngObject.select_time_series}</li>
+                                <li>{lngObject.give_title}</li>
                                 <li>{lngObject.select_data_type_time_series}</li>
                                 <li>{lngObject.select_date_range}</li>
                                 <li>{lngObject.click_create}</li>

--- a/src/js/geodash/CopyDialog.js
+++ b/src/js/geodash/CopyDialog.js
@@ -43,18 +43,18 @@ export default function CopyDialog(props) {
     const dialogButtons = (
         <>
             <button
+                className="btn btn-secondary"
+                onClick={closeDialogs}
+                type="button"
+            >
+            Close
+            </button>
+            <button
                 className="btn btn-primary"
                 onClick={() => copyProjectWidgets(templateId)}
                 type="button"
             >
                 Copy
-            </button>
-            <button
-                className="btn btn-secondary"
-                onClick={closeDialogs}
-                type="button"
-            >
-                Close
             </button>
         </>
     );

--- a/src/js/geodash/CopyDialog.js
+++ b/src/js/geodash/CopyDialog.js
@@ -47,7 +47,7 @@ export default function CopyDialog(props) {
                 onClick={closeDialogs}
                 type="button"
             >
-            Close
+                Close
             </button>
             <button
                 className="btn btn-primary"

--- a/src/js/widgetLayoutEditor.js
+++ b/src/js/widgetLayoutEditor.js
@@ -431,17 +431,6 @@ class WidgetLayoutEditor extends React.PureComponent {
         return (
             <form>
                 <div className="form-group">
-                    <label htmlFor="widgetTitle">Title</label>
-                    <input
-                        className="form-control"
-                        id="widgetTitle"
-                        onChange={e => this.updateTitle(e.target.value)}
-                        placeholder="Enter title"
-                        type="text"
-                        value={this.state.title}
-                    />
-                </div>
-                <div className="form-group">
                     <label htmlFor="widgetTypeSelect">Widget Type</label>
                     <select
                         className="form-control"
@@ -455,6 +444,17 @@ class WidgetLayoutEditor extends React.PureComponent {
                                    <option key={key} value={key}>{title}</option>
                                ))}
                     </select>
+                </div>
+                <div className="form-group">
+                    <label htmlFor="widgetTitle">Title</label>
+                    <input
+                        className="form-control"
+                        id="widgetTitle"
+                        onChange={e => this.updateTitle(e.target.value)}
+                        placeholder="Enter title"
+                        type="text"
+                        value={this.state.title}
+                    />
                 </div>
                 {WidgetDesigner && <WidgetDesigner/>}
             </form>


### PR DESCRIPTION
## Purpose
Moves the widget title below the widget type selection when creating/editing a GeoDash widget. Updates the GeoDash help text to correspond with this change. Note that I didn't update the images on the GeoDash help page until it's decided if we want a GIF or an image. Swaps the position of the "Close" and "Copy" buttons on the "Copy Widget" modal to be consistent with the other GeoDash widget modals.

## Related Issues
Closes CEO-430

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `CEO-### <title>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Screenshots

![Screenshot from 2022-01-25 10-32-26](https://user-images.githubusercontent.com/40574170/151038023-837b5d8e-358c-4494-9962-12a2ca26fb13.png)
![Screenshot from 2022-01-25 10-28-28](https://user-images.githubusercontent.com/40574170/151038031-f6f23aed-cc18-41f9-9363-31e0de18998f.png)

