### PR TITLE
COL-463 Refactor code for calculating area in Stats widget

### DIFF
--- a/src/js/geodash/StatsWidget.js
+++ b/src/js/geodash/StatsWidget.js
@@ -1,7 +1,6 @@
 import React from "react";
-
 import { Polygon } from "ol/geom";
-import { getArea as sphereGetArea } from "ol/sphere";
+import { mercator } from "../utils/mercator";
 
 export default class StatsWidget extends React.Component {
   constructor(props) {
@@ -58,13 +57,8 @@ export default class StatsWidget extends React.Component {
     }
   };
 
-  calculateArea = (poly) => {
-    try {
-      return sphereGetArea(new Polygon([poly]), { projection: "EPSG:4326" }) / 10000;
-    } catch (e) {
-      return "N/A";
-    }
-  };
+  calculateArea = (plotExtentPolygon) => 
+    mercator.calculateArea(new Polygon([plotExtentPolygon]));
 
   renderRow = (label, value, image) => (
     <div className="d-flex align-items-center mb-3">

--- a/src/js/utils/mercator.js
+++ b/src/js/utils/mercator.js
@@ -3,7 +3,7 @@
  *** Mercator-OpenLayers.js
  ***
  *** Author: Gary W. Johnson
- *** Copyright: 2017-2020 Spatial Informatics Group, LLC
+ *** Copyright: 2017-2023 Spatial Informatics Group, LLC
  *** License: LGPLv3
  ***
  *** Description: This library provides a set of functions for
@@ -1420,6 +1420,20 @@ mercator.addPlotLayer = (mapConfig, plots, _callback) => {
 
 /*****************************************************************************
  ***
+ *** Geodash Functions
+ ***
+ *****************************************************************************/
+
+mercator.calculateArea = (obj) => {
+  try {
+    return getArea(obj, { projection: "EPSG:4326" }) / 10000;
+  } catch (e) {
+    return "N/A";
+  }
+};
+
+/*****************************************************************************
+ ***
  *** Functions to export plot and sample features as KML
  ***
  *****************************************************************************/
@@ -1429,15 +1443,16 @@ mercator.asPolygonFeature = (feature) =>
     ? new Feature({ geometry: fromCircle(feature.getGeometry()) })
     : feature;
 
-mercator.calculateGeoJsonArea = (geoJson) => {
-  try {
-    return getArea(mercator.parseGeoJson(geoJson, false), { projection: "EPSG:4326" }) / 10000;
-  } catch (e) {
-    return "N/A";
-  }
-};
+mercator.calculateGeoJsonArea = (geoJson) =>
+  mercator.calculateArea(mercator.parseGeoJson(geoJson, false));
 
 mercator.getKMLFromFeatures = (features) =>
   new KML().writeFeatures(features, { featureProjection: "EPSG:3857" });
+
+/*****************************************************************************
+ ***
+ *** Export mercator
+ ***
+ *****************************************************************************/
 
 export { mercator };


### PR DESCRIPTION
## Purpose

Fix area calculation on stats widget and move it to `mercator.js`.

## Related Issues

Closes COL-463

## Submission Checklist

- [x] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

Geodash > Widget-Statistics 

### Role

Admin, User, Visitor

### Steps

1. Create a project with a statistics widget in geodash;
2. Navigate to collection;
3. Verify the area is correctly calculated.

### Desired Outcome

Have the correct area calculated in hectares.

## Screenshots

