### PR TITLE
COL-513: Add combinatorial imagery for interpretation page

### DIFF
--- a/src/js/components/Select.jsx
+++ b/src/js/components/Select.jsx
@@ -24,6 +24,7 @@ export default function Select({
   options,
   valueKey,
   labelKey,
+  colSize,
 }) {
   return (
     <>
@@ -31,7 +32,7 @@ export default function Select({
         {label}
       </label>
       <select
-        className="form-control form-control-sm col-6"
+        className={`form-control form-control-sm ${colSize}`}
         disabled={disabled}
         id={id}
         onChange={onChange}

--- a/src/js/components/UserSelect.jsx
+++ b/src/js/components/UserSelect.jsx
@@ -17,6 +17,7 @@ export default function UserSelect({ label, id, possibleUsers = [], addUser }) {
         options={possibleUsers.length === 1 ? ["No users to assign."] : possibleUsers}
         value={selectedUserId}
         valueKey="id"
+        colSize="col-6"
       />
       <div className="col-1">
         <button

--- a/src/js/imagery/collectionMenuControls.jsx
+++ b/src/js/imagery/collectionMenuControls.jsx
@@ -746,6 +746,17 @@ export class GEEImageCollectionMenu extends React.Component {
           />
         </div>
         <div className="slide-container">
+          <label>Reducer</label>
+          <input
+            className="form-control"
+            id="geeImageCollectionEndDate"
+            max={new Date().toJSON().split("T")[0]}
+            onChange={(e) => this.setState({ endDate: e.target.value })}
+            type="date"
+            value={this.state.endDate}
+          />
+        </div>
+        <div className="slide-container">
           <label>Visualization Parameters</label>
           <textarea
             className="form-control"

--- a/src/js/imagery/collectionMenuControls.jsx
+++ b/src/js/imagery/collectionMenuControls.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 
+import Select from "../components/Select";
 import { mercator } from "../utils/mercator";
 import { monthlyMapping } from "../utils/generalUtils";
 
@@ -676,6 +677,7 @@ export class GEEImageCollectionMenu extends React.Component {
       startDate: this.props.sourceConfig.startDate,
       endDate: this.props.sourceConfig.endDate,
       visParams: this.props.sourceConfig.visParams,
+      reducer: this.props.sourceConfig.reducer,
     };
   }
 
@@ -696,12 +698,13 @@ export class GEEImageCollectionMenu extends React.Component {
         geeImageCollectionAssetId: this.props.sourceConfig.assetId,
         geeImageCollectionStartDate: this.state.startDate,
         geeImageCollectionEndDate: this.state.endDate,
+        geeImageCollectionReducer: this.state.reducer
       });
     }
   };
 
   updateGEEImageCollection = () => {
-    const { startDate, endDate, visParams } = this.state;
+    const { startDate, endDate, visParams, reducer } = this.state;
     if (new Date(startDate) > new Date(endDate)) {
       alert("Start date must be smaller than the end date.");
     } else {
@@ -715,6 +718,7 @@ export class GEEImageCollectionMenu extends React.Component {
           visParams,
           startDate,
           endDate,
+          reducer,
         })
       );
     }
@@ -746,14 +750,16 @@ export class GEEImageCollectionMenu extends React.Component {
           />
         </div>
         <div className="slide-container">
-          <label>Reducer</label>
-          <input
-            className="form-control"
-            id="geeImageCollectionEndDate"
-            max={new Date().toJSON().split("T")[0]}
-            onChange={(e) => this.setState({ endDate: e.target.value })}
-            type="date"
-            value={this.state.endDate}
+          <Select
+            disabled={false}
+            id="reducerSelect"
+            label="Reducer"
+            labelKey="email"
+            onChange={(e) => this.setState({ reducer: e.target.value })}
+            options={["Min", "Max", "Mean", "Median", "Mode", "Mosaic"]}
+            value={this.state.reducer}
+            valueKey="id"
+            colSize="col-12"
           />
         </div>
         <div className="slide-container">

--- a/src/js/utils/validation.js
+++ b/src/js/utils/validation.js
@@ -1,6 +1,6 @@
 import  _ from "lodash";
 import {  plotLimit, perPlotLimit, sampleLimit } from "../project/constants";
-import { lengthObject, someObject } from "./sequence";
+import { lengthObject, someObject, filterObject } from "./sequence";
 
 
 export default function getErrors (form) {
@@ -132,11 +132,16 @@ export default function getErrors (form) {
         "The sample size limit has been exceeded. Check the Sample Design section for detailed info.",
       allowDrawnSamples &&
         !Object.values(sampleGeometries).some((g) => g) &&
-        "At least one geometry type must be enabled.",];
+      "At least one geometry type must be enabled.",];
+
+  const allAnswersHidden = (answers) => {
+    const hiddenAnswers = filterObject(answers, ([_id, ans]) => ans.hide);
+    return lengthObject(answers) === lengthObject(hiddenAnswers);
+  }
 
   const questionsErrors = [
     lengthObject(surveyQuestions) === 0 && "A survey must include at least one question.",
-      someObject(surveyQuestions, ([_id, sq]) => (lengthObject(sq.answers) === 0 || this.allAnswersHidden(sq.answers))) &&
+      someObject(surveyQuestions, ([_id, sq]) => (lengthObject(sq.answers) === 0 || allAnswersHidden(sq.answers))) &&
         "All survey questions must contain at least one (unhidden) answer.",
   ];
 

--- a/src/py/gee/routes.py
+++ b/src/py/gee/routes.py
@@ -48,7 +48,7 @@ def image(requestDict):
 
 def imageCollection(requestDict):
     visParams = safeParseJSON(getDefault(requestDict, 'visParams', {}))
-    if visParams.get("bands"):
+    if visParams.get("bands") and isinstance(visParams.get("bands"), str):
         bands = visParams.get("bands").replace(' ', '')
         visParams.update({"bands": bands})
     values = imageCollectionToMapId(


### PR DESCRIPTION
## Purpose

Added the reducer options in the collection page so the users can change it during interpretation.
It is now possible to leave the end date empty in order to grab imagery information from the date set of the start date field

## Related Issues

Closes COL-513

## Submission Checklist

- [x] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

collection > imagery selection

### Role

User

### Steps

First test:

1. Start collecting a project that has either sentinel or landsat imagery enabled;
2. Remove the value from end date;
3. Imagery shown should be only from the specific date set on start date.

Second test:
1. Start collecting a project that has either sentinel or landsat imagery enabled;
2. Change the reducer type and set start and end dates;
3. Check that the imagery shown is correct according to the parameters;