### PR TITLE
Inject StyleNode to KML

### DIFF
--- a/src/js/collection.jsx
+++ b/src/js/collection.jsx
@@ -1504,7 +1504,7 @@ class ExternalTools extends React.Component {
       }
       href={
         "data:earth.kml+xml application/vnd.google-earth.kmz, " +
-        encodeURIComponent(this.props.KMLFeatures)
+          encodeURIComponent(this.props.KMLFeatures.replace(/Placemark><Polygon/, 'Placemark><Style><PolyStyle><fill>0</fill></PolyStyle> </Style><Polygon'))
       }
     >
       Download Plot KML
@@ -1512,6 +1512,9 @@ class ExternalTools extends React.Component {
   );
 
   render() {
+
+    if (typeof(this.props.KMLFeatures) === "string") {
+      console.log("js/collection KMLFeatures");};
     return this.props.currentPlot.id ? (
       <>
         <CollapsibleTitle

--- a/src/js/collection.jsx
+++ b/src/js/collection.jsx
@@ -635,6 +635,26 @@ class Collection extends React.Component {
     );
   };
 
+  fillNode = (kml, fill) => {
+    const styleNode = kml.createElement('Style');
+    const polyStyleNode = kml.createElement('PolyStyle');
+    const fillNode = kml.createElement('fill');
+    fillNode.textContent = fill | '0';
+    polyStyleNode.appendChild(fillNode);
+    styleNode.appendChild(polyStyleNode);
+    return styleNode;
+  };
+  
+  outlineKML = (KMLString) => {
+    const Parser = new DOMParser();
+    const Serializer = new XMLSerializer();
+    const parsedKML = Parser.parseFromString(KMLString, "text/xml");
+    const styleNode = this.fillNode(parsedKML, '0');
+    parsedKML.getElementsByTagName("Placemark")[0].insertBefore(styleNode, parsedKML.getElementsByTagName("Placemark")[0].children[0]);
+    return Serializer.serializeToString(parsedKML);
+ 
+  };
+
   createPlotKML = () => {
     const Parser = new DOMParser();
     const Serializer = new XMLSerializer();
@@ -644,16 +664,9 @@ class Collection extends React.Component {
       mercator.asPolygonFeature(plotFeatures[0]),
       ...sampleFeatures,
     ]);
-    const parsedKML = Parser.parseFromString(KMLFeatures, "text/xml");
-    const styleNode = parsedKML.createElement('Style');
-    const polyStyleNode = parsedKML.createElement('PolyStyle');
-    const fillNode = parsedKML.createElement('fill');
-    fillNode.textContent = '0';
-    polyStyleNode.appendChild(fillNode);
-    styleNode.appendChild(polyStyleNode);
-    parsedKML.getElementsByTagName("Placemark")[0].insertBefore(styleNode, parsedKML.getElementsByTagName("Placemark")[0].children[0]);
+
     this.setState({
-      KMLFeatures: Serializer.serializeToString(parsedKML)
+      KMLFeatures: this.outlineKML(KMLFeatures)
     });
   };
 

--- a/src/js/collection.jsx
+++ b/src/js/collection.jsx
@@ -652,12 +652,9 @@ class Collection extends React.Component {
     const styleNode = this.fillNode(parsedKML, '0');
     parsedKML.getElementsByTagName("Placemark")[0].insertBefore(styleNode, parsedKML.getElementsByTagName("Placemark")[0].children[0]);
     return Serializer.serializeToString(parsedKML);
- 
   };
 
   createPlotKML = () => {
-    const Parser = new DOMParser();
-    const Serializer = new XMLSerializer();
     const plotFeatures = mercator.getAllFeatures(this.state.mapConfig, "currentPlot");
     const sampleFeatures = mercator.getAllFeatures(this.state.mapConfig, "currentSamples");
     let KMLFeatures = mercator.getKMLFromFeatures([

--- a/src/js/collection.jsx
+++ b/src/js/collection.jsx
@@ -32,6 +32,7 @@ import {
 } from "./utils/sequence";
 import { getProjectPreferences, setProjectPreferences } from "./utils/preferences";
 import { mercator } from "./utils/mercator";
+import { outlineKML } from "./utils/kml";
 
 class Collection extends React.Component {
   constructor(props) {
@@ -635,24 +636,6 @@ class Collection extends React.Component {
     );
   };
 
-  fillNode = (kml, fill) => {
-    const styleNode = kml.createElement('Style');
-    const polyStyleNode = kml.createElement('PolyStyle');
-    const fillNode = kml.createElement('fill');
-    fillNode.textContent = fill | '0';
-    polyStyleNode.appendChild(fillNode);
-    styleNode.appendChild(polyStyleNode);
-    return styleNode;
-  };
-  
-  outlineKML = (KMLString) => {
-    const Parser = new DOMParser();
-    const Serializer = new XMLSerializer();
-    const parsedKML = Parser.parseFromString(KMLString, "text/xml");
-    const styleNode = this.fillNode(parsedKML, '0');
-    parsedKML.getElementsByTagName("Placemark")[0].insertBefore(styleNode, parsedKML.getElementsByTagName("Placemark")[0].children[0]);
-    return Serializer.serializeToString(parsedKML);
-  };
 
   createPlotKML = () => {
     const plotFeatures = mercator.getAllFeatures(this.state.mapConfig, "currentPlot");
@@ -663,7 +646,7 @@ class Collection extends React.Component {
     ]);
 
     this.setState({
-      KMLFeatures: this.outlineKML(KMLFeatures)
+      KMLFeatures: outlineKML(KMLFeatures)
     });
   };
 

--- a/src/js/utils/kml.js
+++ b/src/js/utils/kml.js
@@ -1,0 +1,18 @@
+const fillNode = (kml, fill) => {
+    const styleNode = kml.createElement('Style');
+    const polyStyleNode = kml.createElement('PolyStyle');
+    const fillNode = kml.createElement('fill');
+    fillNode.textContent = fill | '0';
+    polyStyleNode.appendChild(fillNode);
+    styleNode.appendChild(polyStyleNode);
+    return styleNode;
+  };
+  
+export function  outlineKML (KMLString) {
+    const Parser = new DOMParser();
+    const Serializer = new XMLSerializer();
+    const parsedKML = Parser.parseFromString(KMLString, "text/xml");
+    const styleNode = fillNode(parsedKML, '0');
+    parsedKML.getElementsByTagName("Placemark")[0].insertBefore(styleNode, parsedKML.getElementsByTagName("Placemark")[0].children[0]);
+    return Serializer.serializeToString(parsedKML);
+  };

--- a/src/js/utils/kml.js
+++ b/src/js/utils/kml.js
@@ -1,3 +1,17 @@
+/*****************************************************************************
+ ***
+ *** KML Support 
+ ***
+ *****************************************************************************/
+
+
+/*
+  fillNode: creates a <Style> node to inject into a KML string.
+  Parameters: (kml: string, fill: string)
+    kml is a string parsed from kml.
+    fill is a string representing a number that represents the 'fill' value of the generated style node. defaults to 0.
+  Return: stylenode: KML Node
+*/
 const fillNode = (kml, fill) => {
     const styleNode = kml.createElement('Style');
     const polyStyleNode = kml.createElement('PolyStyle');
@@ -7,7 +21,14 @@ const fillNode = (kml, fill) => {
     styleNode.appendChild(polyStyleNode);
     return styleNode;
   };
-  
+
+/*
+  outlineKML: Injects a Style Node into supplied KML.
+  Parameters: (KMLString: ol.format.KML)
+  Return: ol.format.KML
+  !! NOT PURE !!
+  mutates supplied KML object
+*/
 export function  outlineKML (KMLString) {
     const Parser = new DOMParser();
     const Serializer = new XMLSerializer();

--- a/src/js/utils/mercator.js
+++ b/src/js/utils/mercator.js
@@ -829,13 +829,21 @@ mercator.getCircleStyle = (radius, fillColor, border) =>
   new Style({
     image: new CircleStyle({
       radius,
-      fill: new Fill({ color: fillColor || "rgba(255, 255, 255, 0)" }),
+      fill: new Fill({ color: fillColor || "tansparent" }),
       stroke: new Stroke({
         color: border || "black",
         width: border ? 3 : 2,
       }),
     }),
   });
+
+mercator.outlineStyle = new Style({
+  fill: new Fill({
+    color: 'transparent'}),
+  stroke: new Stroke({
+    color: 'white',
+    width: 2})
+});
 
 // [Pure] Returns a style object that displays all geometry types to which it
 // is applied wth the specified lineColor, lineWidth, pointColor, pointRadius, pointFillColor, fillColor.
@@ -849,7 +857,7 @@ mercator.getGeomStyle = (
 ) =>
   new Style({
     fill: new Fill({
-      color: fillColor || "rgba(255, 255, 255, 0)",
+      color: fillColor || "transparent",
     }),
     stroke: new Stroke({
       color: lineColor,
@@ -857,7 +865,7 @@ mercator.getGeomStyle = (
     }),
     image: new CircleStyle({
       radius: pointRadius,
-      fill: new Fill({ color: pointFillColor || "rgba(255, 255, 255, 0)" }),
+      fill: new Fill({ color: pointFillColor || "transparent" }),
       stroke: new Stroke({
         color: pointColor,
         width: lineWidth,
@@ -879,7 +887,7 @@ const ceoMapPresets = {
 const ceoMapStyleFunctions = {
   geom: (color) => mercator.getGeomStyle(color, 4, color, 6),
   answered: (color) => mercator.getGeomStyle(color, 6, color, 6, color),
-  draw: (color) => mercator.getGeomStyle(color, 4, color, 6, null, "rgba(255, 255, 255, 0.2)"),
+  draw: (color) => mercator.getGeomStyle(color, 4, color, 6, null, "transparent"),
   overview: ({ color, border }) => mercator.getCircleStyle(6, color, border),
   cluster: (numPlots) => mercator.getClusterStyle(10, "#3399cc", "#ffffff", 1, numPlots),
 };
@@ -1007,7 +1015,7 @@ mercator.plotsToVectorSource = (plots) =>
       (plot) =>
         new Feature({
           plotId: plot.id,
-          geometry: mercator.parseGeoJson(plot.center, true),
+          geometry: mercator.parseGeoJson(plot.center, true)
         })
     ),
   });
@@ -1312,7 +1320,7 @@ mercator.enableDragBoxDraw = (mapConfig, callBack) => {
 // associated layer from mapConfig's map object.
 mercator.disableDragBoxDraw = (mapConfig) => {
   mercator.removeInteractionByTitle(mapConfig, "dragBoxDraw");
-  mercator.removeLayerById(mapConfig, "dragBoxLayer");
+  mercator.removnneLayerById(mapConfig, "dragBoxLayer");
   return mapConfig;
 };
 
@@ -1450,13 +1458,13 @@ mercator.calculateArea = (obj) => {
 
 mercator.asPolygonFeature = (feature) =>
   feature.getGeometry().getType() === "Circle"
-    ? new Feature({ geometry: fromCircle(feature.getGeometry()) })
-    : feature;
+  ? new Feature({ geometry: fromCircle(feature.getGeometry())})
+  : feature;
 
 mercator.calculateGeoJsonArea = (geoJson) =>
   mercator.calculateArea(mercator.parseGeoJson(geoJson, false));
 
-mercator.getKMLFromFeatures = (features) =>
+mercator.getKMLFromFeatures = (features) => 
   new KML().writeFeatures(features, { featureProjection: "EPSG:3857" });
 
 /*****************************************************************************

--- a/src/js/utils/mercator.js
+++ b/src/js/utils/mercator.js
@@ -839,7 +839,7 @@ mercator.getCircleStyle = (radius, fillColor, border) =>
 
 mercator.outlineStyle = new Style({
   fill: new Fill({
-    color: 'transparent'}),
+    color: 'rgba(255, 255, 255, 0)'}),
   stroke: new Stroke({
     color: 'white',
     width: 2})
@@ -857,7 +857,7 @@ mercator.getGeomStyle = (
 ) =>
   new Style({
     fill: new Fill({
-      color: fillColor || "transparent",
+      color: fillColor || "rgba(255, 255, 255, 0)",
     }),
     stroke: new Stroke({
       color: lineColor,
@@ -865,7 +865,7 @@ mercator.getGeomStyle = (
     }),
     image: new CircleStyle({
       radius: pointRadius,
-      fill: new Fill({ color: pointFillColor || "transparent" }),
+      fill: new Fill({ color: pointFillColor || "rgba(255, 255, 255, 0)" }),
       stroke: new Stroke({
         color: pointColor,
         width: lineWidth,
@@ -887,7 +887,7 @@ const ceoMapPresets = {
 const ceoMapStyleFunctions = {
   geom: (color) => mercator.getGeomStyle(color, 4, color, 6),
   answered: (color) => mercator.getGeomStyle(color, 6, color, 6, color),
-  draw: (color) => mercator.getGeomStyle(color, 4, color, 6, null, "transparent"),
+  draw: (color) => mercator.getGeomStyle(color, 4, color, 6, null, "rgba(255, 255, 255, 0)"),
   overview: ({ color, border }) => mercator.getCircleStyle(6, color, border),
   cluster: (numPlots) => mercator.getClusterStyle(10, "#3399cc", "#ffffff", 1, numPlots),
 };
@@ -1320,7 +1320,7 @@ mercator.enableDragBoxDraw = (mapConfig, callBack) => {
 // associated layer from mapConfig's map object.
 mercator.disableDragBoxDraw = (mapConfig) => {
   mercator.removeInteractionByTitle(mapConfig, "dragBoxDraw");
-  mercator.removnneLayerById(mapConfig, "dragBoxLayer");
+  mercator.removeLayerById(mapConfig, "dragBoxLayer");
   return mapConfig;
 };
 


### PR DESCRIPTION
## Purpose

<!-- Description of what has been added/changed -->

## Related Issues

Closes COL-###

## Submission Checklist

- [ ] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [ ] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [ ] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

Projects

### Role

Admin

### Steps

1. When logged in as an admin, navigate to a project under an institution. From there, Navigate to a Plot feature, such as by clicking "go to first plot."
2. Download the KML for the project plot by clicking "download plot kml." It is recommended to right-click this button and select "save link as" to facilitate retrieval of exported data. note the destination directory and filename of exported KML file.
3. open a KML browser (such as [Google Earth](https://earth.google.com/web/)).
4. In the case of Google Earth, open the "projects" sidebar from the options to the left. It's probably third from the bottom.
5. Use the "open" > "import KML file from computer" dropdown menu to select the KML file from step 2.



### Desired Outcome

---
6. Note the Ring around the plot sample features, and not a circle obscuring the topography behind.

<!-- If needed, add more tests using the format above (Module Impacted, Role, Steps, Desired Outcome) here. -->

## Screenshots

<!-- Add a screen shot when UI changes are included -->
