### PR TITLE
CEO-487 Statistics widget not reporting elevation and other stats.

### DIFF
--- a/src/py/gee/__init__.py
+++ b/src/py/gee/__init__.py
@@ -4,3 +4,4 @@ sys.path.append(os.path.dirname(__file__))
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
 import routes
+import utils

--- a/src/py/gee/utils.py
+++ b/src/py/gee/utils.py
@@ -640,12 +640,20 @@ def getStatistics(extent):
     extentGeom = ee.Geometry.Polygon(extent)
     elev = ee.Image('USGS/GTOPO30')
     minmaxElev = elev.reduceRegion(
-        ee.Reducer.minMax(), extentGeom, 1000, maxPixels=500000000)
+        reducer=ee.Reducer.minMax(),
+        geometry=extentGeom,
+        scale=30,
+        bestEffort=True,
+        maxPixels=500000000)
     minElev = minmaxElev.get('elevation_min').getInfo()
     maxElev = minmaxElev.get('elevation_max').getInfo()
     ciesinPopGrid = ee.Image('CIESIN/GPWv4/population-count/2020')
     popDict = ciesinPopGrid.reduceRegion(
-        ee.Reducer.sum(), extentGeom, maxPixels=500000000)
+        reducer=ee.Reducer.sum(),
+        geometry=extentGeom,
+        scale=30,
+        bestEffort=True,
+        maxPixels=500000000)
     pop = popDict.get('population-count').getInfo()
     pop = int(pop)
     return {

--- a/src/py/gee/utils.py
+++ b/src/py/gee/utils.py
@@ -638,11 +638,11 @@ def getDegradationPlotsByPoint(geometry, start, end, band):
 
 def getStatistics(extent):
     extentGeom = ee.Geometry.Polygon(extent)
-    elev = ee.Image('USGS/GTOPO30')
-    ciesinPopGrid = ciesinPopGrid =ee.ImageCollection("CIESIN/GPWv411/GPW_Population_Count").sort('system:time_start',False).first()
+    elevation = ee.Image('USGS/GTOPO30')
+    population = ee.ImageCollection("CIESIN/GPWv411/GPW_Population_Count").sort('system:time_start',False).first()
 
     def reduceElev():
-        minmaxElev = elev.reduceRegion(**{
+        minmaxElev = elevation.reduceRegion(**{
             'reducer':ee.Reducer.minMax(),
             'geometry' :extentGeom, 
             'scale':30,
@@ -657,7 +657,7 @@ def getStatistics(extent):
         })
     
     def reducePop ():
-        popDict = ciesinPopGrid.reduceRegion(**{
+        popDict = population.reduceRegion(**{
             'reducer':ee.Reducer.sum().unweighted(),
             'geometry': extentGeom, 
             'maxPixels':1e13,
@@ -668,7 +668,7 @@ def getStatistics(extent):
 
     def sampleElve():
         centriod = extentGeom.centroid(1)
-        sampleElv =  elev.reduceRegion(**{
+        sampleElv =  elevation.reduceRegion(**{
             'reducer':ee.Reducer.first(),
             'geometry': centriod, 
             'maxPixels':1e13,
@@ -681,7 +681,7 @@ def getStatistics(extent):
 
     def samplePop():
         centriod = extentGeom.centroid(1)
-        sample = ciesinPopGrid.reduceRegion(**{
+        sample = population.reduceRegion(**{
             'reducer':ee.Reducer.first(),
             'geometry': centriod, 
             'maxPixels':1e13,


### PR DESCRIPTION
## Purpose
Added import utils to __init__ to allow for autocompletion in VS Code. This makes development and testing easier.

The statistics widget was not reporting elevation statistics for small plots (e.g. smaller than 100m2). The scale for calculating the statistics was set too high to compute anything for these areas. The solution is to have a smaller scale and add the bestEffort parameter.  bestEffort will adjust the scale of the computation to ensure it does not fail. 

## Related Issues
Closes CEO-487

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `CEO-### <title>`)


## Module(s) Impacted
GeoDash

## Testing
Test small plots return statistics.
1. Create a new project .
2. In Plot Design - Add a random distribution of 2 plots and set plot width to 1m.
3. In Sample Design - choose Center for sample distribution.
4. Create project.
5. Add a Statists GeoDash widget.
6. Navigate to the first plots GeoDash widget in collection mode and inspect.

Desired outcome: The widget should display a numerical value for 'Elevation'. 'Elevation should not be 'N/A - N/A'

Test large plots return statistics.
1. Edit previous project.
2. In Plot Design - Update plot width to 10,000m.
3. Confirm edits to project.
4. Navigate to the first plots GeoDash widget in collection mode and inspect.

Desired outcome: The widget should display a numerical value for 'Elevation'. 'Elevation should not be 'N/A - N/A'. The widget should not time out.