### PR TITLE
Cycle users better to fix overlap assign

### DIFF
--- a/src/clj/collect_earth_online/db/projects.clj
+++ b/src/clj/collect_earth_online/db/projects.clj
@@ -239,6 +239,23 @@
                                                                     :plot_id))))))
       nil)))
 
+(defn- start-list-at
+  "Creates a new collection removing the item that matches pred, starting the list at item + 1,
+   and appending the beginning of the list on to the end."
+  [pred coll]
+  (loop [head coll
+         tail []]
+    (cond
+      (empty? head)
+      tail
+
+      (pred (first head))
+      (concat (rest head) tail)
+
+      :else
+      (recur (rest head)
+             (conj tail (first head))))))
+
 (defn- assign-qaqc
   "Assigns additional plots to users based on QA/QC method.  The two options are:
    {:qaqcMethod    \"overlap\"
@@ -265,7 +282,7 @@
                                            user-plots)]))
                      (reduce (fn [acc [user-id user-plots]]
                                (let [other-users (case qaqc-method
-                                                   "overlap" (remove #(= user-id %) users)
+                                                   "overlap" (start-list-at #(= % user-id) users)
                                                    "sme"     smes
                                                    nil)]
                                  (loop [to-users     other-users


### PR DESCRIPTION
## Purpose
Fixes issue where overlapping qaqc did not work correctly for large number of collectors.

## Testing
1. Create a project with 150 plots
2. Assign 10 users
3. Add 2x 100% overlap
4. Each user should have a total of 30 assigned plots.
