### PR TITLE
COL-460 Fixing default values and Bands for image collection asset widget

### DIFF
--- a/src/js/geodash/ImageCollectionAssetDesigner.js
+++ b/src/js/geodash/ImageCollectionAssetDesigner.js
@@ -35,7 +35,7 @@ export default function ImageCollectionAssetDesigner({ isDual = false, prefixPat
       />
       <GDTextArea
         dataKey="visParams"
-        placeholder={'{"bands": "B4, B3, B2", \n"min":0, \n"max": 0.3}'}
+        placeholder={'{"bands": "B4,B3,B2", \n"min":0, \n"max": 0.3}'}
         prefixPath={prefixPath}
         title="Image Parameters (JSON format)"
       />

--- a/src/py/gee/routes.py
+++ b/src/py/gee/routes.py
@@ -47,12 +47,16 @@ def image(requestDict):
 
 
 def imageCollection(requestDict):
+    visParams = safeParseJSON(getDefault(requestDict, 'visParams', {}))
+    if visParams.get("bands"):
+        bands = visParams.get("bands").replace(' ', '')
+        visParams.update({"bands": bands})
     values = imageCollectionToMapId(
         getDefault(requestDict, 'assetId', None),
-        safeParseJSON(getDefault(requestDict, 'visParams', {})),
+        visParams,
         getDefault(requestDict, 'reducer', 'Mean'),
-        getDefault(requestDict, 'startDate', None),
-        getDefault(requestDict, 'endDate', None)
+        getDefault(requestDict, 'startDate', '2022-01-01'),
+        getDefault(requestDict, 'endDate', '2022-12-31')
     )
     return values
 


### PR DESCRIPTION
## Purpose

<!-- Description of what has been added/changed -->

## Related Issues

Closes COL-460

## Submission Checklist

- [x] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

Geodash > Image Collection Asset

### Role

Admin, User

### Steps

1. Add a widget for Image Collection Asset for a project just like the screenshot in the Screenshots section;
2. Start collecting data for a plot in this project;
3. Open the Geodash window to see the widget.

### Desired Outcome

The Image Collection Asset should load the tiles for the specified image source in the widget creation.
If the tiles loaded are fully white or black, adjust the mix/max values.

## Screenshots

<img width="254" alt="image-20230406-203746" src="https://github.com/openforis/collect-earth-online/assets/18133069/e1f0ab4a-bb70-4d84-94e0-76c4c5ae99d6">

