### PR TITLE
COL-489: Fixing issues with QA/QC when using a project template

### DIFF
--- a/src/clj/collect_earth_online/db/projects.clj
+++ b/src/clj/collect_earth_online/db/projects.clj
@@ -347,6 +347,10 @@
   (when-let [assigned-plots (assign-user-plots current-plots design-settings)]
     (p-insert-rows! "plot_assignments" (assign-qaqc assigned-plots design-settings))))
 
+(defn- copy-template-plots [project-id template-id design-settings]
+  (call-sql "copy_template_plots" template-id project-id)
+  (assign-plots design-settings (call-sql "get_plot_centers_by_project" project-id)))
+
 (defn- create-project-plots! [project-id
                               plot-distribution
                               num-plots
@@ -465,7 +469,7 @@
     (try
       ;; Create or copy plots
       (if (and (pos? project-template) use-template-plots)
-        (call-sql "copy_template_plots" project-template project-id)
+        (copy-template-plots project-id project-template design-settings)
         (create-project-plots! project-id
                                plot-distribution
                                num-plots


### PR DESCRIPTION
## Purpose

User assignments were not being done when using a template project. This was due to only copying the plots from the template project to the current one, but not making the user assignments afterward.

This PR fixes this issue.

## Related Issues

Closes COL-489

## Submission Checklist

- [x] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

Wizard > Quality Control

### Role

Admin, User

### Steps

1. Create a project with an arbitrary number of plots and samples (may or may not have users assigned and QA/QC set);
2. Use the project created in the last step as a template for a new project;
3. For this second project, assign users and set QA/QC;
4. Create the project;
5. Test in collection if the project respects the QA/QC.

### Desired Outcome

QA/QC should work correctly when using another project as a template
