### PR TITLE
COL-491 fix plot lock issues

### DIFF
--- a/src/clj/collect_earth_online/db/plots.clj
+++ b/src/clj/collect_earth_online/db/plots.clj
@@ -240,17 +240,15 @@
                                                   plots))
                                            sorted-plots))]
     (if plots-info
-      (do
+      (try
         (unlock-plots user-id)
-        ;; TODO, CEO-90 Technically there is a race condition here.  We need a lock function
-        ;;       that returns truthy/falsy if it correctly created a unique lock.
-        ;;       The quickest way to finish this is to return a "race condition error."
-        ;;       If we get users complaining we can try a recursive find.
         (call-sql "lock_plot"
                   (:plot_id (first plots-info))
                   user-id
                   (time-plus-five-min))
-        (data-response (map #(build-collection-plot % user-id review-mode?) plots-info)))
+        (data-response (map #(build-collection-plot % user-id review-mode?) plots-info))
+       (catch Exception _e
+         (data-response "Unable to get the requested plot.  Please try again.")))
       (data-response "not-found"))))
 
 ;;;

--- a/src/js/collection.js
+++ b/src/js/collection.js
@@ -127,7 +127,7 @@ class Collection extends React.Component {
         this.showGeoDash();
       }
       clearInterval(this.state.storedInterval);
-      this.setState({ storedInterval: setInterval(this.resetPlotLock, 2.3 * 60 * 1000) });
+      this.setState({ storedInterval: setInterval(this.resetPlotLock, 1 * 60 * 1000) });
       //  updateMapImagery is poorly named, this function is detecting if we need to show the "zoom to" overlay
       this.updateMapImagery();
     }

--- a/src/sql/changes/2023-06-05-add-constraints.sql
+++ b/src/sql/changes/2023-06-05-add-constraints.sql
@@ -1,0 +1,4 @@
+ALTER TABLE IF EXISTS public.plot_locks DROP CONSTRAINT plot_locks_pkey;
+
+ALTER TABLE IF EXISTS public.plot_locks ADD CONSTRAINT plot_locks_plot_rid_key UNIQUE (plot_rid);
+ALTER TABLE IF EXISTS public.plot_locks ADD CONSTRAINT plot_locks_user_rid_key UNIQUE (user_rid);


### PR DESCRIPTION
## Purpose

Fix plot lock issue where it would allow two users to interpret the same plot.

## Related Issues

Closes COL-491

## Submission Checklist

- [x] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

Survey > plot collection

### Role

User

### Steps

1. Create a project with samples and no user assignment;
2. log into two different accounts;
3. Try to interpret the same plot with them;

### Desired Outcome

Interpreting a plot with two different accounts shouldn't be possible