### PR TITLE
Hot fix to bug introduced in latest deployment

### DIFF
--- a/src/js/survey/NewQuestionDesigner.js
+++ b/src/js/survey/NewQuestionDesigner.js
@@ -67,9 +67,7 @@ export default class NewQuestionDesigner extends React.Component {
       ) {
         const newId = getNextInSequence(Object.keys(surveyQuestions));
         const newCardOrder = getNextInSequence(
-          mapObjectArray(surveyQuestions, ([_id, sql]) => {
-            return sql.cardOrder;
-          })
+          mapObjectArray(surveyQuestions, ([_id, sql]) => sql.cardOrder).filter((c) => c)
         );
         const newQuestion = {
           question:


### PR DESCRIPTION
## Purpose

Fixes a bug introduced when trying to fix the survey card reordering: #1608 . Note that this re-breaks the survey card reordering bug (each survey card has a `cardOrder` of 0 and is not able to be reordered properly in the UI).

This is a duplicate of #1610 so that we can deploy the change to production.
 

## Testing

### Module Impacted
 Survey & Rules > Create new question

### Role

User
### Steps


1. Create a question with a few answers.
2. Create a second question with the parent question set to the first question
3. Add some answers to the second question
4. Try to create a new question with new parents

### Desired Outcome

The question from step 4 should be created properly. 

