### PR TITLE
TRI-78 Add systemd notify after server start

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -17,7 +17,7 @@
         ring/ring-json            {:mvn/version "0.5.0"}
         seancorfield/next.jdbc    {:mvn/version "1.1.613"}
         sig-gis/triangulum        {:git/url "https://github.com/sig-gis/triangulum"
-                                   :sha     "1d11f22f01420be39ba9ca966c21d97df3aebdc9"}}
+                                   :sha     "31caa03b954ea724c181c5fdd876caf07459b233"}}
 
  :aliases {:build-db         {:main-opts ["-m" "triangulum.build-db"]}
            :config           {:main-opts ["-m" "triangulum.config"]}

--- a/deps.edn
+++ b/deps.edn
@@ -17,7 +17,7 @@
         ring/ring-json            {:mvn/version "0.5.0"}
         seancorfield/next.jdbc    {:mvn/version "1.1.613"}
         sig-gis/triangulum        {:git/url "https://github.com/sig-gis/triangulum"
-                                   :sha     "eca491ec19149da885624b692a0cc2a476dd19ec"}}
+                                   :sha     "1d11f22f01420be39ba9ca966c21d97df3aebdc9"}}
 
  :aliases {:build-db         {:main-opts ["-m" "triangulum.build-db"]}
            :config           {:main-opts ["-m" "triangulum.config"]}

--- a/src/clj/collect_earth_online/server.clj
+++ b/src/clj/collect_earth_online/server.clj
@@ -5,6 +5,7 @@
             [ring.adapter.jetty :refer [run-jetty]]
             [triangulum.cli     :refer [get-cli-options]]
             [triangulum.config  :refer [get-config]]
+            [triangulum.notify  :as notify]
             [triangulum.logging :refer [log-str set-log-path!]]
             [triangulum.sockets :refer [send-to-server! socket-open?]]
             [collect-earth-online.handler :refer [create-handler-stack]]))
@@ -81,7 +82,9 @@
           (reset! repl-server (start-server {:name :ceo-repl :port 5555 :accept 'clojure.core.server/repl})))
         (reset! server (run-jetty handler config))
         (reset! clean-up-service (start-clean-up-service!))
-        (set-log-path! log-dir)))))
+        (set-log-path! log-dir)
+        (when (notify/available?)
+          (notify/ready!))))))
 
 (defn stop-server! []
   (set-log-path! "")


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Adds `(notify/ready!)` once the server has started.

## Related Issues
Closes TRI-78

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `CEO-### <title>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
<!-- Create a BDD style test script -->
Update the systemd unit file and restart the service using: `sudo clojure -M:systemd enable -r collect-earth-online -u ceo -d /opt/ceo/collect-earth-online`
