### PR TITLE
COL-508: Fix image collection assets bug

### DIFF
--- a/src/py/gee/routes.py
+++ b/src/py/gee/routes.py
@@ -48,7 +48,8 @@ def image(requestDict):
 
 def imageCollection(requestDict):
     visParams = safeParseJSON(getDefault(requestDict, 'visParams', {}))
-    if visParams.get("bands"):
+    bands = visParams.get("bands")
+    if bands and isinstance(bands, str):
         bands = visParams.get("bands").replace(' ', '')
         visParams.update({"bands": bands})
     values = imageCollectionToMapId(


### PR DESCRIPTION
## Purpose

Fix Image Collection Assets when passing visibility parameters as a list

## Related Issues

Closes COL-508

## Submission Checklist

- [ ] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [ ] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [ ] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

<!-- List the Module > Submodule impacted by this test (e.g. Validation > Project Boundary or Subscriptions > Add) -->
<!-- The current list of all Modules is: Home, Institution, Imagery, Projects, Wizard, Survey & Rules, Collection, GeoDash. -->

### Steps

1. Create an imagery for landsat using the GEE Image Collection Asset as the type;
2. Go to the collection page for a project that is using this imagery;
3. Change the imagery to be the one created in step one;
4. Image should load correctly.

