### PR TITLE
COL-418 Lower case user emails on registration and adding to institution

### DIFF
--- a/src/clj/collect_earth_online/db/users.clj
+++ b/src/clj/collect_earth_online/db/users.clj
@@ -44,7 +44,7 @@
 
 (defn register [{:keys [params]}]
   (let [reset-key             (str (UUID/randomUUID))
-        email                 (:email params)
+        email                 (str/lower-case (:email params))
         password              (:password params)
         password-confirmation (:passwordConfirmation params)]
     (if-let [error-msg (get-register-errors email password password-confirmation)]
@@ -196,7 +196,7 @@
       (data-response {}))))
 
 (defn update-institution-role [{:keys [params]}]
-  (let [new-user-email   (:newUserEmail params)
+  (let [new-user-email   (str/lower-case (:newUserEmail params))
         account-id       (if-let [id (:accountId params)]
                            (tc/val->int id)
                            (-> (call-sql "get_user_by_email" new-user-email)

--- a/src/js/register.js
+++ b/src/js/register.js
@@ -59,7 +59,7 @@ class Register extends React.Component {
                   autoComplete="off"
                   className="form-control"
                   id="email"
-                  onChange={(e) => this.setState({ email: e.target.value.toLowerCase() })}
+                  onChange={(e) => this.setState({ email: e.target.value })}
                   placeholder="Email"
                   type="email"
                   value={this.state.email}

--- a/src/js/register.js
+++ b/src/js/register.js
@@ -59,7 +59,7 @@ class Register extends React.Component {
                   autoComplete="off"
                   className="form-control"
                   id="email"
-                  onChange={(e) => this.setState({ email: e.target.value })}
+                  onChange={(e) => this.setState({ email: e.target.value.toLowerCase() })}
                   placeholder="Email"
                   type="email"
                   value={this.state.email}

--- a/src/js/reviewInstitution.js
+++ b/src/js/reviewInstitution.js
@@ -1296,6 +1296,7 @@ class UserList extends React.Component {
   updateUserInstitutionRole = (accountId, newUserEmail, newInstitutionRole) => {
     const existingRole = (this.state.institutionUserList.find((u) => u.id === accountId) || {})
       .institutionRole;
+    const lowerCaseNewUserEmail = newUserEmail.toLowerCase();
     const adminCount = this.state.institutionUserList.filter(
       (user) => user.institutionRole === "admin"
     ).length;
@@ -1312,7 +1313,7 @@ class UserList extends React.Component {
           },
           body: JSON.stringify({
             accountId,
-            newUserEmail,
+            newUserEmail: lowerCaseNewUserEmail,
             institutionId: this.props.institutionId,
             institutionRole: newInstitutionRole,
           }),

--- a/src/sql/changes/2023-04-17-lowercase-user-emails.sql
+++ b/src/sql/changes/2023-04-17-lowercase-user-emails.sql
@@ -1,0 +1,3 @@
+UPDATE users SET email = LOWER(email);
+
+REINDEX INDEX users_email_key;


### PR DESCRIPTION
## Purpose

Make user emails lowercase for registration.
The email field for inviting a user to an institution is case-insensitive.
Added a `.sql` change to update all existing user emails to lowercase.

## Related Issues

Closes COL-418

## Submission Checklist

- [x] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

Institution>Members

### Role

Admin

### Steps

#### Registration
1. Register as a new user with a mixed case email;
2. Make sure the email is lowercase.

#### Invite a user to the institution
1. Try inviting an existing user using some uppercase letters in the email.
2. Make sure the user is correctly invited and appears on the institution user's list.

### Desired Outcome

All existing user emails should be lowercase after running the query.
New users' emails should be saved as lowercase.
Inviting a user to an institution is case-insensitive.

## Screenshots

