### PR TITLE
Switch from using dates to ISO date strings for the degradation widget.

### DIFF
--- a/src/js/geodash/GraphWidget.js
+++ b/src/js/geodash/GraphWidget.js
@@ -3,7 +3,7 @@ import Highcharts from "highcharts";
 import HighchartsReact from "highcharts-react-official";
 import _, {isArray} from "lodash";
 
-import {formatDateISO} from "../utils/generalUtils";
+import {formatDateISOString} from "../utils/generalUtils";
 
 window.Highcharts = Highcharts;
 
@@ -170,7 +170,7 @@ export default class GraphWidget extends React.Component {
                     cursor: "pointer",
                     events: {
                         select: e => {
-                            handleSelectDate(formatDateISO(new Date(e.target.x)));
+                            handleSelectDate(formatDateISOString(new Date(e.target.x)));
                         }
                     }
                 },

--- a/src/js/utils/generalUtils.js
+++ b/src/js/utils/generalUtils.js
@@ -54,6 +54,13 @@ export const monthlyMapping = {
     "12": "December"
 };
 
+export function formatDateISOString(date) {
+    const str = date.toISOString()
+    const re = /(\d{4}-\d{2}-\d{2})/g
+    
+    return str.match(re)[0]
+}
+
 export function formatDateISO(date) {
     const month = date.getMonth() + 1; // getMonth() is zero-based
     const day = date.getDate();


### PR DESCRIPTION
## Purpose
There was a mismatch between the image date displayed in the degradation widgets scatter chart and the date that was passed to the get image URL function. The mismatch caused Landsat images to not show up.  The JavaScript date was being coerced to the local time zone when the GEE image date in UTC milliseconds since epoch values were passed. 

Added function to force the date to stay in UTC.

```
// GEE image date 2000-01-11 in Mekong region.
var s = 947560246512
console.log(s)
console.log(new Date(s).toString())
console.log(new Date(s).toISOString())

>947560246512
>"Mon Jan 10 2000 21:10:46 GMT-0600 (Central Standard Time)"
>"2000-01-11T03:10:46.512Z"
```
Example illustrating the issue.

## Related Issues
Closes CEO-506

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `CEO-### <title>`)
- [ ] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Module(s) Impacted
<!-- List the Module > Submodule impacted by this PR (e.g. GeoDash > Help Page). -->
<!-- The current list of all Modules is: Home, Institution, Imagery, Projects, Wizard, Survey & Rules, Collection, and GeoDash. -->
<!-- For a list of all of the SubModules, please see the CEO Testing Plan (All Tests) spreadsheet. -->

## Testing
<!-- Create a BDD style test script -->
1. Given..., When ..., Then ....

