### PR TITLE
Fix reducer renaming bands

### DIFF
--- a/src/py/gee/utils.py
+++ b/src/py/gee/utils.py
@@ -91,7 +91,10 @@ def imageCollectionToMapId(assetId, visParams, reducer, startDate, endDate):
     if reducer.lower() == 'mosaic':
         reducedImage = ee.Image(eeCollection.mosaic())
     else:
-        reducedImage = ee.Image(eeCollection.reduce(getReducer(reducer)))
+        bandNames = eeCollection.first().bandNames()
+        orderBandNames = ee.List.sequence(0,bandNames.length().subtract(1))
+        reducedImage = ee.Image(eeCollection.reduce(getReducer(reducer))) \
+            .select(orderBandNames, bandNames)
     return imageToMapId(reducedImage, visParams)
 
 # TODO, should we allow user to select first cloud free image again?


### PR DESCRIPTION
## Purpose
col.reduce(ee.Reducer) renames all bands to bandName_reducerName which causes a mismatch between the band names and image visualization json.

Fix: Get the band names before the reduction and their order before reducing the image collection. After the collection has been reduced to an image select the bands in the proper order and rename them to the original band names. 

Notes: No Jira issue that I can find. Not tested on local dev site, but python GEE code tested and works. 

## Related Issues
Closes CEO-###

## Submission Checklist
- [ ] Included Jira issue in the PR title (e.g. `CEO-### <title>`)
- [ ] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Module(s) Impacted
Imagery

## Testing
<!-- Create a BDD style test script -->
1. Given..., When ..., Then ....

## Screenshots
<!-- Add a screen shot when UI changes are included -->
