### PR TITLE
COL-478 dont allow to hide all answers

### DIFF
--- a/src/js/project/CreateProjectWizard.js
+++ b/src/js/project/CreateProjectWizard.js
@@ -401,12 +401,17 @@ export default class CreateProjectWizard extends React.Component {
     return errorList.filter((e) => e);
   };
 
+  allAnswersHidden = (answers) => {
+    const hiddenAnswers = filterObject(answers, ([_id, ans]) => ans.hide);
+    return lengthObject(answers) === lengthObject(hiddenAnswers);
+  }
+
   validateSurveyQuestions = () => {
     const { surveyQuestions } = this.context;
     const errorList = [
       lengthObject(surveyQuestions) === 0 && "A survey must include at least one question.",
-      someObject(surveyQuestions, ([_id, sq]) => lengthObject(sq.answers) === 0) &&
-        "All survey questions must contain at least one answer.",
+      someObject(surveyQuestions, ([_id, sq]) => (lengthObject(sq.answers) === 0 || this.allAnswersHidden(sq.answers))) &&
+        "All survey questions must contain at least one (unhidden) answer.",
     ];
     return errorList.filter((e) => e);
   };


### PR DESCRIPTION
## Purpose

Don't allow project admin to hide all answers to a question

## Related Issues

Closes COL-478

## Submission Checklist

- [x] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

Wizard > Survey Questions

### Role

Admin

### Steps

1. Create a survey question to a project;
2. Create a few answers to it;
3. hide all questions;
4. try to go to the next step.

### Desired Outcome

The user shouldn't be able to go to the next step if all answers for a question are hidden

