### PR TITLE
CEO-446 Fix when adding color/answer pairs with Bulk Add, only the last pair is added

### DIFF
--- a/src/js/survey/BulkAddAnswers.js
+++ b/src/js/survey/BulkAddAnswers.js
@@ -15,20 +15,23 @@ export default function BulkAddAnswers({closeDialog, surveyQuestionId, surveyQue
         } else {
             const newId = getNextInSequence(Object.keys(surveyQuestion.answers));
             const pairs = partition(splitArr, 2);
-            pairs.forEach(([color, answer], idx) => {
+            const updatedAnswers = pairs.reduce((answers, [color, answer], idx) => {
                 const newAnswer = {answer: answer.trim(), color};
-                setProjectDetails({
-                    surveyQuestions: {
-                        ...surveyQuestions,
-                        [surveyQuestionId]: {
-                            ...surveyQuestion,
-                            answers: {
-                                ...surveyQuestion.answers,
-                                [newId + idx]: newAnswer
-                            }
+                return {
+                    [newId + idx]: newAnswer,
+                    ...answers
+                };
+            }, surveyQuestion.answers);
+            setProjectDetails({
+                surveyQuestions: {
+                    ...surveyQuestions,
+                    [surveyQuestionId]: {
+                        ...surveyQuestion,
+                        answers: {
+                            ...updatedAnswers
                         }
                     }
-                });
+                }
             });
             closeDialog();
         }


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
The new answers are parsed, collected  and added all at once, preventing the bug where only the last one get added. 

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `CEO-### <title>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
<!-- Create a BDD style test script -->
1. In Survey Questions, after adding a survey question 
2. Click bulk add
3. Insert: #00FF00, green,#FF0000, red
4. The answers should be parsed, and all of them added 