### PR TITLE
SER-4 SumofAnswers rules bug and showing saved answers

### DIFF
--- a/src/js/collection.js
+++ b/src/js/collection.js
@@ -498,11 +498,9 @@ class Collection extends React.Component {
             mercator.samplesToVectorSource(visible),
             mercator.ceoMapStyles("geom", unansweredColor)
         );
-        mercator.enableSelection(
-            mapConfig,
-            "currentSamples",
-            sampleId => this.setState({selectedSampleId: sampleId})
-        );
+        mercator.enableSelection(mapConfig, "currentSamples", sampleId => {
+            sampleId != -1 && this.setState({selectedSampleId: sampleId});
+        });
     };
 
     featuresToDrawLayer = drawTool => {
@@ -796,7 +794,6 @@ class Collection extends React.Component {
 
                 mercator.highlightSampleGeometry(feature, color);
             });
-        this.setState({selectedSampleId: -1});
     };
 
     calcVisibleSamples = currentQuestionId => {

--- a/src/js/collection.js
+++ b/src/js/collection.js
@@ -498,9 +498,8 @@ class Collection extends React.Component {
             mercator.samplesToVectorSource(visible),
             mercator.ceoMapStyles("geom", unansweredColor)
         );
-        mercator.enableSelection(mapConfig, "currentSamples", sampleId => {
-            sampleId != -1 && this.setState({selectedSampleId: sampleId});
-        });
+        mercator.enableSelection(mapConfig, "currentSamples", sampleId =>
+            sampleId !== -1 && this.setState({selectedSampleId: sampleId}));
     };
 
     featuresToDrawLayer = drawTool => {

--- a/src/js/survey/SurveyCollection.js
+++ b/src/js/survey/SurveyCollection.js
@@ -161,7 +161,7 @@ export default class SurveyCollection extends React.Component {
 
     getSurveyAnswerText = (questionId, answerId) => {
         const {surveyQuestions} = this.props;
-        return _.get(surveyQuestions, [questionId, "answers", answerId, "answer"], "");
+        return _.get(surveyQuestions, [questionId, "answered", answerId, "answerText"], "");
     };
 
     checkRuleTextMatch = (surveyRule, questionIdToSet, _answerId, answerText) => {

--- a/src/js/survey/SurveyCollection.js
+++ b/src/js/survey/SurveyCollection.js
@@ -206,8 +206,8 @@ export default class SurveyCollection extends React.Component {
         ([_sqId, aq]) => aq.answered.map(a => a.sampleId)
     );
 
-    checkRuleSumOfAnswers = (surveyRule, questionIdToSet, answerId, _answerText) => {
-        const answerVal = Number(this.getSurveyAnswerText(questionIdToSet, answerId));
+    checkRuleSumOfAnswers = (surveyRule, questionIdToSet, answerId, answerText) => {
+        const answerVal = answerText || Number(this.getSurveyAnswerText(questionIdToSet, answerId));
         if (surveyRule.questionIds.includes(questionIdToSet)) {
             const answeredQuestions = this.getAnsweredQuestions(surveyRule.questionIds, questionIdToSet);
             if (surveyRule.questionIds.length === lengthObject(answeredQuestions) + 1) {
@@ -243,8 +243,8 @@ export default class SurveyCollection extends React.Component {
         }
     };
 
-    checkRuleMatchingSums = (surveyRule, questionIdToSet, answerId, _answerText) => {
-        const answerVal = Number(this.getSurveyAnswerText(questionIdToSet, answerId));
+    checkRuleMatchingSums = (surveyRule, questionIdToSet, answerId, answerText) => {
+        const answerVal = answerText || Number(this.getSurveyAnswerText(questionIdToSet, answerId));
         if (surveyRule.questionIds1.concat(surveyRule.questionIds2).includes(questionIdToSet)) {
             const answeredQuestions1 = this.getAnsweredQuestions(surveyRule.questionIds1, questionIdToSet);
             const answeredQuestions2 = this.getAnsweredQuestions(surveyRule.questionIds2, questionIdToSet);

--- a/src/js/survey/SurveyCollectionAnswers.js
+++ b/src/js/survey/SurveyCollectionAnswers.js
@@ -149,10 +149,11 @@ class AnswerInput extends React.Component {
                     />
                     <button
                         className="text-center btn btn-outline-lightgreen btn-sm ml-2"
+                        disabled={!newInput}
                         id="save-input"
                         name="save-input"
                         onClick={() => {
-                            if (!answer.required || newInput.length) {
+                            if (!answer.required || newInput) {
                                 validateAndSetCurrentValue(surveyNodeId, answerId, newInput);
                             }
                         }}


### PR DESCRIPTION
## Purpose
We allow for the sum check rule of questions to be run correctly. And also we allow for the user to see the answer of different plots when collecting and moving about. Previously the answers would not show on UI in the input field. 

## Related Issues
Closes COM-###

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `COM-### Did something here`)
- [x] Code passes linter rules (`npx eslint "src/js/**"`)
- [ ] No new reflection warnings (`clojure -M:check-reflection`)

## Testing
#### Module Impacted
<!-- List the Module > Submodule impacted by this test (e.g. Validation > Project Boundary or Subscriptions > Add) -->
<!-- The current list of all Modules is: Account, Home, Subscriptions, Stats, Validation, Reporting, and Admin. -->

#### Role
<!-- Admin, User, or Visitor -->

#### Steps
<!-- All steps needed to test this PR -->
1. Create a project with at least 2 questions with input of type number 
2. Add a sum rule for those questions (up to a number like 3) 
3. Start collecting on plots 
4. Input a number and then save it, move to the next plot 
5. Go back to the previous plot, the number inputed previously should still show up 
6. Go to next plot and save answer for it, such that its value combined with previous plot sums to bigger number set in the rule, hit save. 
7. You should see a popup telling you about the error, and giving you the constrained possible values that validate the rule for that input. 

## Screenshots
Values get shown when moving back to the plot. 

<img width="1233" alt="Screen Shot 2022-06-28 at 5 02 23 PM" src="https://user-images.githubusercontent.com/8908139/176323983-f3ef2310-12cd-4d75-87d9-e05fcc5f5e1e.png">

