### PR TITLE
CEO-440 Remove the Bulk Add button when not in DesignMode. (Feb testing bug fix)

### DIFF
--- a/src/js/survey/SurveyDesignQuestion.js
+++ b/src/js/survey/SurveyDesignQuestion.js
@@ -183,7 +183,7 @@ export default function SurveyDesignQuestion({indentLevel, inDesignMode, surveyQ
                                 surveyQuestionId={surveyQuestionId}
                             />
                         )}
-                        {surveyQuestion.componentType !== "input" && (
+                        {inDesignMode && surveyQuestion.componentType !== "input" && (
                             <button
                                 className="btn btn-sm btn-success"
                                 onClick={() => setBulkAdd(true)}


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
Hide the bulk add button of project questions when reviewing a project. 

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `CEO-### <title>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
<!-- Create a BDD style test script -->
1. Given an institution , and creating a project with at least one Question/Answer 
2. Click review 
3. Survey Question Card doesn't show the Bulk Add Button
