### PR TITLE
Fix zero and number input types in sum rule

### DIFF
--- a/src/js/collection.js
+++ b/src/js/collection.js
@@ -727,7 +727,7 @@ class Collection extends React.Component {
             const newSamples = sampleIds.reduce((acc, sampleId) => {
                 const newQuestion = {
                     answerId,
-                    ...answerText && {answer: answerText}
+                    ...answerText !== "" && {answer: answerText}
                 };
 
                 const childQuestionIds = this.getChildQuestionIds(questionId);

--- a/src/js/survey/SurveyCollection.js
+++ b/src/js/survey/SurveyCollection.js
@@ -188,7 +188,7 @@ export default class SurveyCollection extends React.Component {
         Object.entries(answeredQuestions)
             .reduce((acc, [qId, aq]) => {
                 const answeredVal = Number(aq.answered.find(ans =>
-                    ans.sampleId === sampleId).answerText); 
+                    ans.sampleId === sampleId).answerText);
                 return acc + answeredVal;
             }, 0);
 

--- a/src/js/survey/SurveyCollection.js
+++ b/src/js/survey/SurveyCollection.js
@@ -218,7 +218,7 @@ export default class SurveyCollection extends React.Component {
                     const invalidSum = commonSampleIds
                         .map(sampleId => this.sumAnsweredQuestionsPerSample(answeredQuestions, sampleId))
                         .find(s => s + answerVal !== surveyRule.validSum);
-                    if (invalidSum) {
+                    if (invalidSum || invalidSum === 0) {
                         const {question} = this.props.surveyQuestions[questionIdToSet];
                         return `Sum of answers validation failed.\r\n\nSum for questions [${
                                 surveyRule.questionIds.map(q => this.getSurveyQuestionText(q)).toString()

--- a/src/js/survey/SurveyCollectionAnswers.js
+++ b/src/js/survey/SurveyCollectionAnswers.js
@@ -4,7 +4,6 @@ import SvgIcon from "../components/svg/SvgIcon";
 import RequiredInput from "../components/RequiredInput";
 
 import {firstEntry, mapObjectArray} from "../utils/sequence";
-import {isNumber} from "../utils/generalUtils";
 
 function AnswerButton({surveyNodeId, surveyNode, selectedSampleId, validateAndSetCurrentValue}) {
     const {answers, answered, dataType} = surveyNode;
@@ -18,8 +17,8 @@ function AnswerButton({surveyNodeId, surveyNode, selectedSampleId, validateAndSe
                             className="btn btn-outline-darkgray btn-sm btn-block pl-1 text-truncate"
                             id={ans.answer + "_" + ansId}
                             onClick={() => {
-                               const value = dataType === "number" ? Number(ans.answer) : ans.answer;
-                               validateAndSetCurrentValue(surveyNodeId, ansId, value)
+                                const value = dataType === "number" ? Number(ans.answer) : ans.answer;
+                                validateAndSetCurrentValue(surveyNodeId, ansId, value);
                             }}
                             style={{
                                 boxShadow: answered.some(a => a.answerId === ansId && a.sampleId === selectedSampleId)
@@ -66,8 +65,8 @@ function AnswerRadioButton({
                         <button
                             className="btn btn-outline-darkgray btn-sm btn-block pl-1 text-truncate"
                             onClick={() => {
-                              const value = dataType === "number" ? Number(ans.answer) : ans.answer;
-                                validateAndSetCurrentValue(surveyNodeId, ansId, value)
+                                const value = dataType === "number" ? Number(ans.answer) : ans.answer;
+                                validateAndSetCurrentValue(surveyNodeId, ansId, value);
                             }}
                             title={ans.answer}
                             type="button"

--- a/src/js/survey/SurveyCollectionAnswers.js
+++ b/src/js/survey/SurveyCollectionAnswers.js
@@ -4,9 +4,10 @@ import SvgIcon from "../components/svg/SvgIcon";
 import RequiredInput from "../components/RequiredInput";
 
 import {firstEntry, mapObjectArray} from "../utils/sequence";
+import {isNumber} from "../utils/generalUtils";
 
 function AnswerButton({surveyNodeId, surveyNode, selectedSampleId, validateAndSetCurrentValue}) {
-    const {answers, answered} = surveyNode;
+    const {answers, answered, dataType} = surveyNode;
     return (
         <ul className="samplevalue justify-content-center my-1">
             {mapObjectArray(answers, ([strId, ans]) => {
@@ -16,7 +17,10 @@ function AnswerButton({surveyNodeId, surveyNode, selectedSampleId, validateAndSe
                         <button
                             className="btn btn-outline-darkgray btn-sm btn-block pl-1 text-truncate"
                             id={ans.answer + "_" + ansId}
-                            onClick={() => validateAndSetCurrentValue(surveyNodeId, ansId, ans.answer)}
+                            onClick={() => {
+                               const value = dataType === "number" ? Number(ans.answer) : ans.answer;
+                               validateAndSetCurrentValue(surveyNodeId, ansId, value)
+                            }}
                             style={{
                                 boxShadow: answered.some(a => a.answerId === ansId && a.sampleId === selectedSampleId)
                                     ? "0px 0px 8px 3px black inset"
@@ -52,7 +56,7 @@ function AnswerRadioButton({
     selectedSampleId,
     validateAndSetCurrentValue
 }) {
-    const {answers, answered} = surveyNode;
+    const {answers, answered, dataType} = surveyNode;
     return (
         <ul className="samplevalue justify-content-center">
             {mapObjectArray(answers, ([strId, ans]) => {
@@ -61,7 +65,10 @@ function AnswerRadioButton({
                     <li key={ansId} className="mb-1">
                         <button
                             className="btn btn-outline-darkgray btn-sm btn-block pl-1 text-truncate"
-                            onClick={() => validateAndSetCurrentValue(surveyNodeId, ansId, ans.answer)}
+                            onClick={() => {
+                              const value = dataType === "number" ? Number(ans.answer) : ans.answer;
+                                validateAndSetCurrentValue(surveyNodeId, ansId, value)
+                            }}
                             title={ans.answer}
                             type="button"
                         >


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
In JavaScript 0 is falsy and most inputs are strings, this patch is to handle such exceptions/assumptions and making sure the value passed to model logic is of the expected type.

## Related Issues
Closes CEO-###

## Submission Checklist
- [ ] Included Jira issue in the PR title (e.g. `CEO-### <title>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Module(s) Impacted
<!-- List the Module > Submodule impacted by this PR (e.g. GeoDash > Help Page). -->
<!-- The current list of all Modules is: Home, Institution, Imagery, Projects, Wizard, Survey & Rules, Collection, and GeoDash. -->
<!-- For a list of all of the SubModules, please see the CEO Testing Plan (All Tests) spreadsheet. -->

## Testing
<!-- Create a BDD style test script -->
1. Given..., When ..., Then ....

## Screenshots
<!-- Add a screen shot when UI changes are included -->
1. Create a sum rule of 100 
2. Create 2 questions of type Answer Button (has 0 as possible choice) 
3. Create an other questions of type input 
4. When collecting, put 0 in first, then 0 in second 

Should show alert about not satisfied rule (sum to 100)