### PR TITLE
WIP: COL-476: Add required fields geodash

### DIFF
--- a/src/js/geodash/form/BasemapSelector.js
+++ b/src/js/geodash/form/BasemapSelector.js
@@ -24,6 +24,7 @@ export default function BasemapSelector() {
         id="basemap-select"
         onChange={(e) => setWidgetDesign("basemapId", parseInt(e.target.value))}
         value={getWidgetDesign("basemapId")}
+        required
       >
         {(imagery || []).map(({ id, title }) => (
           <option key={id} value={id}>

--- a/src/js/geodash/form/GDInput.js
+++ b/src/js/geodash/form/GDInput.js
@@ -25,6 +25,7 @@ export default function GDInput({
         type="text"
         value={getWidgetDesign(dataKey, prefixPath)}
         className="form-control"
+        required
       />
     </div>
   );

--- a/src/js/geodash/form/GDSelect.js
+++ b/src/js/geodash/form/GDSelect.js
@@ -18,6 +18,7 @@ export default function GDSelect({ title, items, dataKey, prefixPath = "" }) {
         id={dataKey}
         onChange={(e) => setWidgetDesign(dataKey, e.target.value, prefixPath)}
         value={val}
+        required
       >
         {val === "-1" && (
           <option className="" value="-1">

--- a/src/js/geodash/form/GDTextArea.js
+++ b/src/js/geodash/form/GDTextArea.js
@@ -15,6 +15,7 @@ export default function GDTextArea({ title, placeholder, dataKey, prefixPath = "
         rows="4"
         style={{ overflow: "hidden", overflowWrap: "break-word", resize: "vertical" }}
         value={getWidgetDesign(dataKey, prefixPath)}
+        required
       />
     </div>
   );


### PR DESCRIPTION
## Purpose

Users are being able to create geodash widgets without inputting any required information on the geodash creation modals. This PR makes some fields required.

## Related Issues

Closes COL-476

## Submission Checklist

- [x] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

Geodash > geodash creation

### Role

Admin

### Steps

1. Create a project;
2. Go to the `Configure Geodash` page;
3. Try to create some geodash widgets without inputting any fields.

### Desired Outcome

User should not be able to create the geodash widgets while the required fields are empty.
