### PR TITLE
CEO-450  Add optional flag in config.default.edn to auto validate emails (for devs without email set up)

### DIFF
--- a/config.default.edn
+++ b/config.default.edn
@@ -8,7 +8,8 @@
                :pass     ""
                :tls      true
                :port     587
-               :base-url "https://my.domain/"}
+               :base-url "https://my.domain/"
+               :auto-validate? true}
  :server      {:http-port 8080
                :mode      "prod"
                :log-dir   "logs"}

--- a/config.default.edn
+++ b/config.default.edn
@@ -9,7 +9,7 @@
                :tls      true
                :port     587
                :base-url "https://my.domain/"
-               :auto-validate? true}
+               :auto-validate? false}
  :server      {:http-port 8080
                :mode      "prod"
                :log-dir   "logs"}

--- a/src/clj/collect_earth_online/db/users.clj
+++ b/src/clj/collect_earth_online/db/users.clj
@@ -49,20 +49,20 @@
         password-confirmation (:passwordConfirmation params)]
     (if-let [error-msg (get-register-errors email password password-confirmation)]
       (data-response error-msg)
-      (let [timestamp (-> (DateTimeFormatter/ofPattern "yyyy/MM/dd HH:mm:ss")
-                          (.format (LocalDateTime/now)))
-            email-msg (format (str "Dear %s,\n\n"
-                                   "Thank you for signing up for CEO!\n\n"
-                                   "Your Account Summary Details:\n\n"
-                                   "  Email: %s\n"
-                                   "  Created on: %s\n\n"
-                                   "  Click the following link to verify your email:\n"
-                                   "  %sverify-email?email=%s&passwordResetKey=%s\n\n"
-                                   "Kind Regards,\n"
-                                   "  The CEO Team")
-                              email email timestamp (get-base-url) (URLEncoder/encode email) reset-key)
+      (let [timestamp      (-> (DateTimeFormatter/ofPattern "yyyy/MM/dd HH:mm:ss")
+                               (.format (LocalDateTime/now)))
+            email-msg      (format (str "Dear %s,\n\n"
+                                        "Thank you for signing up for CEO!\n\n"
+                                        "Your Account Summary Details:\n\n"
+                                        "  Email: %s\n"
+                                        "  Created on: %s\n\n"
+                                        "  Click the following link to verify your email:\n"
+                                        "  %sverify-email?email=%s&passwordResetKey=%s\n\n"
+                                        "Kind Regards,\n"
+                                        "  The CEO Team")
+                                   email email timestamp (get-base-url) (URLEncoder/encode email) reset-key)
             auto-validate? (get-config :mail :auto-validate?)
-            user-id (sql-primitive (call-sql "add_user" {:log? false} email password reset-key))]
+            user-id        (sql-primitive (call-sql "add_user" {:log? false} email password reset-key))]
         (if auto-validate?
           (do (call-sql "user_verified" user-id)
               (data-response "You have successfully created an account"))

--- a/src/clj/collect_earth_online/db/users.clj
+++ b/src/clj/collect_earth_online/db/users.clj
@@ -6,6 +6,7 @@
   (:require [clojure.string :as str]
             [triangulum.database :refer [call-sql sql-primitive]]
             [triangulum.type-conversion :as tc]
+            [triangulum.config  :refer [get-config]]
             [collect-earth-online.utils.mail :refer [email? send-mail get-base-url]]
             [collect-earth-online.views      :refer [data-response]]))
 
@@ -59,13 +60,16 @@
                                    "  %sverify-email?email=%s&passwordResetKey=%s\n\n"
                                    "Kind Regards,\n"
                                    "  The CEO Team")
-                              email email timestamp (get-base-url) (URLEncoder/encode email) reset-key)]
-        (call-sql "add_user" {:log? false} email password reset-key)
-        (try
-          (send-mail email nil nil "Welcome to CEO!" email-msg "text/plain")
-          (data-response "")
-          (catch Exception _
-            (data-response (str "A new user account was created but there was a server error.  Please contact support@sig-gis.com."))))))))
+                              email email timestamp (get-base-url) (URLEncoder/encode email) reset-key)
+            auto-validate? (get-config :mail :auto-validate?)
+            user-id (sql-primitive (call-sql "add_user" {:log? false} email password reset-key))]
+        (if auto-validate?
+          (do (call-sql "user_verified" user-id)
+              (data-response "You have successfully created an account"))
+          (try
+            (send-mail email nil nil "Welcome to CEO!" email-msg "text/plain")
+            (catch Exception _
+              (data-response (str "A new user account was created but there was a server error.  Please contact support@sig-gis.com.")))))))))
 
 (defn logout [_]
   (data-response "" {:session nil}))


### PR DESCRIPTION
## Purpose
Add option to not send the welcome email if this flag is set.  Just set verified to true in the DB.

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `CEO-### <title>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
<!-- Create a BDD style test script -->
1. Copy config.default.edn to config.edn 
2. Set :auto-validate? in :mail map to true 
3. Run the app, register a new user 
4. A new user should register and validated