### PR TITLE
Fix a bug where you couldn't create a GeoDash widget.

### DIFF
--- a/src/js/widgetLayoutEditor.js
+++ b/src/js/widgetLayoutEditor.js
@@ -252,7 +252,7 @@ class WidgetLayoutEditor extends React.PureComponent {
     getNextLayout = (width = 3, height = 1) => {
         const {widgets} = this.state;
         const layouts = widgets.map(w => w.layout);
-        const nextY = getNextInSequence(...layouts.map(l => (l.y || 0)));
+        const nextY = getNextInSequence(layouts.map(l => (l.y || 0)));
 
         if (height === 1) {
             const emptyXY = _.range(nextY).map(y => {


### PR DESCRIPTION
## Purpose
Fixes the following bug:

1. Create a new project.
2. Go to the GeoDash widget layout editor for that project.
3. Try to add a widget (of any type).
4. Nothing happens when clicking "Create".
5. The console throws the following error:
```
Uncaught TypeError: undefined is not iterable (cannot read property Symbol(Symbol.iterator))
    at _iterableToArray (iterableToArray.js?11b0:2:1)
    at _toConsumableArray (toConsumableArray.js?448a:10:1)
    at getNextInSequence (sequence.js?9d01:24:1)
    at WidgetLayoutEditor.eval [as getNextLayout] (widgetLayoutEditor.js?dfe6:255:1)
    at eval (widgetLayoutEditor.js?dfe6:312:1)
    at HTMLUnknownElement.callCallback (react-dom.development.js?61bb:188:1)
    at Object.invokeGuardedCallbackDev (react-dom.development.js?61bb:237:1)
    at invokeGuardedCallback (react-dom.development.js?61bb:292:1)
    at invokeGuardedCallbackAndCatchFirstError (react-dom.development.js?61bb:306:1)
    at executeDispatch (react-dom.development.js?61bb:389:1)
```


## Submission Checklist
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
You should be able to create GeoDash widgets.


