### PR TITLE
adds NBR, NDWI, NDVI to widget options

### DIFF
--- a/src/js/geodash/DegradationDesigner.jsx
+++ b/src/js/geodash/DegradationDesigner.jsx
@@ -10,7 +10,7 @@ export default function DegradationDesigner() {
       <BasemapSelector />
       <GDSelect
         dataKey="band"
-        items={["NDFI", "SWIR1", "NIR", "RED", "GREEN", "BLUE", "SWIR2"]}
+        items={["NDFI", "SWIR1", "NIR", "RED", "GREEN", "BLUE", "SWIR2", "NDVI", "NBR", "NDWI"]}
         title="Band to graph"
       />
       <GDDateRange />

--- a/src/js/geodash/DegradationWidget.jsx
+++ b/src/js/geodash/DegradationWidget.jsx
@@ -29,7 +29,7 @@ export default class DegradationWidget extends React.Component {
   render() {
     const { degDataType } = this.state;
     const { widget } = this.props;
-    const selectOptions = [
+    const sarBandOptions = [
       { label: "VV", value: "VV" },
       { label: "VH", value: "VH" },
       { label: "VV/VH", value: "VV/VH" },
@@ -103,7 +103,7 @@ export default class DegradationWidget extends React.Component {
                     height: "30px",
                   }}
                 >
-                  {selectOptions.map(({ value, label }) => (
+                  {sarBandOptions.map(({ value, label }) => (
                     <option key={value} value={value}>
                       {label}
                     </option>

--- a/src/js/geodash/TimeSeriesDesigner.jsx
+++ b/src/js/geodash/TimeSeriesDesigner.jsx
@@ -47,7 +47,7 @@ export default function TimeSeriesDesigner() {
 
   useEffect(() => {
     getBandsFromGateway(setBands, assetId, assetType).catch(console.error);
-  }, [])
+  }, []);
 
   return (
     <>
@@ -59,7 +59,7 @@ export default function TimeSeriesDesigner() {
       {getWidgetDesign("sourceName") === "Landsat" && (
         <GDSelect
           dataKey="indexName"
-          items={["NDVI", "EVI", "EVI 2", "NDMI", "NDWI"]}
+          items={["NDVI", "EVI", "EVI 2", "NDMI", "NDWI", "NBR"]}
           title="Band to graph"
         />
       )}


### PR DESCRIPTION
## Purpose

Added options to Degradation Wizard and Time Series Graph Widgets: [NDVI, NBR and NDWI] and [NBR] respectively.

## Related Issues

Closes COL-###

## Submission Checklist

- [ ] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [ ] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [ ] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

GeoDash

### Role

Admin

### Steps

Choose existing project and navigate to the GeoDash configuration page. Create a Time Series Graph and Select "NBR" as the band. Then create a Degradation Tool Widget and select either "NDVI", "NDWI", or "NBR" as the graph band. T

1.

### Desired Outcome

New widgets appear in the database with the aforementioned graph band options.

<!-- If needed, add more tests using the format above (Module Impacted, Role, Steps, Desired Outcome) here. -->

## Screenshots

<!-- Add a screen shot when UI changes are included -->
