### PR TITLE
Download shape files

### DIFF
--- a/src/clj/collect_earth_online/db/projects.clj
+++ b/src/clj/collect_earth_online/db/projects.clj
@@ -938,7 +938,7 @@
   [{:keys [params]}]
   (let [project-id (:projectId params)
         zip-file (zip-shape-files project-id)
-        file-name (last (str/split zip-file "/"))]
+        file-name (last (str/split zip-file #"/"))]
     (if zip-file
       {:headers {"Content-Type" "application/zip"
                  "Content-Disposition" (str "attachment; filename=" file-name)}

--- a/src/clj/collect_earth_online/db/projects.clj
+++ b/src/clj/collect_earth_online/db/projects.clj
@@ -7,7 +7,7 @@
    [clojure.set                                   :as set]
    [clojure.string                                :as str]
    [collect-earth-online.generators.clj-point     :refer [generate-point-plots generate-point-samples]]
-   [collect-earth-online.generators.external-file :refer [generate-file-plots generate-file-samples]]
+   [collect-earth-online.generators.external-file :refer [generate-file-plots generate-file-samples zip-shape-files]]
    [collect-earth-online.utils.geom               :refer [make-geo-json-polygon]]
    [collect-earth-online.utils.part-utils         :as pu]
    [collect-earth-online.views                    :refer [data-response]]
@@ -17,7 +17,8 @@
                                                           sql-primitive]]
    [triangulum.logging                            :refer [log]]
    [triangulum.type-conversion                    :as tc]
-   [triangulum.utils                              :as u]))
+   [triangulum.utils                              :as u]
+   [clojure.java.io :as io]))
 
 ;;;
 ;;; Auth functions
@@ -932,3 +933,16 @@
                                               ".csv")}
          :body (str/join "\n" (cons headers-out data-rows))})
       (data-response "Project not found."))))
+
+(defn create-shape-files
+  [{:keys [params]}]
+  (let [project-id (:projectId params)
+        zip-file (zip-shape-files project-id)
+        file-name (last (str/split zip-file "/"))]
+    (if zip-file
+      {:headers {"Content-Type" "application/zip"
+                 "Content-Disposition" (str "attachment; filename=" file-name)}
+       :body (io/file zip-file)
+       :status 200}
+      {:status 500
+       :body "Error generating shape files."})))

--- a/src/clj/collect_earth_online/db/projects.clj
+++ b/src/clj/collect_earth_online/db/projects.clj
@@ -4,21 +4,21 @@
    java.util.Date
    java.util.UUID)
   (:require
-   [clojure.set                                   :as set]
-   [clojure.string                                :as str]
+   [clojure.java.io :as io]
+   [clojure.set                                   :as    set]
+   [clojure.string                                :as    str]
    [collect-earth-online.generators.clj-point     :refer [generate-point-plots generate-point-samples]]
    [collect-earth-online.generators.external-file :refer [generate-file-plots generate-file-samples zip-shape-files]]
    [collect-earth-online.utils.geom               :refer [make-geo-json-polygon]]
-   [collect-earth-online.utils.part-utils         :as pu]
+   [collect-earth-online.utils.part-utils         :as    pu]
    [collect-earth-online.views                    :refer [data-response]]
    [triangulum.database                           :refer [call-sql
                                                           insert-rows!
                                                           p-insert-rows!
                                                           sql-primitive]]
    [triangulum.logging                            :refer [log]]
-   [triangulum.type-conversion                    :as tc]
-   [triangulum.utils                              :as u]
-   [clojure.java.io :as io]))
+   [triangulum.type-conversion                    :as    tc]
+   [triangulum.utils                              :as    u]))
 
 ;;;
 ;;; Auth functions
@@ -934,7 +934,7 @@
          :body (str/join "\n" (cons headers-out data-rows))})
       (data-response "Project not found."))))
 
-(defn create-shape-files
+(defn create-shape-files!
   [{:keys [params]}]
   (let [project-id (:projectId params)
         zip-file (zip-shape-files project-id)

--- a/src/clj/collect_earth_online/generators/external_file.clj
+++ b/src/clj/collect_earth_online/generators/external_file.clj
@@ -261,20 +261,22 @@
   [folder-name project-id table-name db-config]
   (sh-wrapper-quoted folder-name {}
                          (pgsql2shp-string db-config
-                                           (str project-id "-plots")
-                                           (str "\"SELECT * FROM " table-name "_shapes WHERE p_id=" project-id "\""))
-                         (str "7z a " project-id "-" table-name ".zip " project-id "-plots*")))
-
+                                           (str project-id "-" table-name)
+                                           (str "\"SELECT * FROM get_" table-name "_shapes(" project-id ")\""))))
 
 (defn create-shape-files
-  [table-name project-id]
-  (let [folder-name (str tmp-dir "/ceo-tmp-" project-id "-" table-name "/")
-        db-config   (get-config :database)
-        zip-name    (str project-id "-" table-name ".zip")]
+  [folder-name table-name project-id]
+  (let [shape-folder-name (str folder-name table-name "-shape-files/")
+        db-config   (get-config :database)]
+    (sh-wrapper folder-name {} (str "rm -rf " shape-folder-name) (str "mkdir " shape-folder-name))
+    (export-table-to-file shape-folder-name project-id table-name db-config)))
+
+(defn zip-shape-files
+  [project-id]
+  (let [folder-name (str tmp-dir "/ceo-tmp-" project-id "-files/")]
     (sh-wrapper tmp-dir {} (str "rm -rf " folder-name) (str "mkdir " folder-name))
-    (sh-wrapper-quoted folder-name {}
-                         (pgsql2shp-string db-config
-                                           (str project-id "-plots")
-                                           (str "\"SELECT * FROM " table-name "_shapes WHERE project_id=" project-id "\""))
-                         (str "7z a " zip-name " " project-id "-plots*"))
-    (str folder-name zip-name)))
+    (create-shape-files folder-name "plot" project-id)
+    (create-shape-files folder-name "sample" project-id)
+    (sh-wrapper tmp-dir {}
+                (str "7z a " folder-name "/files" ".zip " folder-name "/*"))
+    (str folder-name "files.zip")))

--- a/src/clj/collect_earth_online/routing.clj
+++ b/src/clj/collect_earth_online/routing.clj
@@ -104,7 +104,7 @@
    [:post "/update-project"]                 {:handler     projects/update-project!
                                               :auth-type   :admin
                                               :auth-action :block}
-   [:get "/create-shape-files"]             {:handler projects/create-shape-files
+   [:get "/create-shape-files"]              {:handler projects/create-shape-files!
                                               :auth-type :user
                                               :auth-action :block}
    ;; Plots API

--- a/src/clj/collect_earth_online/routing.clj
+++ b/src/clj/collect_earth_online/routing.clj
@@ -104,6 +104,7 @@
    [:post "/update-project"]                 {:handler     projects/update-project!
                                               :auth-type   :admin
                                               :auth-action :block}
+   [:post "/create-shape-files"]             {:handler projects/create-shape-files}
    ;; Plots API
    [:get  "/get-collection-plot"]            {:handler     plots/get-collection-plot
                                               :auth-type   :collect

--- a/src/clj/collect_earth_online/routing.clj
+++ b/src/clj/collect_earth_online/routing.clj
@@ -104,7 +104,9 @@
    [:post "/update-project"]                 {:handler     projects/update-project!
                                               :auth-type   :admin
                                               :auth-action :block}
-   [:post "/create-shape-files"]             {:handler projects/create-shape-files}
+   [:get "/create-shape-files"]             {:handler projects/create-shape-files
+                                              :auth-type :user
+                                              :auth-action :block}
    ;; Plots API
    [:get  "/get-collection-plot"]            {:handler     plots/get-collection-plot
                                               :auth-type   :collect

--- a/src/js/project/ManageProject.js
+++ b/src/js/project/ManageProject.js
@@ -310,6 +310,12 @@ class ProjectManagement extends React.Component {
               type="button"
               value="Download Sample Data"
             />
+            <input
+              className="btn btn-outline-lightgreen btn-sm w-100"
+              onClick={() => window.open(`/create-shape-files?projectId=${id}`, "_blank")}
+              type="button"
+              value="Download Shape Files"
+            />
           </div>
         </div>
       </div>

--- a/src/js/reviewInstitution.js
+++ b/src/js/reviewInstitution.js
@@ -1261,6 +1261,18 @@ function Project({ project, isAdmin, deleteProject }) {
               S
             </button>
           </div>
+          <div className="col-1 pl-0">
+            <button
+              className="btn btn-sm btn-outline-lightgreen btn-block"
+              onClick={() =>
+                window.open(`/create-shape-files?projectId=${project.id}`, "_blank")
+              }
+              title="Download Shape Files"
+              type="button"
+            >
+              Shapes
+            </button>
+          </div>
         </>
       )}
     </div>

--- a/src/sql/functions/plots.sql
+++ b/src/sql/functions/plots.sql
@@ -541,10 +541,10 @@ CREATE OR REPLACE FUNCTION get_plot_centers_by_project(_project_id integer)
 $$ LANGUAGE SQL;
 
 CREATE OR REPLACE FUNCTION get_plot_shapes(_project_id integer)
-  RETURNS TABLE (project_id integer,
-                 plot_id    integer,
-                 plot_geom  geometry(Geometry, 4326))
-  AS $$
+ RETURNS TABLE (project_id integer,
+                plot_id    integer,
+                plot_geom  geometry(Geometry, 4326)
+ ) AS $$
 
     WITH plot_geoms AS (SELECT project_rid, plot_distribution, plot_shape, plot_size, plot_uid,
                                ST_Transform(plot_geom, 3857) AS plot_geom
@@ -576,11 +576,11 @@ CREATE OR REPLACE FUNCTION get_plot_shapes(_project_id integer)
 $$ LANGUAGE SQL;
 
 CREATE OR REPLACE FUNCTION get_sample_shapes(_project_id integer)
-  RETURNS TABLE (project_id integer,
-                 plot_id integer,
-                 sample_id integer,
-                 sample_geom geometry(Geometry, 4326))
-  AS $$
+ RETURNS TABLE (project_id integer,
+                plot_id integer,
+                sample_id integer,
+                sample_geom geometry(Geometry, 4326)
+ ) AS $$
 
     (SELECT project_rid, plot_rid, sample_uid, sample_geom
        FROM samples s

--- a/src/sql/functions/plots.sql
+++ b/src/sql/functions/plots.sql
@@ -539,3 +539,59 @@ CREATE OR REPLACE FUNCTION get_plot_centers_by_project(_project_id integer)
     WHERE project_rid = _project_id
 
 $$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION get_plot_shapes(_project_id integer)
+  RETURNS TABLE (project_id integer,
+                 plot_id    integer,
+                 plot_geom  geometry(Geometry, 4326))
+  AS $$
+
+    WITH plot_geoms AS (SELECT project_rid, plot_distribution, plot_shape, plot_size, plot_uid,
+                               ST_Transform(plot_geom, 3857) AS plot_geom
+                        FROM projects AS pr
+                        INNER JOIN plots AS pl
+                        ON pr.project_uid = pl.project_rid
+                        WHERE project_uid = _project_id),
+
+         plot_boundaries AS (SELECT plot_uid,
+                                    CASE
+                                      WHEN plot_distribution = 'shp'
+                                      THEN plot_geom
+                                      WHEN plot_shape = 'circle'
+                                      THEN ST_Buffer(plot_geom, plot_size/2)
+                                      WHEN plot_shape = 'square'
+                                      THEN ST_MakeEnvelope(ST_X(plot_geom) - plot_size/2,
+                                                           ST_Y(plot_geom) - plot_size/2,
+                                                           ST_X(plot_geom) + plot_size/2,
+                                                           ST_Y(plot_geom) + plot_size/2,
+                                                           3857)
+                                      ELSE plot_geom
+                                    END AS plot_boundary
+                             FROM plot_geoms)
+
+      SELECT project_rid, plot_uid, ST_Transform(plot_geom, 4326) AS plot_geom
+      FROM plot_geoms
+      INNER JOIN plot_boundaries
+      USING (plot_uid)
+$$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION get_sample_shapes(_project_id integer)
+  RETURNS TABLE (project_id integer,
+                 plot_id integer,
+                 sample_id integer,
+                 sample_geom geometry(Geometry, 4326))
+  AS $$
+
+    (SELECT project_rid, plot_rid, sample_uid, sample_geom
+       FROM samples s
+       INNER JOIN plots pl
+       ON pl.plot_uid = s.plot_rid
+       WHERE pl.project_rid = _project_id)
+    UNION
+    (SELECT project_rid, plot_rid, sample_uid, sample_geom
+       FROM ext_samples s
+       INNER JOIN plots pl
+       ON pl.plot_uid = s.plot_rid
+       WHERE pl.project_rid = _project_id)
+
+$$ LANGUAGE SQL;


### PR DESCRIPTION
## Purpose

Download shape files for a project as a zipped folder.

## Related Issues

Closes COL-347

## Submission Checklist

- [x] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

Projects > Shape Files

### Role

User

### Steps

1. Go to an institution;
2. Click the button `Shape Files` for the desired project;
3. Accept the download for the `.zip` file

### Desired Outcome

The user should be able to open the plot and sample shape files in a GIS software (e.g. qGIS).

