### PR TITLE
Add indexes to FK for faster delete

### DIFF
--- a/src/sql/changes/update_2021-02-07_add_missing_index.sql
+++ b/src/sql/changes/update_2021-02-07_add_missing_index.sql
@@ -1,0 +1,5 @@
+CREATE INDEX projects_institution_rid    ON projects (institution_rid);
+CREATE INDEX project_imagery_project_rid ON project_imagery (project_rid);
+CREATE INDEX ext_samples_plot_rid        ON ext_samples (plot_rid);
+CREATE INDEX plot_assignments_plot_rid   ON plot_assignments (plot_rid);
+CREATE INDEX plot_assignments_user_rid   ON plot_assignments (user_rid);

--- a/src/sql/functions/project.sql
+++ b/src/sql/functions/project.sql
@@ -152,7 +152,16 @@ CREATE OR REPLACE FUNCTION delete_project(_project_id integer)
  RETURNS void AS $$
 
  BEGIN
-    -- Delete plots first for performance
+    -- Delete fks first for performance
+    DELETE FROM sample_values WHERE sample_rid IN (
+        SELECT sample_uid FROM samples, plots
+        WHERE plot_uid = plot_rid
+            AND project_rid = _project_id
+    );
+    DELETE FROM samples WHERE plot_rid IN (SELECT plot_uid FROM plots WHERE project_rid = _project_id);
+    DELETE FROM ext_samples WHERE plot_rid IN (SELECT plot_uid FROM plots WHERE project_rid = _project_id);
+    DELETE FROM user_plots WHERE plot_rid IN (SELECT plot_uid FROM plots WHERE project_rid = _project_id);
+    DELETE FROM plot_assignments WHERE plot_rid IN (SELECT plot_uid FROM plots WHERE project_rid = _project_id);
     DELETE FROM plots WHERE project_rid = _project_id;
     DELETE FROM projects WHERE project_uid = _project_id;
 

--- a/src/sql/tables/all.sql
+++ b/src/sql/tables/all.sql
@@ -43,6 +43,8 @@ CREATE TABLE institution_users (
     role_rid           integer NOT NULL REFERENCES roles (role_uid),
     CONSTRAINT per_institution_per_plot UNIQUE(institution_rid, user_rid)
 );
+CREATE INDEX institution_users_institution_rid ON institution_users (institution_rid);
+CREATE INDEX institution_users_user_rid        ON institution_users (user_rid);
 
 -- Stores imagery data
 -- 1 institution -> many imagery
@@ -59,6 +61,7 @@ CREATE TABLE imagery (
     archived_date      date,
     is_proxied         boolean DEFAULT FALSE
 );
+CREATE INDEX imagery_institution_rid ON imagery (institution_rid);
 
 -- Stores information about projects
 -- Each project must be associated with an institution
@@ -92,6 +95,7 @@ CREATE TABLE projects (
     plot_file_name         varchar(511),
     sample_file_name       varchar(511)
 );
+CREATE INDEX projects_institution_rid ON projects (institution_rid);
 
 -- Stores project imagery
 -- 1 project -> many imagery
@@ -101,6 +105,7 @@ CREATE TABLE project_imagery (
     imagery_rid            integer REFERENCES imagery (imagery_uid) ON DELETE CASCADE ON UPDATE CASCADE,
     CONSTRAINT per_project_per_imagery UNIQUE(project_rid, imagery_rid)
 );
+CREATE INDEX project_imagery_project_rid ON project_imagery (project_rid);
 
 --            1 project -> many |plots ->                                       many samples|
 --                              |plots -> many user_plots -> many sample_values 1 <- samples|
@@ -114,6 +119,7 @@ CREATE TABLE plots (
     visible_id         integer,
     extra_plot_info    jsonb
 );
+CREATE INDEX plots_projects_rid ON plots (project_rid);
 
 -- Stores sample information, including a reference to external sample data if it exists
 CREATE TABLE samples (
@@ -123,6 +129,7 @@ CREATE TABLE samples (
     visible_id           integer,
     extra_sample_info    jsonb
 );
+CREATE INDEX samples_plot_rid ON samples (plot_rid);
 
 -- A duplicate of external file samples for restoring samples
 CREATE TABLE ext_samples (
@@ -132,6 +139,7 @@ CREATE TABLE ext_samples (
     visible_id           integer,
     extra_sample_info    jsonb
 );
+CREATE INDEX ext_samples_plot_rid ON ext_samples (plot_rid);
 
 -- Stores information about a plot as data is collected, including the user who collected it
 CREATE TABLE user_plots (
@@ -145,6 +153,8 @@ CREATE TABLE user_plots (
     flagged_reason      text,
     CONSTRAINT per_user_per_plot UNIQUE(user_rid, plot_rid)
 );
+CREATE INDEX user_plots_plot_rid ON user_plots (plot_rid);
+CREATE INDEX user_plots_user_rid ON user_plots (user_rid);
 
 -- Stores collected data for a single sample
 CREATE TABLE sample_values (
@@ -156,6 +166,9 @@ CREATE TABLE sample_values (
     saved_answers         jsonb,
     CONSTRAINT per_sample_per_user UNIQUE(sample_rid, user_plot_rid)
 );
+CREATE INDEX sample_values_user_plot_rid ON sample_values (user_plot_rid);
+CREATE INDEX sample_values_sample_rid    ON sample_values (sample_rid);
+CREATE INDEX sample_values_imagery_rid   ON sample_values (imagery_rid);
 
 -- Stores active user information for a plot
 -- many plots <-> many users, although by other means we restrict it to 1 user to 1 plot
@@ -173,6 +186,8 @@ CREATE TABLE plot_assignments (
     plot_rid    integer NOT NULL REFERENCES plots(plot_uid) ON DELETE CASCADE,
     PRIMARY KEY(user_rid, plot_rid)
 );
+CREATE INDEX plot_assignments_plot_rid ON plot_assignments (plot_rid);
+CREATE INDEX plot_assignments_user_rid ON plot_assignments (user_rid);
 
 -- Stores widget information for a project
 -- 1 project -> many widgets
@@ -181,16 +196,4 @@ CREATE TABLE project_widgets (
     project_rid    integer NOT NULL REFERENCES projects (project_uid) ON DELETE CASCADE ON UPDATE CASCADE,
     widget         jsonb
 );
-
--- Indices on FK
-CREATE INDEX plots_projects_rid                ON plots (project_rid);
-CREATE INDEX samples_plot_rid                  ON samples (plot_rid);
-CREATE INDEX imagery_institution_rid           ON imagery (institution_rid);
-CREATE INDEX institution_users_institution_rid ON institution_users (institution_rid);
-CREATE INDEX institution_users_user_rid        ON institution_users (user_rid);
-CREATE INDEX user_plots_plot_rid               ON user_plots (plot_rid);
-CREATE INDEX user_plots_user_rid               ON user_plots (user_rid);
-CREATE INDEX sample_values_user_plot_rid       ON sample_values (user_plot_rid);
-CREATE INDEX sample_values_sample_rid          ON sample_values (sample_rid);
-CREATE INDEX sample_values_imagery_rid         ON sample_values (imagery_rid);
 CREATE INDEX project_widgets_project_rid       ON project_widgets (project_rid);


### PR DESCRIPTION
## Purpose
Indexes on foreign keys were missing for some newer tables.

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `CEO-### <title>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
`SELECT delete_project(1)`

