### PR TITLE
CEO-451 Allow deletion of imagery to partially cascade by setting to null

### DIFF
--- a/src/sql/changes/update_2022-02-10_fix_fx_cascade.sql
+++ b/src/sql/changes/update_2022-02-10_fix_fx_cascade.sql
@@ -1,0 +1,14 @@
+ALTER TABLE IF EXISTS sample_values DROP CONSTRAINT IF EXISTS sample_values_imagery_rid_fkey;
+ALTER TABLE sample_values
+    ADD CONSTRAINT sample_values_imagery_rid_fkey FOREIGN KEY (imagery_rid)
+    REFERENCES imagery (imagery_uid) MATCH SIMPLE
+    ON UPDATE NO ACTION
+    ON DELETE SET NULL;
+
+
+ALTER TABLE IF EXISTS projects DROP CONSTRAINT IF EXISTS projects_imagery_rid_fkey;
+ALTER TABLE IF EXISTS projects
+    ADD CONSTRAINT projects_imagery_rid_fkey FOREIGN KEY (imagery_rid)
+    REFERENCES imagery (imagery_uid) MATCH SIMPLE
+    ON UPDATE NO ACTION
+    ON DELETE SET NULL;

--- a/src/sql/tables/all.sql
+++ b/src/sql/tables/all.sql
@@ -86,7 +86,7 @@ CREATE TABLE projects (
     archived_date          date,
     token_key              text DEFAULT NULL,
     options                jsonb NOT NULL DEFAULT '{}'::jsonb,
-    imagery_rid            integer REFERENCES imagery (imagery_uid),
+    imagery_rid            integer REFERENCES imagery (imagery_uid) ON DELETE SET NULL,
     allow_drawn_samples    boolean,
     design_settings        jsonb NOT NULL DEFAULT '{}'::jsonb,
     plot_file_name         varchar(511),
@@ -97,7 +97,7 @@ CREATE TABLE projects (
 -- 1 project -> many imagery
 CREATE TABLE project_imagery (
     project_imagery_uid    SERIAL PRIMARY KEY,
-    project_rid            integer REFERENCES projects(project_uid) ON DELETE CASCADE ON UPDATE CASCADE,
+    project_rid            integer REFERENCES projects (project_uid) ON DELETE CASCADE ON UPDATE CASCADE,
     imagery_rid            integer REFERENCES imagery (imagery_uid) ON DELETE CASCADE ON UPDATE CASCADE,
     CONSTRAINT per_project_per_imagery UNIQUE(project_rid, imagery_rid)
 );
@@ -151,7 +151,7 @@ CREATE TABLE sample_values (
     sample_value_uid      SERIAL PRIMARY KEY,
     user_plot_rid         integer NOT NULL REFERENCES user_plots (user_plot_uid) ON DELETE CASCADE ON UPDATE CASCADE,
     sample_rid            integer NOT NULL REFERENCES samples (sample_uid) ON DELETE CASCADE ON UPDATE CASCADE,
-    imagery_rid           integer REFERENCES imagery (imagery_uid),
+    imagery_rid           integer REFERENCES imagery (imagery_uid) ON DELETE SET NULL,
     imagery_attributes    jsonb,
     saved_answers         jsonb,
     CONSTRAINT per_sample_per_user UNIQUE(sample_rid, user_plot_rid)


### PR DESCRIPTION
## Purpose
We dont want projects or collected data to disappear when imagery is removed so we left on delete to restrict.  In the ui, when an imagery is removed, its really just archived.  However sometimes we need to delete data where on delete to restrict (removing an entire institution with delete from institutions... gets blocked if it added any imagery)
