### PR TITLE
CEO-427 Simplify update route to fix assignment issues

### DIFF
--- a/src/clj/collect_earth_online/db/projects.clj
+++ b/src/clj/collect_earth_online/db/projects.clj
@@ -318,6 +318,10 @@
                             (str/join ", " (take 10 bad-plots))
                             "]"))))))
 
+(defn- assign-plots [design-settings current-plots]
+  (when-let [assigned-plots (assign-user-plots current-plots design-settings)]
+    (p-insert-rows! "plot_assignments" (assign-qaqc assigned-plots design-settings))))
+
 (defn- create-project-plots! [project-id
                               lon-min
                               lat-min
@@ -366,8 +370,7 @@
                         "This can come from improper coordinates or projection when uploading shape or csv data.")))
 
   (let [saved-plots (call-sql "get_plot_centers_by_project" project-id)]
-    (when-let [assigned-plots (assign-user-plots saved-plots design-settings)]
-      (p-insert-rows! "plot_assignments" (assign-qaqc assigned-plots design-settings)))
+    (assign-plots design-settings saved-plots)
     (create-project-samples! project-id
                              plot-shape
                              plot-size
@@ -543,10 +546,6 @@
        (same-ring? (exterior-ring (:coordinates geom1))
                    (exterior-ring (:coordinates geom2)))))
 
-(defn modified-design? [ds1 ds2]
-  (not= (-> ds1 (tc/jsonb->clj))
-        (-> ds2 (tc/jsonb->clj))))
-
 (defn update-project! [{:keys [params]}]
   (let [project-id           (tc/val->int (:projectId params))
         imagery-id           (or (:imageryId params) (get-first-public-imagery))
@@ -573,9 +572,8 @@
                                  (tc/val->bool (:allowDrawnSamples params)))
         survey-questions     (tc/clj->jsonb (:surveyQuestions params))
         survey-rules         (tc/clj->jsonb (:surveyRules params))
-        update-survey        (tc/val->bool (:updateSurvey params))
         project-options      (tc/clj->jsonb (:projectOptions params default-options))
-        design-settings      (tc/clj->jsonb (:designSettings params default-settings))
+        design-settings      (:designSettings params default-settings)
         plot-file-name       (:plotFileName params)
         plot-file-base64     (:plotFileBase64 params)
         sample-file-name     (:sampleFileName params)
@@ -604,7 +602,7 @@
                   survey-questions
                   survey-rules
                   project-options
-                  design-settings)
+                  (tc/clj->jsonb design-settings))
 
         (when-let [imagery-list (:projectImageryList params)]
           (call-sql "delete_project_imagery" project-id)
@@ -615,10 +613,10 @@
           nil
 
           (or (not= plot-distribution (:plot_distribution original-project))
-              (modified-design? design-settings (:design_settings original-project))
               (if (#{"csv" "shp"} plot-distribution)
                 plot-file-base64
-                (or (not (same-polygon-boundary? (tc/jsonb->clj boundary) (tc/jsonb->clj (:boundary original-project))))
+                (or (not (same-polygon-boundary? (tc/jsonb->clj boundary)
+                                                 (tc/jsonb->clj (:boundary original-project))))
                     (not= num-plots    (:num_plots original-project))
                     (not= plot-shape   (:plot_shape original-project))
                     (not= plot-size    (:plot_size original-project))
@@ -645,34 +643,35 @@
                                    allow-drawn-samples?
                                    design-settings))
 
-          (or (not= sample-distribution (:sample_distribution original-project))
-              (if (#{"csv" "shp"} sample-distribution)
-                sample-file-base64
-                (or (not= samples-per-plot (:samples_per_plot original-project))
-                    (not= sample-resolution (:sample_resolution original-project)))))
+          :else
           (do
-            (call-sql "delete_user_plots_by_project" project-id)
-            (call-sql "delete_all_samples_by_project" project-id)
-            (create-project-samples! project-id
-                                     plot-shape
-                                     plot-size
-                                     sample-distribution
-                                     samples-per-plot
-                                     sample-resolution
-                                     sample-file-name
-                                     sample-file-base64
-                                     allow-drawn-samples?
-                                     (call-sql "get_plot_centers_by_project" project-id)))
-
-          ;; NOTE: Old stored questions can have a different format than when passed from the UI.
-          ;;       This is why we check whether the survey questions are different on the front (for now).
-          (or update-survey
-              (and (:allow_drawn_samples original-project) (not allow-drawn-samples?)))
-          (reset-collected-samples! project-id))
+            (if (or (not= sample-distribution (:sample_distribution original-project))
+                    (if (#{"csv" "shp"} sample-distribution)
+                      sample-file-base64
+                      (or (not= samples-per-plot (:samples_per_plot original-project))
+                          (not= sample-resolution (:sample_resolution original-project)))))
+              (do
+                (call-sql "delete_user_plots_by_project" project-id)
+                (call-sql "delete_all_samples_by_project" project-id)
+                (create-project-samples! project-id
+                                         plot-shape
+                                         plot-size
+                                         sample-distribution
+                                         samples-per-plot
+                                         sample-resolution
+                                         sample-file-name
+                                         sample-file-base64
+                                         allow-drawn-samples?
+                                         (call-sql "get_plot_centers_by_project" project-id)))
+              (reset-collected-samples! project-id))
+            (when (not= design-settings (tc/jsonb->clj (:design_settings original-project)))
+              (call-sql "delete_plot_assignments_by_project" project-id)
+              (assign-plots design-settings (call-sql "get_plot_centers_by_project" project-id)))))
 
         ;; Final clean up
         (call-sql "update_project_counts" project-id)
         (data-response "")
+
         (catch Exception e
           (let [causes (:causes (ex-data e))]
             ;; Log unknown errors

--- a/src/clj/collect_earth_online/db/projects.clj
+++ b/src/clj/collect_earth_online/db/projects.clj
@@ -645,6 +645,7 @@
 
           :else
           (do
+            ;; Always recreate samples or reset them
             (if (or (not= sample-distribution (:sample_distribution original-project))
                     (if (#{"csv" "shp"} sample-distribution)
                       sample-file-base64
@@ -664,6 +665,7 @@
                                          allow-drawn-samples?
                                          (call-sql "get_plot_centers_by_project" project-id)))
               (reset-collected-samples! project-id))
+            ;; Redo assignments if they changed
             (when (not= design-settings (tc/jsonb->clj (:design_settings original-project)))
               (call-sql "delete_plot_assignments_by_project" project-id)
               (assign-plots design-settings (call-sql "get_plot_centers_by_project" project-id)))))

--- a/src/js/project/ReviewChanges.js
+++ b/src/js/project/ReviewChanges.js
@@ -1,5 +1,4 @@
 import React from "react";
-import _ from "lodash";
 
 import ReviewForm from "./ReviewForm";
 
@@ -56,19 +55,7 @@ export default class ReviewChanges extends React.Component {
     };
 
     updateProject = () => {
-        // TODO: Match project details in context as in state (i.e. do not spread into context).
-        const updateSurvey = this.surveyQuestionUpdated(this.context, this.context.originalProject);
-        const extraMessage = (this.plotsUpdated(this.context, this.context.originalProject)
-          || this.plotDesignChanged(this.context, this.context.originalProject))
-            ? "  Plots and samples will be recreated, losing all collection data."
-            : this.samplesUpdated(this.context, this.context.originalProject)
-                ? "  Samples will be recreated, losing all collection data."
-                : updateSurvey
-                    ? "  Updating survey questions or rules will reset all collected data."
-                    : this.allowDrawnSamplesDisallowed(this.context, this.context.originalProject)
-                        ? "  Disallowing users to draw samples will reset all collected data."
-                        : "";
-        if (confirm("Do you really want to update this project?" + extraMessage)) {
+        if (confirm("Collection data will cleared to reset the project. Do you really want to update this project?")) {
             this.context.processModal(
                 "Updating Project",
                 () => fetch(
@@ -81,8 +68,7 @@ export default class ReviewChanges extends React.Component {
                         },
                         body: JSON.stringify({
                             projectId: this.context.projectId,
-                            ...this.buildProjectObject(),
-                            updateSurvey // FIXME this is a shim for when stored questions are in an old format.
+                            ...this.buildProjectObject()
                         })
                     }
                 )
@@ -137,33 +123,6 @@ export default class ReviewChanges extends React.Component {
             sampleFileBase64: this.context.sampleFileBase64
         };
     };
-
-    allowDrawnSamplesDisallowed = (projectDetails, originalProject) =>
-        originalProject.allowDrawnSamples && !projectDetails.allowDrawnSamples;
-
-    surveyQuestionUpdated = (projectDetails, originalProject) =>
-        !_.isEqual(projectDetails.surveyQuestions, originalProject.surveyQuestions)
-            || !_.isEqual(projectDetails.surveyRules, originalProject.surveyRules);
-
-    plotDesignChanged = ({designSettings}, {designSettings: originalDesignSettings}) =>
-        !(_.isEqual(designSettings, originalDesignSettings));
-
-    plotsUpdated = (projectDetails, originalProject) =>
-        projectDetails.plotDistribution !== originalProject.plotDistribution
-            || (["csv", "shp"].includes(this.context.plotDistribution)
-                ? projectDetails.plotFileBase64
-                : projectDetails.boundary !== originalProject.boundary
-                    || projectDetails.numPlots !== originalProject.numPlots
-                    || projectDetails.plotShape !== originalProject.plotShape
-                    || projectDetails.plotSize !== originalProject.plotSize
-                    || projectDetails.plotSpacing !== originalProject.plotSpacing);
-
-    samplesUpdated = (projectDetails, originalProject) =>
-        projectDetails.sampleDistribution !== originalProject.sampleDistribution
-            || (["csv", "shp"].includes(this.context.sampleDistribution)
-                ? projectDetails.sampleFileBase64
-                : projectDetails.samplesPerPlot !== originalProject.samplesPerPlot
-                    || projectDetails.sampleResolution !== originalProject.sampleResolution);
 
     /// Render Functions
 

--- a/src/sql/functions/plots.sql
+++ b/src/sql/functions/plots.sql
@@ -505,6 +505,15 @@ CREATE OR REPLACE FUNCTION delete_user_plots_by_project(_project_id integer)
 
 $$ LANGUAGE SQL;
 
+-- For clearing all user plots in a project
+CREATE OR REPLACE FUNCTION delete_plot_assignments_by_project(_project_id integer)
+ RETURNS void AS $$
+
+    DELETE FROM plot_assignments WHERE plot_rid IN (SELECT plot_uid FROM plots WHERE project_rid = _project_id)
+
+$$ LANGUAGE SQL;
+
+
 -- For clearing all samples in a project
 CREATE OR REPLACE FUNCTION delete_all_samples_by_project(_project_id integer)
  RETURNS void AS $$


### PR DESCRIPTION
## Purpose
Simplify update route to fix assignment issues.  We have reached critical mass on being able to only make changes based on specific setting changes.  This simplifies it to 3 possibilities:
1. The project is published and only non critical information can be updated.
2. Plot design is updated. Recreating the plots already resets everything else.
3. All other changes in draft mode will reset collected plots (completely re-create samples if the sample design changes)

User messaging is also simplified.

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `CEO-### <title>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
1. Create a project
2. Changes many permutations of the settings (the bug was assignments not updating)
3. The project should update as expected