### PR TITLE
initial fix geodash custom time series

### DIFF
--- a/src/js/geodash/GraphWidget.js
+++ b/src/js/geodash/GraphWidget.js
@@ -111,7 +111,7 @@ export default class GraphWidget extends React.Component {
 
   loadTimeSeries = () => {
     const { widget, plotExtentPolygon } = this.props;
-    const path = this.widgetIsCustom() ? "timeSeriesByAsset" : "timeSeriesByIndex";
+    const path = this.widgetIsCustom() ? "timeSeriesByIndex" : "timeSeriesByIndex"; // how to remove this line and have fn work still..?
     fetch("/geo-dash/gateway-request", {
       method: "POST",
       headers: {

--- a/src/py/gee/routes.py
+++ b/src/py/gee/routes.py
@@ -161,7 +161,7 @@ def getPlanetTile(requestDict):
 
 # ########## Time Series ##########
 
-
+# this would be deprecated if its not being used anywhere else
 def timeSeriesByAsset(requestDict):
     values = {
         'timeseries': getTimeSeriesByCollectionAndIndex(
@@ -186,7 +186,11 @@ def timeSeriesByIndex(requestDict):
             getDefault(requestDict, 'geometry', None),
             getDefault(requestDict, 'startDate', None),
             getDefault(requestDict, 'endDate', None),
-            'median'
+            'median',
+            getDefault(requestDict, 'assetId', None), # assetId is needed for the sourceName=='custom' case now
+            getDefault(requestDict, 'band', None), # band is needed for the sourceName=='custom' case now
+
+
         )
     }
     return values


### PR DESCRIPTION
## Purpose

Bug Fix  - Geodash Time Series graphs not loading when using Custom Image Collection assets

## Related Issues

Closes COL-462

## Submission Checklist

- [x] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [ ] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [ ] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted
Geodash > GraphWidget

### Role

Admin, User, or Visitor

### Steps

<!-- All steps needed to test this PR -->

1. Use or create a new project with GeoDash
2. At Edit Project step, Configure Geo-Dash
3. Add a new Widget -> Time Series
4. Use these settings: 
* Imagery Source: **Custom**
* GEE Image Collection Asset ID: **LANDSAT/LC09/C02/T1**
* Select a Band
* Don't select a reducer (to test more complex line graph)
* Select a time range of at least a year

Repeat step 4 to make 1 or 2 more graph widgets
Possible Image Collections to use:
MODIS/061/MOD09A1
COPERNICUS/S2_SR_HARMONIZED

### Desired Outcome

The time series graph loads a line graph after several seconds. 
---

<!-- If needed, add more tests using the format above (Module Impacted, Role, Steps, Desired Outcome) here. -->

## Screenshots

<!-- Add a screen shot when UI changes are included -->
