### PR TITLE
Bugfix/export custom drawn samples

### DIFF
--- a/src/sql/functions/plots.sql
+++ b/src/sql/functions/plots.sql
@@ -585,13 +585,13 @@ CREATE OR REPLACE FUNCTION get_sample_shapes(_project_id integer)
                 sample_geom geometry(Geometry, 4326)
  ) AS $$
 
-    (SELECT project_rid, plot_rid, sample_uid, ST_Buffer(sample_geom, 0.0001)
+    (SELECT project_rid, plot_rid, sample_uid, ST_Buffer(sample_geom, 0.000001)
        FROM samples s
        INNER JOIN plots pl
        ON pl.plot_uid = s.plot_rid
        WHERE pl.project_rid = _project_id)
     UNION
-    (SELECT project_rid, plot_rid, sample_uid as sample_uid, ST_Buffer(sample_geom, 0.0001)
+    (SELECT project_rid, plot_rid, sample_uid as sample_uid, ST_Buffer(sample_geom, 0.000001)
        FROM ext_samples s
        INNER JOIN plots pl
        ON pl.plot_uid = s.plot_rid

--- a/src/sql/functions/plots.sql
+++ b/src/sql/functions/plots.sql
@@ -585,13 +585,13 @@ CREATE OR REPLACE FUNCTION get_sample_shapes(_project_id integer)
                 sample_geom geometry(Geometry, 4326)
  ) AS $$
 
-    (SELECT project_rid, plot_rid, sample_uid, sample_geom
+    (SELECT project_rid, plot_rid, sample_uid, ST_Buffer(sample_geom, 0.0001)
        FROM samples s
        INNER JOIN plots pl
        ON pl.plot_uid = s.plot_rid
        WHERE pl.project_rid = _project_id)
     UNION
-    (SELECT project_rid, plot_rid, sample_uid as sample_uid, sample_geom
+    (SELECT project_rid, plot_rid, sample_uid as sample_uid, ST_Buffer(sample_geom, 0.0001)
        FROM ext_samples s
        INNER JOIN plots pl
        ON pl.plot_uid = s.plot_rid


### PR DESCRIPTION
## Purpose

Users were unable to export shape files in case the interpreters would draw their custom samples when collecting, this PR fixes this issue.

## Related Issues

Closes COL-547

## Submission Checklist

- [x] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

Project > Overview > Export shape files

### Role

Admin

### Steps


1. Create a project where the interpreters can draw their own shapes;
2. Go to the collection page of the project;
3. Answer the survey while drawing your own sample shapes (use lines and polygons);
4. Go to the project overview page and download shape files;

### Desired Outcome

The user should be able to download the shape files normally, even if there are multiple geometries drawn by the user

<!-- If needed, add more tests using the format above (Module Impacted, Role, Steps, Desired Outcome) here. -->

## Screenshots
![custom_shapes](https://github.com/openforis/collect-earth-online/assets/18133069/10ef3ee1-1763-473d-9fa5-34da382d5cff)
