### PR TITLE
Blank screen for required text

### DIFF
--- a/src/js/components/RequiredInput.jsx
+++ b/src/js/components/RequiredInput.jsx
@@ -11,7 +11,7 @@ export default function RequiredInput({
   required = true,
 }) {
   const [touched, setTouched] = useState(false);
-  const error = required && touched && value.length === 0;
+  const error = required && touched && (!value || value.length === 0);
   return (
     <div style={{ display: "flex", flexDirection: "column", alignItems: "start" }}>
       {label && (

--- a/src/js/survey/SurveyCollectionAnswers.jsx
+++ b/src/js/survey/SurveyCollectionAnswers.jsx
@@ -136,7 +136,7 @@ class AnswerInput extends React.Component {
         newInput: this.props.surveyNode.answered[0] ? answerText : ""});
     } else {
       this.setState({
-        newInput: matchingNode ? matchingNode.answerText : ""
+        newInput: matchingNode.answerText ? matchingNode.answerText : ""
       });
     }
   };


### PR DESCRIPTION
## Purpose

In cases where input text is required and the textbox is clicked on, an undefined value caused a typerror. Reported by Aurelie Shapiro. 

## Testing

Needed to manually set values for required and touch variables since this is a case where answerText was undefined. 

### Role

Admin

### Steps

Try a required text input field and saving the answer after clicking on the text box in a case where allSamplesMatch = false.

## Screenshots

https://github.com/openforis/collect-earth-online/assets/47796239/e2e7063f-7f26-46eb-b72c-51b1724bc9d7


