### PR TITLE
COL-443: Imagery widget date

### DIFF
--- a/src/js/geodash/MapWidget.jsx
+++ b/src/js/geodash/MapWidget.jsx
@@ -157,10 +157,13 @@ export default class MapWidget extends React.Component {
     const { sourceConfig, id, attribution, isProxied } =
       this.props.imageryList.find((imagery) => imagery.id === widget.basemapId) ||
       this.props.imageryList.find((imagery) => imagery.title === "Open Street Map") ||
-      this.props.imageryList[0];
+          this.props.imageryList[0];
+    console.log("getting widget type", widget);
     const basemapLayer = new TileLayer({
       source: mercator.createSource(
-        sourceConfig,
+        (widget.basemapType === "PlanetNICFI") ? 
+          {... sourceConfig, time: widget.basemapNICFIDate}
+        : sourceConfig,
         id,
         attribution,
         isProxied,

--- a/src/js/geodash/MapWidget.jsx
+++ b/src/js/geodash/MapWidget.jsx
@@ -158,7 +158,6 @@ export default class MapWidget extends React.Component {
       this.props.imageryList.find((imagery) => imagery.id === widget.basemapId) ||
       this.props.imageryList.find((imagery) => imagery.title === "Open Street Map") ||
           this.props.imageryList[0];
-    console.log("getting widget type", widget);
     const basemapLayer = new TileLayer({
       source: mercator.createSource(
         (widget.basemapType === "PlanetNICFI") ? 

--- a/src/js/geodash/MapWidget.jsx
+++ b/src/js/geodash/MapWidget.jsx
@@ -157,7 +157,7 @@ export default class MapWidget extends React.Component {
     const { sourceConfig, id, attribution, isProxied } =
       this.props.imageryList.find((imagery) => imagery.id === widget.basemapId) ||
       this.props.imageryList.find((imagery) => imagery.title === "Open Street Map") ||
-          this.props.imageryList[0];
+      this.props.imageryList[0];
     const basemapLayer = new TileLayer({
       source: mercator.createSource(
         (widget.basemapType === "PlanetNICFI") ? 

--- a/src/js/geodash/TimeSeriesDesigner.jsx
+++ b/src/js/geodash/TimeSeriesDesigner.jsx
@@ -24,7 +24,6 @@ export async function getBandsFromGateway(setBands, assetId, assetType) {
       }
       );
       const data = await res.json();
-      console.log("data is: ", data);
       if (data.hasOwnProperty("bands")) {
         setBands(data.bands);
       } else if (data.hasOwnProperty("errMsg")) {

--- a/src/js/geodash/form/BasemapSelector.jsx
+++ b/src/js/geodash/form/BasemapSelector.jsx
@@ -66,7 +66,7 @@ export default function BasemapSelector() {
   return (
     <div className="form-group">
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-        <label htmlFor="basemap-select">Basemap</label> 
+        <label htmlFor="basemap-select">Basemap</label>
         <button
           className="btn btn-sm btn-secondary mb-1"
           onClick={getInstitutionImagery}

--- a/src/js/geodash/form/BasemapSelector.jsx
+++ b/src/js/geodash/form/BasemapSelector.jsx
@@ -1,11 +1,61 @@
-import React, { useContext } from "react";
+import React, { useContext, useState, useEffect } from "react";
 
 import { EditorContext } from "../constants";
 import SvgIcon from "../../components/svg/SvgIcon";
 
+
 export default function BasemapSelector() {
   const { setWidgetDesign, getWidgetDesign, imagery, getInstitutionImagery, institutionId } =
-    useContext(EditorContext);
+        useContext(EditorContext);
+  const [nicfiLayers, setNICFILayers] = useState([]);
+  const [imageryType, setImageryType] = useState("");
+  
+  function nicfiDateSelector(){
+    const options = (
+      nicfiLayers || []).map(
+        (l)=>{
+          const name = l.slice(34, l.length - 7); 
+          return (
+            <option
+              value={l}
+              key={name}
+            >
+              {name}
+            </option>);}
+      );
+    
+    return (
+      <select
+        className="form-control"
+        id="nicfi-layer"
+        onChange={(e)=>{setWidgetDesign("basemapNICFIDate", e.target.value);}}
+        value={getWidgetDesign("basemapNICFIDate") || ""}         
+      >
+        {options}
+      </select>);
+  }
+  
+  const getNICFILayers = () => {
+    fetch("/get-nicfi-dates")
+      .then((response) => (response.ok ? response.json() : Promise.reject(response)))
+      .then((layers) => {
+        setNICFILayers(layers);
+        setWidgetDesign("basemapNICFIDate", layers[0]);        
+      })
+      .catch((error) => console.error(error));
+  };
+  
+  useEffect(()=> {
+    (imageryType === "PlanetNICFI") ?
+      getNICFILayers() 
+      : setWidgetDesign("basemapNICFIDate", null);
+  }, [imageryType]);
+  
+  useEffect(()=>{
+    setImageryType((imagery || []).filter((i)=> i.id === getWidgetDesign("basemapId"))[0].sourceConfig.type);
+    
+  }, [imagery]);
+  
   return (
     <div className="form-group">
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
@@ -22,16 +72,19 @@ export default function BasemapSelector() {
       <select
         className="form-control"
         id="basemap-select"
-        onChange={(e) => setWidgetDesign("basemapId", parseInt(e.target.value))}
+        onChange={(e) => {
+          setWidgetDesign("basemapId", parseInt(e.target.value));
+          setImageryType(imagery.filter((i)=> i.id.toString() === e.target.value)[0].sourceConfig.type);}}
         value={getWidgetDesign("basemapId")}
         required
       >
-        {(imagery || []).map(({ id, title }) => (
+        {(imagery || []).map(({ id, title}) => (
           <option key={id} value={id}>
             {title}
           </option>
         ))}
       </select>
+      {(imageryType === "PlanetNICFI") && nicfiDateSelector()}
       <div style={{ fontSize: ".85em", padding: "0 .5rem" }}>
         Adding imagery to basemaps is available on the&nbsp;
         <a

--- a/src/js/geodash/form/BasemapSelector.jsx
+++ b/src/js/geodash/form/BasemapSelector.jsx
@@ -5,11 +5,12 @@ import SvgIcon from "../../components/svg/SvgIcon";
 
 
 export default function BasemapSelector() {
-  const { setWidgetDesign, getWidgetDesign, imagery, getInstitutionImagery, institutionId } =
+  const { widget, widgetDesign, setWidgetDesign, getWidgetDesign, imagery, getInstitutionImagery, institutionId } =
         useContext(EditorContext);
   const [nicfiLayers, setNICFILayers] = useState([]);
   const [imageryType, setImageryType] = useState("");
-  
+  const [basemap, setBasemap] = useState(imagery.filter((i)=>i.id === getWidgetDesign("basemapId")));
+
   function nicfiDateSelector(){
     const options = (
       nicfiLayers || []).map(
@@ -22,17 +23,22 @@ export default function BasemapSelector() {
             >
               {name}
             </option>);}
-      );
-    
+      );    
     return (
-      <select
-        className="form-control"
-        id="nicfi-layer"
-        onChange={(e)=>{setWidgetDesign("basemapNICFIDate", e.target.value);}}
-        value={getWidgetDesign("basemapNICFIDate") || ""}         
-      >
-        {options}
-      </select>);
+      <div>
+        <label htmlFor="nicfi-layer">Select Date:</label> 
+        <select
+          className="form-control"
+          id="nicfi-layer"
+          onChange={(e)=>{            
+            setWidgetDesign("basemapNICFIDate", e.target.value);
+          }}
+          value={
+            getWidgetDesign("basemapNICFIDate")}         
+        >          
+          {options}
+        </select>
+      </div>);
   }
   
   const getNICFILayers = () => {
@@ -40,7 +46,7 @@ export default function BasemapSelector() {
       .then((response) => (response.ok ? response.json() : Promise.reject(response)))
       .then((layers) => {
         setNICFILayers(layers);
-        setWidgetDesign("basemapNICFIDate", layers[0]);        
+        setWidgetDesign("basemapNICFIDate", widget[0].basemapNICFIDate);        
       })
       .catch((error) => console.error(error));
   };
@@ -54,13 +60,13 @@ export default function BasemapSelector() {
   
   useEffect(()=>{
     setImageryType((imagery || []).filter((i)=> i.id === getWidgetDesign("basemapId"))[0].sourceConfig.type);
-    
+    setBasemap((imagery || []).filter((i)=> i.id === getWidgetDesign("basemapId"))[0]);
   }, [imagery]);
   
   return (
     <div className="form-group">
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-        <label htmlFor="basemap-select">Basemap</label>
+        <label htmlFor="basemap-select">Basemap</label> 
         <button
           className="btn btn-sm btn-secondary mb-1"
           onClick={getInstitutionImagery}
@@ -75,6 +81,7 @@ export default function BasemapSelector() {
         id="basemap-select"
         onChange={(e) => {
           setWidgetDesign("basemapId", parseInt(e.target.value));
+          setBasemap(imagery.filter((i)=> i.id.toString() === e.target.value)[0]);
           setImageryType(imagery.filter((i)=> i.id.toString() === e.target.value)[0].sourceConfig.type);}}
         value={getWidgetDesign("basemapId")}
         required

--- a/src/js/geodash/form/BasemapSelector.jsx
+++ b/src/js/geodash/form/BasemapSelector.jsx
@@ -46,6 +46,7 @@ export default function BasemapSelector() {
   };
   
   useEffect(()=> {
+    setWidgetDesign("basemapType", imageryType);
     (imageryType === "PlanetNICFI") ?
       getNICFILayers() 
       : setWidgetDesign("basemapNICFIDate", null);

--- a/src/js/widgetLayoutEditor.jsx
+++ b/src/js/widgetLayoutEditor.jsx
@@ -312,9 +312,10 @@ class WidgetLayoutEditor extends React.PureComponent {
   };
 
   buildNewWidget = () => {
-    const { title, type, widgetDesign } = this.state;
+    const { title, type, widgetDesign, basemapNICFIDate } = this.state;
     return {
       name: title,
+      basemapNICFIDate,
       type,
       ...widgetDesign,
     };
@@ -346,7 +347,7 @@ class WidgetLayoutEditor extends React.PureComponent {
   saveWidgetEdits = () => {
     const {
       originalWidget: { id, layout },
-    } = this.state;
+    } = this.state;    
     const errors = this.getWidgetErrors();
     if (errors.length) {
       alert(errors.join("\n\n"));
@@ -502,6 +503,7 @@ class WidgetLayoutEditor extends React.PureComponent {
           setWidgetDesign: this.setWidgetDesign,
           widgetDesign: this.state.widgetDesign,
           imagery: this.state.imagery,
+          widget: this.state.widgets.filter((w)=>w.basemapId === this.state.widgetDesign.basemapId)[0],
           getInstitutionImagery: this.getInstitutionImagery,
         }}
       >

--- a/src/js/widgetLayoutEditor.jsx
+++ b/src/js/widgetLayoutEditor.jsx
@@ -461,7 +461,12 @@ class WidgetLayoutEditor extends React.PureComponent {
             className="form-control"
             id="widgetTitle"
             onChange={(e) => this.updateTitle(e.target.value)}
-            placeholder="Enter title"
+            placeholder={
+              this.getWidgetDesign("basemapNICFIDate") ?
+                "Planet NICFI " +
+                this.getWidgetDesign("basemapNICFIDate").slice(
+                  34, this.getWidgetDesign("basemapNICFIDate").length - 7)
+                : "Enter Title"}
             type="text"
             value={this.state.title}
           />

--- a/src/js/widgetLayoutEditor.jsx
+++ b/src/js/widgetLayoutEditor.jsx
@@ -347,7 +347,7 @@ class WidgetLayoutEditor extends React.PureComponent {
   saveWidgetEdits = () => {
     const {
       originalWidget: { id, layout },
-    } = this.state;    
+    } = this.state;
     const errors = this.getWidgetErrors();
     if (errors.length) {
       alert(errors.join("\n\n"));


### PR DESCRIPTION
- ## Purpose

Adds a date selector to NICFI-based imagery when using the "Imagery Selector" widget in the Geo-Dash. When Collecting, users can then open their geo-dash and see that widget's imagery set to the selected basemap. 

## Related Issues

Closes COL-###

## Submission Checklist

- [ x] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [ x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [ x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

Log in as an admin and navigate to institution imagery. Create or update a Planet NICFI basemap layer and select a date. The list defaults to the most recent date. Save or update the widget, then navigate to that institution's projects and select "edit" so that the "configure geo-dash" button becomes available. Navigate to the geo-dash configuration for the project and create or update an imagery widget. Select the Planet-NICFI enabled basemap and observe the "date" selector which appears. Note the default date is set to that which was defined in the basemap above. Feel free to update the basemap date. Save the changes and navigate to the project and then to "collect" from there, "go to first plot" and then "geo-dash." Note the imagery widget with updated basemap data. One may also open the network console, refresh the page, and observe requests to nicfi that correspond to the basemap date configured in the widget.

### Module Impacted

Geo-Dash

### Role

Admin

Admin

