### PR TITLE
CEO-472 Fix count for project having widgets

### DIFF
--- a/src/sql/functions/project.sql
+++ b/src/sql/functions/project.sql
@@ -577,7 +577,7 @@ CREATE OR REPLACE FUNCTION select_project_by_id(_project_id integer)
         created_date,
         published_date,
         closed_date,
-        count(widget_uid) > 1,
+        count(widget_uid) > 0,
         token_key
     FROM projects
     LEFT JOIN project_widgets


### PR DESCRIPTION
## Purpose
Fix bug where geodash with 1 widget would not auto launch

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `CEO-### <title>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Testing
1. Create a project with Auto-launch Geo-Dash set
2. Add just 1 widget
3. Collect. 

The geodash window should pop up for each plot.

