### PR TITLE
COL-406: Bump clojure version

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -6,7 +6,7 @@
         com.draines/postal        {:mvn/version "2.0.3"}
         com.cognitect/transit-clj {:mvn/version "1.0.324"}
         hiccup/hiccup             {:mvn/version "2.0.0-alpha2"}
-        org.clojure/clojure       {:mvn/version "1.10.1"}
+        org.clojure/clojure       {:mvn/version "1.11.1"}
         org.clojure/core.async    {:mvn/version "1.3.610"}
         org.clojure/data.json     {:mvn/version "1.0.0"}
         org.clojure/tools.cli     {:mvn/version "1.0.194"}


### PR DESCRIPTION
## Purpose

Bumping clojure version to 1.11.1