### PR TITLE
fix cloud coverage type

### DIFF
--- a/src/py/gee/utils.py
+++ b/src/py/gee/utils.py
@@ -271,7 +271,7 @@ def filteredSentinelComposite(visParams, startDate, endDate, metadataCloudCoverM
 
     sentinel2 = ee.ImageCollection('COPERNICUS/S2')
     f2017s2 = sentinel2.filterDate(startDate, endDate).filterMetadata(
-        'CLOUDY_PIXEL_PERCENTAGE', 'less_than', metadataCloudCoverMax)
+        'CLOUDY_PIXEL_PERCENTAGE', 'less_than', int(metadataCloudCoverMax))
     m2017s2 = f2017s2.map(scaleAndCloudScore)
     m2017s3 = m2017s2.qualityMosaic('cloudscore')
     return imageToMapId(m2017s3, visParams)


### PR DESCRIPTION
## Purpose

This is a hotfix PR to solve a high-priority bug.

filterMetadata method expects an integer and was being passed a string, making the Sentinel-2 composition fail.
Though this is not the best fix for this issue, it is the lowest-impact fix for it. With more time, a proper fix will be implemented and tested on the development branch before going to main.
