### PR TITLE
COL-345: Check rules before deleting questions

### DIFF
--- a/src/js/survey/AnswerDesigner.js
+++ b/src/js/survey/AnswerDesigner.js
@@ -19,6 +19,12 @@ export default class AnswerDesigner extends React.Component {
   removeAnswer = () => {
     const { surveyQuestionId, answerId } = this.props;
     const { surveyQuestions, setProjectDetails } = this.context;
+    const answerHasRule = this.answerRule(surveyQuestionId, parseInt(answerId));
+    if (answerHasRule) {
+      alert(
+        "This answer is being used in a rule. Please either delete or update the rule before removing the answer.");
+      return null;
+    }
     const matchingQuestion = findObject(
       surveyQuestions,
       ([_id, sq]) =>

--- a/src/js/survey/SurveyDesignQuestion.js
+++ b/src/js/survey/SurveyDesignQuestion.js
@@ -43,6 +43,11 @@ export default function SurveyDesignQuestion({ indentLevel, editMode, surveyQues
 
   const removeQuestion = () => {
     const childQuestionIds = getChildQuestionIds(surveyQuestionId);
+    const questionHasRules = checkQuestionRules(surveyQuestionId);
+    if(questionHasRules) {
+      alert("This question is being used in a rule. Please either delete or update the rule before removing the question");
+      return null;
+    }
     const newSurveyQuestions = filterObject(
       surveyQuestions,
       ([sqId]) => !childQuestionIds.includes(Number(sqId))
@@ -61,7 +66,9 @@ export default function SurveyDesignQuestion({ indentLevel, editMode, surveyQues
         (rl.questionId1 === questionId ||
          rl.questionId2 === questionId) ||
         // Rules for Sums of answers
-        (rl.questionIds?.includes(questionId))
+        (rl.questionIds?.includes(questionId)) ||
+        // Rules for Regex Matching or Number Range
+        (rl.questionId === questionId)
       ));
     return matchingRule;
   }


### PR DESCRIPTION
## Purpose

If a user deletes a question or answer referenced in a rule, it breaks the collection stage. This PR implements a check before deletion, which disallows the user to delete questions/answers in case they are being used in a rule.

## Related Issues

Closes COL-345

## Submission Checklist

- [x] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

 Survey & Rules > Survey

### Role

Admin

### Steps

1. Create a project containing several questions and answers;
2. Add a few rules to some questions or answers;
3. Try deleting questions and answers with no rules; you should be able to delete them;
4. Try deleting questions and answers referenced in a rule; It should give an alert and not delete them.

### Desired Outcome

Questions and answers not referenced in the rules should be deleted normally.
Questions and answers referenced in rules should not be deleted, and an alert should appear explaining.

