### PR TITLE
CEO-493 import json, fix type checking 

### DIFF
--- a/src/py/gee/utils.py
+++ b/src/py/gee/utils.py
@@ -3,6 +3,7 @@ import os
 import ee
 import math
 import sys
+import json
 from ee.ee_exception import EEException
 from gee.inputs import getLandsat, getS1
 
@@ -41,7 +42,7 @@ def getReducer(reducer):
         return ee.Reducer.median()
 
 def safeParseJSON(val):
-    if type(val) == "<class 'dict'>":
+    if isinstance(val,  dict):
         return val
     else:
         try:


### PR DESCRIPTION
Add missing json import. Check value type with isinstance() rather than a string. Checking a dictionary against a string returns false and without json imported every time safeParseJSON is called an exception is thrown - thus resetting any visParams to an empty dictionary. This should fix CEO-493 unless there are other issues. I haven't had a chance to lest locally yet. 

## Purpose
Need to import json to use json.load()
Checking instance type using isinstance(). Checking type with a sting returns false (python 3.8.12)


## Related Issues
CEO-493

## Submission Checklist
- [ ] Included Jira issue in the PR title (e.g. `CEO-### <title>`)
- [ ] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Module(s) Impacted
<!-- List the Module > Submodule impacted by this PR (e.g. GeoDash > Help Page). -->
Geodash 

## Testing
<!-- Create a BDD style test script -->
1. Given..., When ..., Then ....


