### PR TITLE
COL-522: Multiple interpretation review

### DIFF
--- a/src/js/collection.jsx
+++ b/src/js/collection.jsx
@@ -741,7 +741,7 @@ class Collection extends React.Component {
           if (this.state.inReviewMode) {
             this.setState({ remainingPlotters: this.state.remainingPlotters.filter((plotter) => plotter.userId != this.state.currentUserId) });
             if(this.state.remainingPlotters.length > 0) {
-              alert("There are more interpretations for this plot. Please select the user from the user dropdown to review another interpretation")
+              alert("There are more interpretations for this plot.\nPlease select the user from the user dropdown to review another interpretation.")
               return null;
             }
           }

--- a/src/js/collection.jsx
+++ b/src/js/collection.jsx
@@ -52,6 +52,8 @@ class Collection extends React.Component {
       messageBox: null,
       plotList: [],
       plotters: [],
+      userPlotList: [],
+      remainingPlotters: [],
       unansweredColor: "black",
       selectedQuestionId: -1,
       selectedSampleId: -1,
@@ -406,6 +408,7 @@ class Collection extends React.Component {
           } else {
             this.setState({
               userPlotList: data,
+              remainingPlotters: data,
               currentPlot: data[0],
               currentUserId: data[0].userId,
               ...this.newPlotValues(data[0]),
@@ -735,6 +738,13 @@ class Collection extends React.Component {
         }),
       }).then((response) => {
         if (response.ok) {
+          if (this.state.inReviewMode) {
+            this.setState({ remainingPlotters: this.state.remainingPlotters.filter((plotter) => plotter.userId != this.state.currentUserId) });
+            if(this.state.remainingPlotters.length > 0) {
+              alert("There are more interpretations for this plot. Please select the user from the user dropdown to review another interpretation")
+              return null;
+            }
+          }
           return this.navToNextPlot(true);
         } else {
           console.log(response);


### PR DESCRIPTION
## Purpose

Don't jump to another plot if there are still interpretations to be reviewed.

## Related Issues

Closes COL-522

## Submission Checklist

- [x] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

Collection

### Role

Admin

### Steps

1. Create a project that allows multiple interpretation of a plot;
2. Collect sample data with multiple users for the same plot;
3. Log in as a project admin or survey reviewer and start reviewing the interpretations;
4. the system should not jump the reviewer to another plot if there are still interpretations to be reviewed;

### Desired Outcome

The app will only redirect the reviewer to a new plot if all the interpretations of the current plot have been reviewed, otherwise it will create an alert telling the user that there are still interpretations to be reviewed.

## Screenshots

<!-- Add a screen shot when UI changes are included -->
