### PR TITLE
CEO-445 Fix colors on the widget editor modal

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -87,7 +87,6 @@
     opacity: 0.4;
     pointer-events: none;
 }
-
 /*********/
 /* Fonts */
 /*********/
@@ -155,6 +154,10 @@ h4 {font-size: 0.8rem;}
 .bg-lightgray {
     background-color: #eceeef;
 }
+.bg-yellow {
+  background-color: #fccf07;
+  color: #279b93;
+}
 
 /***********/
 /* Buttons */
@@ -174,14 +177,14 @@ h4 {font-size: 0.8rem;}
 }
 .btn-yellow {
     background-color: #fccf07;
-    color: #279b93;
+    color: white;
     -webkit-transition: background-color 50ms linear;
     -ms-transition: background-color 50ms linear;
     transition: background-color 50ms linear;
 }
 .btn-yellow a:hover {
     background-color: #ecbc0d;
-    color: #279b93;
+    color: white;
 }
 .btn-lightgreen {
     background-color: #31bab0;

--- a/src/js/geodash/CopyDialog.js
+++ b/src/js/geodash/CopyDialog.js
@@ -43,14 +43,14 @@ export default function CopyDialog(props) {
     const dialogButtons = (
         <>
             <button
-                className="btn btn-secondary"
+                className="btn btn-red"
                 onClick={closeDialogs}
                 type="button"
             >
                 Close
             </button>
             <button
-                className="btn btn-primary"
+                className="btn btn-yellow"
                 onClick={() => copyProjectWidgets(templateId)}
                 type="button"
             >

--- a/src/js/widgetLayoutEditor.js
+++ b/src/js/widgetLayoutEditor.js
@@ -388,7 +388,7 @@ class WidgetLayoutEditor extends React.PureComponent {
     createDialogButtons = () => (
         <>
             <button
-                className="btn btn-secondary"
+                className="btn btn-red"
                 data-dismiss="modal"
                 onClick={this.cancelNewWidget}
                 type="button"
@@ -396,7 +396,7 @@ class WidgetLayoutEditor extends React.PureComponent {
                 Cancel
             </button>
             <button
-                className="btn btn-primary"
+                className="btn btn-lightgreen"
                 onClick={this.createNewWidget}
                 type="button"
             >


### PR DESCRIPTION
## Purpose
Use ceo green and yellow instead of bootstrap colors. 

## Related Issues
Closes CEO-###

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `CEO-### <title>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Screenshots
![image](https://user-images.githubusercontent.com/8908139/154590646-0b0cac2b-0a0a-443e-9f2f-8f1010f1220d.png)
![image](https://user-images.githubusercontent.com/8908139/154590894-06417fb0-4804-4d11-8a03-35dbbafa9bc0.png)

