### PR TITLE
SER-85 Fix saving question answers when duplicates get generated

### DIFF
--- a/src/js/collection.js
+++ b/src/js/collection.js
@@ -1114,7 +1114,9 @@ class SideBar extends React.Component {
     const hasSamples = safeLength(currentPlot.samples) > 0;
     const allAnswered = everyObject(
       surveyQuestions,
-      ([_id, sq]) => safeLength(sq.visible) === safeLength(sq.answered)
+      ([_id, sq]) =>
+        (!sq.cardOrder && sq.parentQuestionId === -1) || // Skip over the duplicate questions
+        safeLength(sq.visible) === safeLength(sq.answered)
     );
     if (answerMode !== "question") {
       alert("You must be in question mode to save the collection.");


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
There is a problem in some projects that has child questions that depend on conditions in parent answers, somehow gets duplicated and when going through collection, these duplicate child questions get checked if they have been answered or not and that prevents the user from saving the plot answers. This fix (initial) tries to skip over such questions and hopefully we get to tackle it at the root to not produce such duplicates in the first place when designing questions/answers. 

## Related Issues
Closes SER-85

## Module(s) Impacted
Collection 

## Testing
<!-- Create a BDD style test script -->
1.  Create a project such as this one: https://collect.earth/collection?projectId=32124
   (It has many questions that are children to parent questions) 
2. Collect and answer questions 

The plots should be saved
