### PR TITLE
COL-408: revert to previous answer

### DIFF
--- a/src/js/survey/SurveyCollection.js
+++ b/src/js/survey/SurveyCollection.js
@@ -402,9 +402,10 @@ export default class SurveyCollection extends React.Component {
     );
   };
 
-  validateAndSetCurrentValue = (questionIdToSet, answerId, answerText = null) => {
+  validateAndSetCurrentValue = (questionIdToSet, answerId, answerText = null, previousAnswer = null) => {
     const ruleError = this.rulesViolated(questionIdToSet, answerId, answerText);
     if (ruleError) {
+      this.props.setCurrentValue(questionIdToSet, answerId, previousAnswer);
       alert(ruleError);
     } else {
       this.props.setCurrentValue(questionIdToSet, answerId, answerText);

--- a/src/js/survey/SurveyCollectionAnswers.js
+++ b/src/js/survey/SurveyCollectionAnswers.js
@@ -123,12 +123,22 @@ class AnswerInput extends React.Component {
 
   resetInputText = () => {
     const answerId = Number(firstEntry(this.props.surveyNode.answers)[0]);
+    const answerText = this.props.surveyNode.answered[0]?.answerText;
+    const allSamplesMatch = this.props.surveyNode.answered.every(
+      (a) => {
+        return (a.answerId === answerId && (a.answerText === answerText && a.answerText != undefined))}
+    );
     const matchingNode = this.props.surveyNode.answered.find(
       (a) => a.answerId === answerId && a.sampleId === this.props.selectedSampleId
     );
-    this.setState({
-      newInput: matchingNode ? matchingNode.answerText : "",
-    });
+    if(allSamplesMatch) {
+      this.setState ({
+        newInput: this.props.surveyNode.answered[0] ? answerText : ""});
+    } else {
+      this.setState({
+        newInput: matchingNode ? matchingNode.answerText : ""
+      });
+    }
   };
 
   updateInputValue = (value) => this.setState({ newInput: value });
@@ -167,7 +177,7 @@ class AnswerInput extends React.Component {
           name="save-input"
           onClick={() => {
             if (!answer.required || newInput || newInput === 0) {
-              validateAndSetCurrentValue(surveyNodeId, answerId, newInput);
+              validateAndSetCurrentValue(surveyNodeId, answerId, newInput, answer.answer);
             }
           }}
           style={{ height: "2.5rem" }}


### PR DESCRIPTION
## Purpose

In case the input text fails the rules check, return the answer to what it was before

## Related Issues

Closes COL-408

## Submission Checklist

- [x] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

Survey > Collection

### Role

User

### Steps

1. Create a project with an input text/number that has a rule;
2. Go to the collection page;
3. Input a correct answer and save;
4. Input an incorrect answer and try to save.

### Desired Outcome

After the rule fails, the answer in the text/number input field should return to its former value.
