### PR TITLE
COL-433: Fix Planet API integration

### DIFF
--- a/src/py/gee/planet.py
+++ b/src/py/gee/planet.py
@@ -154,7 +154,7 @@ def add_similar_features(feature, geometry, buffer):
     return features_layer(features, name)
 
 
-def getPlanetMapID(api_key, geometry, start, end=None, layerCount=1, item_types=['PSScene3Band', 'PSScene4Band'], buffer=0.5, addsimilar=True):
+def getPlanetMapID(api_key, geometry, start, end=None, layerCount=1, item_types=['PSScene'], buffer=0.5, addsimilar=True):
     fullList = []
     global PLANET_API_KEY
     PLANET_API_KEY = api_key

--- a/src/py/gee/routes.py
+++ b/src/py/gee/routes.py
@@ -152,12 +152,11 @@ def featureCollection(requestDict):
 def getPlanetTile(requestDict):
     values = getPlanetMapID(
         getDefault(requestDict, 'apiKey'),
-        getDefault(requestDict, 'geometry'), getDefault(
-            requestDict, 'startDate'),
+        getDefault(requestDict, 'geometry'),
+        getDefault(requestDict, 'startDate'),
         getDefault(requestDict, 'endDate', None),
         getDefault(requestDict, 'layerCount', 1),
-        getDefault(requestDict, 'itemTypes', [
-                    'PSScene3Band', 'PSScene4Band']),
+        getDefault(requestDict, 'itemTypes', ['PSScene']),
         float(getDefault(requestDict, 'buffer', 0.5)),
         bool(strtobool(getDefault(requestDict, 'addsimilar', 'True')))
     )


### PR DESCRIPTION
## Purpose

Planet API integration was not working due to using deprecated item_types as default values.

## Related Issues

Closes COL-433

## Submission Checklist

- [x] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

Imagery > Planet Daily

### Role

User

### Steps

1. Select "Planet Daily" imagery.
2. Change any of the parameters and click "Update Imagery".

### Desired Outcome

Images should load correctly
