### PR TITLE
COL-466 Fix survey card reordering on new projects

### DIFF
--- a/src/js/survey/NewQuestionDesigner.js
+++ b/src/js/survey/NewQuestionDesigner.js
@@ -67,7 +67,9 @@ export default class NewQuestionDesigner extends React.Component {
       ) {
         const newId = getNextInSequence(Object.keys(surveyQuestions));
         const newCardOrder = getNextInSequence(
-          mapObjectArray(surveyQuestions, ([_id, sql]) => sql.cardOrder).filter((c) => c)
+          mapObjectArray(surveyQuestions, ([_id, sql]) => {
+            return sql.cardOrder;
+          })
         );
         const newQuestion = {
           question:


### PR DESCRIPTION
## Purpose
Fixing the survey card reordering -- the cardOrder attribute was not being set properly upon new question creation.

## Related Issues
Closes COL-466

## Submission Checklist
- [x] Included Jira issue in the PR title (e.g. `CEO-### <title>`)
- [x] Code passes linter rules (`npm run eslint`/`clj-kondo --lint src`)

## Module(s) Impacted
Survey & Rules > Card reordering

## Testing
1. Create a new project
2. Create at least two questions
3. Try to reorder the questions

The questions should reorder appropriately. 

