### PR TITLE
COL-468 Deleting a parent answer no longer breaks CEO

### DIFF
--- a/src/js/survey/SurveyDesignQuestion.js
+++ b/src/js/survey/SurveyDesignQuestion.js
@@ -162,7 +162,7 @@ export default function SurveyDesignQuestion({ indentLevel, editMode, surveyQues
                     {surveyQuestion.parentAnswerIds.length === 0
                       ? "Any"
                       : surveyQuestion.parentAnswerIds
-                          .map((paId) => parentQuestion.answers[paId].answer)
+                          .map((paId) => parentQuestion.answers[paId]?.answer)
                           .join(", ")}
                   </li>
                 </>


### PR DESCRIPTION
## Purpose

Added optional chaining to avoid breaking the project wizard when deleting an answer with child. 

## Related Issues

Closes COL-468

## Submission Checklist

- [x] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

Wizard > Survey questions

### Role

Admin

### Steps


1. Create a new project
2. Go to the survey questions;
3. Add a question with some answers;
4. Create another question using one of the previous question's answers as a parent;
5. Delete the parent answer;

### Desired Outcome

The page should no longer break when deleting a parent answer

