### PR TITLE
COL-461 Bugfix/geodash preloaded images not loading

### DIFF
--- a/src/clj/collect_earth_online/db/geodash.clj
+++ b/src/clj/collect_earth_online/db/geodash.clj
@@ -16,15 +16,15 @@
 
 (require-python '[sys :bind-ns])
 (py. (get-attr sys "path") "append" "src/py")
-(require-python '[gee.routes :as gee]
-                '[gee.utils :refer [initialize]])
+(require-python '[gee.routes :as gee :reload]
+                '[gee.utils :as utils :reload])
 
 (defonce last-initialized (atom 0))
 
 (defn- check-initialized []
   (when (> (- (System/currentTimeMillis) @last-initialized) max-age)
     (let [{:keys [ee-account ee-key-path]} (get-config :gee)]
-      (initialize ee-account ee-key-path)
+      (utils/initialize ee-account ee-key-path)
       (reset! last-initialized (System/currentTimeMillis)))))
 
 (defn- parse-py-errors [e]

--- a/src/js/geodash/MapWidget.js
+++ b/src/js/geodash/MapWidget.js
@@ -132,7 +132,6 @@ export default class MapWidget extends React.Component {
   };
 
   checkForCache = (postObject) => {
-    return null;
     const msPerDay = 24 * 60 * 60 * 1000;
     const jsonKey = JSON.stringify(postObject);
     const { url, lastGatewayUpdate } = JSON.parse(localStorage.getItem(jsonKey)) || {};

--- a/src/js/geodash/MapWidget.js
+++ b/src/js/geodash/MapWidget.js
@@ -132,6 +132,7 @@ export default class MapWidget extends React.Component {
   };
 
   checkForCache = (postObject) => {
+    return null;
     const msPerDay = 24 * 60 * 60 * 1000;
     const jsonKey = JSON.stringify(postObject);
     const { url, lastGatewayUpdate } = JSON.parse(localStorage.getItem(jsonKey)) || {};

--- a/src/py/gee/routes.py
+++ b/src/py/gee/routes.py
@@ -67,7 +67,7 @@ def filteredLandsat(requestDict):
         {
             'min': getDefault(requestDict, 'min', '0.03,0.01,0.05'),
             'max': getDefault(requestDict, 'max', '0.45,0.5,0.4'),
-            'bands': getDefault(requestDict, 'bands', 'B4,B5,B3')
+            'bands': getDefault(requestDict, 'bands', 'BLUE,RED,GREEN')
         },
         getDefault(requestDict, 'cloudLessThan', 60),
     )

--- a/src/py/gee/routes.py
+++ b/src/py/gee/routes.py
@@ -60,8 +60,8 @@ def imageCollection(requestDict):
 # ########## Pre defined ee.ImageCollection ##########
 
 def filteredLandsat(requestDict):
-    startDate = getDefault(requestDict, 'startDate')
-    endDate = getDefault(requestDict, 'endDate')
+    startDate = getDefault(requestDict, 'startDate', '1990-01-01')
+    endDate = getDefault(requestDict, 'endDate', '2100-01-01')
     values = filteredImageCompositeToMapId(
         getLandsatToa(startDate, endDate),
         {
@@ -74,8 +74,8 @@ def filteredLandsat(requestDict):
     return values
 
 def filteredNicfi(requestDict):
-    startDate = getDefault(requestDict, 'startDate')
-    endDate = getDefault(requestDict, 'endDate')
+    startDate = getDefault(requestDict, 'startDate', '1990-01-01')
+    endDate = getDefault(requestDict, 'endDate', '2100-01-01')
     values = filteredNicfiCompositeToMapId(
         getNICFI({'start':startDate, 'end':endDate}),
         {

--- a/src/py/gee/utils.py
+++ b/src/py/gee/utils.py
@@ -250,7 +250,7 @@ def filteredImageCompositeToMapId(eeCollection, visParams, metadataCloudCoverMax
     eeCollection = eeCollection.filterMetadata(
         'CLOUD_COVER',
         'less_than',
-        metadataCloudCoverMax
+        int(metadataCloudCoverMax)
         )
     eeMosaicImage = medoid(eeCollection,  ['BLUE', 'GREEN', 'RED', 'NIR', 'SWIR1', 'SWIR2'])
 


### PR DESCRIPTION
## Purpose

Preloaded Image Collection Widget was not loading composite imagery for Landsat and Sentinel-2. This PR fixes the issue


## Related Issues

Closes COL-###

## Submission Checklist

- [x] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

Geodash > Widget - Preloaded Image Collections 

### Role

Admin

### Steps

1. Create a Preloaded Image Collection for a project, choosing a composite imagery source, either Sentinel-2 or Lansat. Insert fields for start/end dates, bands, and cloud coverage;
2. Go to the collection page for the project;
3. Choose a plot and open the Geodash;
4. Composite imagery for this widget should load after 5 to 10 seconds.

### Desired Outcome

Widget works correctly by loading the composite imagery for the desired source.
