### PR TITLE
SER-297 Auto-populate the list with band names in Time series widget

### DIFF
--- a/src/js/geodash/TimeSeriesDesigner.js
+++ b/src/js/geodash/TimeSeriesDesigner.js
@@ -58,7 +58,7 @@ export default function TimeSeriesDesigner() {
             placeholder="LANDSAT/LC8_L1T_TOA"
             title="GEE Image Collection Asset ID"
             onBlur={() => getBandsFromGateway(setBands, assetId, assetType)}
-            onKeyPress={(e) =>
+            onKeyDown={(e) =>
               e.key === "Enter" && getBandsFromGateway(setBands, assetId, assetType)
             }
           />

--- a/src/js/geodash/TimeSeriesDesigner.js
+++ b/src/js/geodash/TimeSeriesDesigner.js
@@ -7,9 +7,43 @@ import GetBands from "./form/GetBands";
 
 import { EditorContext } from "./constants";
 
+export const getBandsFromGateway = (setBands, assetId, assetType) => {
+  if (assetId?.length) {
+    fetch("/geo-dash/gateway-request", {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        path: "getAvailableBands",
+        assetId,
+        assetType,
+      }),
+    })
+      .then((res) => (res.ok ? res.json() : Promise.reject()))
+      .then((data) => {
+        if (data.hasOwnProperty("bands")) {
+          setBands(data.bands);
+        } else if (data.hasOwnProperty("errMsg")) {
+          setBands(data.errMsg);
+        } else {
+          setBands(null);
+        }
+      })
+      .catch((error) => {
+        console.error(error);
+        setBands(null);
+      });
+  }
+};
+
 export default function TimeSeriesDesigner() {
   const [bands, setBands] = useState(null);
   const { getWidgetDesign } = useContext(EditorContext);
+  const assetId = getWidgetDesign("assetId");
+  const assetType = "imageCollection";
+
   return (
     <>
       <GDSelect
@@ -23,9 +57,13 @@ export default function TimeSeriesDesigner() {
             dataKey="assetId"
             placeholder="LANDSAT/LC8_L1T_TOA"
             title="GEE Image Collection Asset ID"
+            onBlur={() => getBandsFromGateway(setBands, assetId, assetType)}
+            onKeyPress={(e) =>
+              e.key === "Enter" && getBandsFromGateway(setBands, assetId, assetType)
+            }
           />
           <GetBands
-            assetId={getWidgetDesign("assetId")}
+            assetId={assetId}
             assetType="imageCollection"
             bands={bands}
             hideLabel

--- a/src/js/geodash/form/GDInput.js
+++ b/src/js/geodash/form/GDInput.js
@@ -2,7 +2,15 @@ import React, { useContext } from "react";
 
 import { EditorContext } from "../constants";
 
-export default function GDInput({ title, placeholder, dataKey, disabled, prefixPath = "" }) {
+export default function GDInput({
+  title,
+  placeholder,
+  dataKey,
+  disabled,
+  prefixPath = "",
+  onKeyPress,
+  onBlur,
+}) {
   const { setWidgetDesign, getWidgetDesign } = useContext(EditorContext);
   return (
     <div className="form-group">
@@ -15,6 +23,8 @@ export default function GDInput({ title, placeholder, dataKey, disabled, prefixP
         placeholder={placeholder}
         type="text"
         value={getWidgetDesign(dataKey, prefixPath)}
+        onKeyPress={onKeyPress}
+        onBlur={onBlur}
       />
     </div>
   );

--- a/src/js/geodash/form/GDInput.js
+++ b/src/js/geodash/form/GDInput.js
@@ -8,7 +8,7 @@ export default function GDInput({
   dataKey,
   disabled,
   prefixPath = "",
-  onKeyPress,
+  onKeyDown,
   onBlur,
 }) {
   const { setWidgetDesign, getWidgetDesign } = useContext(EditorContext);
@@ -16,15 +16,15 @@ export default function GDInput({
     <div className="form-group">
       <label htmlFor={dataKey}>{title}</label>
       <input
-        className="form-control"
         disabled={disabled}
         id={dataKey}
+        onBlur={onBlur}
         onChange={(e) => setWidgetDesign(dataKey, e.target.value, prefixPath)}
+        onKeyDown={onKeyDown}
         placeholder={placeholder}
         type="text"
         value={getWidgetDesign(dataKey, prefixPath)}
-        onKeyPress={onKeyPress}
-        onBlur={onBlur}
+        className="form-control"
       />
     </div>
   );

--- a/src/js/geodash/form/GetBands.js
+++ b/src/js/geodash/form/GetBands.js
@@ -2,46 +2,16 @@ import React from "react";
 
 import { isArray } from "../../utils/generalUtils";
 import SvgIcon from "../../components/svg/SvgIcon";
+import { getBandsFromGateway } from "../TimeSeriesDesigner";
 
 export default function GetBands({ bands, setBands, assetId, assetType, hideLabel }) {
-  const getBandsFromGateway = () => {
-    if (assetId.length) {
-      fetch("/geo-dash/gateway-request", {
-        method: "POST",
-        headers: {
-          Accept: "application/json",
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          path: "getAvailableBands",
-          assetId,
-          assetType,
-        }),
-      })
-        .then((res) => (res.ok ? res.json() : Promise.reject()))
-        .then((data) => {
-          if (data.hasOwnProperty("bands")) {
-            setBands(data.bands);
-          } else if (data.hasOwnProperty("errMsg")) {
-            setBands(data.errMsg);
-          } else {
-            setBands(null);
-          }
-        })
-        .catch((error) => {
-          console.error(error);
-          setBands(null);
-        });
-    }
-  };
-
   return (
     <>
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
         <label>Available Bands</label>
         <button
           className="btn btn-sm btn-secondary mb-1"
-          onClick={getBandsFromGateway}
+          onClick={getBandsFromGateway(setBands, assetId, assetType)}
           title="Refresh Available Bands"
           type="button"
         >


### PR DESCRIPTION
## Purpose
<!-- Description of what has been added/changed -->
When a custom image collection is inputted we want it to auto populate the list with band names ("onBlur" and "onEnterKey") (as opposed to the current functionality where it's blank until the refresh button is clicked)
## Related Issues
Closes CEO-###

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `CEO-### <title>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Module(s) Impacted
<!-- List the Module > Submodule impacted by this PR (e.g. GeoDash > Help Page). -->
<!-- The current list of all Modules is: Home, Institution, Imagery, Projects, Wizard, Survey & Rules, Collection, and GeoDash. -->
<!-- For a list of all of the SubModules, please see the CEO Testing Plan (All Tests) spreadsheet. -->