### PR TITLE
COL-520: Fix incorrect plot sizes

### DIFF
--- a/src/clj/collect_earth_online/utils/geom.clj
+++ b/src/clj/collect_earth_online/utils/geom.clj
@@ -4,6 +4,8 @@
 
 ;;; GeoJSON
 
+(def wsg84-radius 6378136.98)
+
 (defn make-wkt-point [lon lat]
   (format "POINT(%s %s)" lon lat))
 
@@ -20,7 +22,7 @@
   [& points]
   (let [points (mapv (fn [[lon lat]]
                        [(* lon 111319.490778)
-                        (-> lat (+ 90.0) (/ 360.0) (* Math/PI) (Math/tan) (Math/log) (* 6378136.98))])
+                        (-> lat (+ 90.0) (/ 360.0) (* Math/PI) (Math/tan) (Math/log) (* wsg84-radius))])
                      points)]
     (if (= 1 (count points))
       (first points)
@@ -31,8 +33,12 @@
   [& points]
   (let [points (mapv (fn [[x y]]
                        [(/ x 111319.490778)
-                        (-> y (/ 6378136.98) (Math/exp) (Math/atan) (/ Math/PI) (* 360.0) (- 90.0))])
+                        (-> y (/ wsg84-radius) (Math/exp) (Math/atan) (/ Math/PI) (* 360.0) (- 90.0))])
                      points)]
     (if (= 1 (count points))
       (first points)
       points)))
+
+(defn epsg3857-point-resolution
+  [point]
+  (/ 1 (Math/cosh (/ (second point) wsg84-radius))))

--- a/src/js/utils/mercator.js
+++ b/src/js/utils/mercator.js
@@ -26,7 +26,7 @@ import { GeoJSON, KML } from "ol/format";
 import { Tile as TileLayer, Vector as VectorLayer, Group as LayerGroup } from "ol/layer";
 import { BingMaps, Cluster, OSM, TileWMS, Vector as VectorSource, XYZ } from "ol/source";
 import { Circle as CircleStyle, Fill, Stroke, Style, Text as StyleText } from "ol/style";
-import { fromLonLat, transform, transformExtent } from "ol/proj";
+import { fromLonLat, transform, transformExtent, getPointResolution } from "ol/proj";
 import { fromExtent, fromCircle } from "ol/geom/Polygon";
 import { getArea } from "ol/sphere";
 import { formatDateISO, isNumber } from "./generalUtils";
@@ -988,13 +988,15 @@ mercator.geometryToGeoJSON = (geometry, toProjection, fromProjection = null, dec
   });
 };
 
+
 // [Pure] Returns a polygon geometry matching the passed in parameters.
 mercator.getPlotPolygon = (center, size, shape) => {
   const [centerX, centerY] = mercator.parseGeoJson(center, true).getCoordinates();
-  const radius = size / 2;
+  const radius = (size / 2) / (getPointResolution('EPSG:3857', 1, [centerX, centerY]));
+  
   return shape === "circle"
-    ? new Circle([centerX, centerY], radius)
-    : fromExtent([centerX - radius, centerY - radius, centerX + radius, centerY + radius]);
+    ? new Circle(center, radius)
+    : fromExtent([centerX - radius, centerY - radius, centerX + radius, centerY + radius])
 };
 
 // [Pure] Returns a new vector source containing the passed in plots.


### PR DESCRIPTION
## Purpose

When drawing and creating plots and samples, the application wasn't considering the latitude, making polygons smaller the further away they were from the Equator.  This PR fixes this issue by correcting the measurements in EPSG:3857.

## Related Issues

Closes COL-520

## Submission Checklist

- [x] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

Collection > Plots

### Role

User

### Steps

1. Create a project with either a circle or square plot, preferably in a place far from the Equator;
2. Start collection for the project;
3. Check for the size of the plot using the scale available on the map present on the collection page;
4. Export KML, use it in google earth, and measure the plot's side size or radius;
5. Open geodash and check that the plots are drawn correctly;

### Desired Outcome

Make sure in steps 3 and 4 that the measurements match the plot size set in project creation.

## Screenshots

<!-- Add a screen shot when UI changes are included -->
