### PR TITLE
adds alert message specific to admins when attempting to navigate in …

### DIFF
--- a/src/js/collection.jsx
+++ b/src/js/collection.jsx
@@ -402,9 +402,11 @@ class Collection extends React.Component {
         .then((response) => (response.ok ? response.json() : Promise.reject(response)))
         .then((data) => {
           if (data === "not-found") {
+            const err = (direction === "id" ? "Plot not" : "No more plots") +
+                  " found for this navigation mode.";
+            const reviewModeWarning = "\n If you have just changed navigation modes, please click the “Next” or “Back” arrows in order to see the plots for this navigation mode.";
             alert(
-              (direction === "id" ? "Plot not" : "No more plots") +
-                " found for this navigation mode."
+              inReviewMode ? err + reviewModeWarning : err
             );
           } else {
             this.setState({


### PR DESCRIPTION
…review mode

## Purpose

When administrators switch between navigation modes and then click “refresh” instead of one of the arrows, they see the “plot not found for this navigation mode” error. Updates error message with text “If you have just changed navigation modes, please click the “Next” or “Back” arrows in order to see the plots for this navigation mode.” 

## Related Issues

Closes COL-410

## Submission Checklist

- [x] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

Projects

### Role

Admin

### Steps

<!-- All steps needed to test this PR -->

1. in Collect-Earth-Online, log in as admin and navigate to test project.
2. change mode to "admin review." note button "go to plot" text changed to "refresh"
3. attempt to "refresh" the project


### Desired Outcome
Note updated error text with reference to navigation mode

Further testing:
repeat testing steps above when navigation mode is set to "collect" as opposed to "admin review"
for step 2, note that the button text has not changed
for step 3, attempt to "go to next plot"
note that the error text has not changed.

## Screenshots

<!-- Add a screen shot when UI changes are included -->
