### PR TITLE
Hide children cards if parent's answerId is not within their parentAnswerIds

### DIFF
--- a/src/js/collection.jsx
+++ b/src/js/collection.jsx
@@ -923,7 +923,15 @@ class Collection extends React.Component {
     const newSurveyQuestions = mapObject(
       this.state.currentProject.surveyQuestions,
       ([questionId, question]) => {
-        const visible = this.calcVisibleSamples(Number(questionId)) || [];
+        const visibleSamples = this.calcVisibleSamples(Number(questionId)) || [];
+        const visible = visibleSamples.filter((sample) => {
+          if (question.parentQuestionId !== -1) {
+            const parentAnswerId = _.get(userSamples, [sample.id, question.parentQuestionId, "answerId"]);
+            return question.parentAnswerIds.includes(parentAnswerId);
+          }
+          return true;
+        });
+  
         const answered = visible
           .filter((vs) => userSamples[vs.id][questionId])
           .map((vs) => ({


### PR DESCRIPTION
### Purpose

Questions cards were still visible even if their parent question's answer made them not applicable based on a set rule. 

### Testing

Created projects with parent questions in two levels and verified that it was reacting appropriately based on the rules I gave the project. 

### Role

Collectors.

### Desired Outcome

Questions are hidden if parent question's answer is not in their parent answers array:

https://github.com/openforis/collect-earth-online/assets/47796239/468c4097-0d03-4451-9f48-81ea36bc8d9a




