### PR TITLE
COL-464: Fix NICFI images not loading when set to newest

### DIFF
--- a/src/js/geodash/MapWidget.js
+++ b/src/js/geodash/MapWidget.js
@@ -17,13 +17,20 @@ export default class MapWidget extends React.Component {
       timeOutRefs: [],
       overlayValue: 100,
       opacityValue: 100,
+      newestNicfiLayer: "",
     };
   }
 
   /// Lifecycle
 
   componentDidMount() {
-    this.initMap();
+    fetch("/get-nicfi-dates")
+      .then((response) => (response.ok ? response.json() : Promise.reject(response)))
+      .then((layers) => {
+        this.setState({ newestNicfiLayer: layers[0] })
+        this.initMap();
+      })
+      .catch((error) => console.error(error));
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -159,7 +166,17 @@ export default class MapWidget extends React.Component {
       this.props.imageryList.find((imagery) => imagery.title === "Open Street Map") ||
       this.props.imageryList[0];
     const basemapLayer = new TileLayer({
-      source: mercator.createSource(sourceConfig, id, attribution, isProxied),
+      source: mercator.createSource(sourceConfig,
+                                    id,
+                                    attribution,
+                                    isProxied,
+                                    [[-180, -90],
+                                     [180, -90],
+                                     [180, 90],
+                                     [-180, 90],
+                                     [-180, -90]],
+                                    false,
+                                    this.state.newestNicfiLayer),
     });
     const plotSampleLayer = new VectorLayer({
       source: this.props.vectorSource,

--- a/src/js/utils/mercator.js
+++ b/src/js/utils/mercator.js
@@ -256,11 +256,11 @@ mercator.createSource = (
     const dataLayer = (sourceConfig.time === "newest") ? newestNicfiLayer : sourceConfig.time;
     return new XYZ({
       url:
-      "get-nicfi-tiles?z={z}&x={x}&y={y}" +
+        "get-nicfi-tiles?z={z}&x={x}&y={y}" +
         `&dataLayer=${dataLayer}` +
         `&band=${sourceConfig.band}` +
         `&imageryId=${imageryId}`,
-      attributions: attribution
+      attributions: attribution,
     });
 
   } else if (type === "PlanetDaily") {

--- a/src/js/utils/mercator.js
+++ b/src/js/utils/mercator.js
@@ -220,7 +220,8 @@ mercator.createSource = (
     [-180, 90],
     [-180, -90],
   ],
-  show = false
+  show = false,
+  newestNicfiLayer = ""
 ) => {
   const { type } = sourceConfig;
   if (isProxied) {
@@ -252,14 +253,16 @@ mercator.createSource = (
       attributions: attribution,
     });
   } else if (type === "PlanetNICFI") {
+    const dataLayer = (sourceConfig.time === "newest") ? newestNicfiLayer : sourceConfig.time;
     return new XYZ({
       url:
-        "get-nicfi-tiles?z={z}&x={x}&y={y}" +
-        `&dataLayer=${sourceConfig.time}` +
+      "get-nicfi-tiles?z={z}&x={x}&y={y}" +
+        `&dataLayer=${dataLayer}` +
         `&band=${sourceConfig.band}` +
         `&imageryId=${imageryId}`,
-      attributions: attribution,
+      attributions: attribution
     });
+
   } else if (type === "PlanetDaily") {
     // make ajax call to get layerid then add xyz layer
     const theJson = {


### PR DESCRIPTION
## Purpose

When using Planet NICFI Imagery, when the user selected `newest imagery`  it would fail due to trying to pass `newest` as the mosaic name.
This PR fixes the issue by retrieving the newest NICFI mosaic layer before trying to get the imagery if it is set to `newest`.

## Related Issues

Closes COL-464

## Submission Checklist

- [x] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

Geodash > MapWidget

### Role

User

### Steps

1. Create a geodash widget for a project using Planet NICFI as a basemap;
2. Navigate to the project collection page;
3. Go to a plot and open the geodash;
4. NICFI imagery should load.

### Desired Outcome

NICFI imagery should load as a basemap
