### PR TITLE
CEO-423 Show user assignments when copy plots is selected

### DIFF
--- a/src/js/project/CreateProjectWizard.js
+++ b/src/js/project/CreateProjectWizard.js
@@ -1,15 +1,15 @@
 import React from "react";
 import _ from "lodash";
 
-import {ImagerySelection} from "./ImagerySelection";
-import {Overview, OverviewIntro} from "./Overview";
-import {PlotDesign, PlotDesignReview} from "./PlotDesign";
+import AOIMap from "./AOIMap";
 import SurveyQuestionsDesigner from "../survey/SurveyQuestionsDesigner";
 import SurveyCollectionPreview from "../survey/SurveyCollectionPreview";
 import SurveyRulesDesigner from "../survey/SurveyRulesDesigner";
-import AOIMap from "./AOIMap";
-import {SampleDesign, SampleReview, SamplePreview} from "./SampleDesign";
+import PlotStep from "./PlotStep";
 import SvgIcon from "../components/svg/SvgIcon";
+import {ImagerySelection} from "./ImagerySelection";
+import {Overview, OverviewIntro} from "./Overview";
+import {SampleDesign, SampleReview, SamplePreview} from "./SampleDesign";
 
 import {mercator} from "../utils/mercator";
 import {last, lengthObject, removeFromSet, someObject} from "../utils/sequence";
@@ -51,15 +51,7 @@ export default class CreateProjectWizard extends React.Component {
             plots: {
                 title: "Plot Design",
                 description: "Area of interest and plot generation for collection",
-                StepComponent: () => (this.context.useTemplatePlots
-                    ? <PlotDesignReview/>
-                    : (
-                        <PlotDesign
-                            boundary={this.context.boundary}
-                            getTotalPlots={this.getTotalPlots}
-                            institutionUserList={this.context.institutionUserList}
-                        />
-                    )),
+                StepComponent: () => <PlotStep getTotalPlots={this.getTotalPlots}/>,
                 helpDescription: "Collection Map Preview",
                 StepHelpComponent: () => (
                     <AOIMap

--- a/src/js/project/PlotDesign.js
+++ b/src/js/project/PlotDesign.js
@@ -3,8 +3,6 @@ import React from "react";
 import {formatNumberWithCommas, encodeFileAsBase64} from "../utils/generalUtils";
 import {ProjectContext, plotLimit} from "./constants";
 import {mercator} from "../utils/mercator";
-import AssignPlots from "./AssignPlots";
-import QualityControl from "./QualityControl";
 
 export class PlotDesign extends React.Component {
     constructor(props) {
@@ -245,8 +243,7 @@ export class PlotDesign extends React.Component {
 
     render() {
         const {plotDistribution, plotShape} = this.context;
-        const {institutionUserList} = this.props;
-        const totalPlots = this.props.getTotalPlots();
+        const {totalPlots} = this.props;
         const plotUnits = plotShape === "circle" ? "Plot diameter (m)" : "Plot width (m)";
 
         const plotOptions = {
@@ -327,10 +324,6 @@ export class PlotDesign extends React.Component {
                     {totalPlots > 0 && totalPlots > plotLimit
                         && `\n* The maximum allowed number for the selected plot distribution is ${formatNumberWithCommas(plotLimit)}.`}
                 </p>
-                <div className="row mr-1">
-                    <AssignPlots institutionUserList={institutionUserList} totalPlots={totalPlots}/>
-                    <QualityControl institutionUserList={institutionUserList} totalPlots={totalPlots}/>
-                </div>
             </div>
         );
     }

--- a/src/js/project/PlotStep.js
+++ b/src/js/project/PlotStep.js
@@ -1,0 +1,34 @@
+import React, {useContext} from "react";
+import {ProjectContext} from "./constants";
+
+import AssignPlots from "./AssignPlots";
+import QualityControl from "./QualityControl";
+import {PlotDesign, PlotDesignReview} from "./PlotDesign";
+
+export default function PlotStep({getTotalPlots}) {
+    const {institutionUserList, boundary, useTemplatePlots} = useContext(ProjectContext);
+    const totalPlots = getTotalPlots();
+    return (
+        <>
+            {useTemplatePlots
+                ? <PlotDesignReview/>
+                : (
+                    <PlotDesign
+                        boundary={boundary}
+                        institutionUserList={institutionUserList}
+                        totalPlots={totalPlots}
+                    />
+                )}
+            <div className="row mr-1">
+                <AssignPlots
+                    institutionUserList={institutionUserList}
+                    totalPlots={totalPlots}
+                />
+                <QualityControl
+                    institutionUserList={institutionUserList}
+                    totalPlots={totalPlots}
+                />
+            </div>
+        </>
+    );
+}


### PR DESCRIPTION
## Purpose
When use template plots is selected the review pane is shown.  This moves the assignment components outside of the plot designer so they are still shown.

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `CEO-### <title>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
1. Create a project with users assigned.
2. Create a new project with the first one as a template
3. On the plots tab, you should be able to adjust the user assignments without modifying the plot info

## Screenshots
![image](https://user-images.githubusercontent.com/33734037/151235755-063adc41-5cf4-4048-a19a-72f745170d12.png)

