### PR TITLE
COL-553: Import Collect's survey

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -5,6 +5,7 @@
                                    :git/sha "f39c78c281d68cc29ed819ad3763e0417ae1952c"}
         org.clojure/clojure       {:mvn/version "1.11.1"}
         org.clojure/data.json     {:mvn/version "1.0.0"}
+        org.clojure/data.xml      {:mvn/version "0.0.8"}
         ring/ring                 {:mvn/version "1.8.2"}
         sig-gis/triangulum        {:git/url "https://github.com/sig-gis/triangulum"
                                    :git/sha "5cffefc2e8a8027a178d7ff1103cb2e38e174bba"}}

--- a/src/clj/collect_earth_online/db/projects.clj
+++ b/src/clj/collect_earth_online/db/projects.clj
@@ -6,7 +6,7 @@
             [clojure.set                                   :as set]
             [clojure.string                                :as str]
             [collect-earth-online.generators.clj-point     :refer [generate-point-plots generate-point-samples]]
-            [collect-earth-online.generators.external-file :refer [generate-file-plots generate-file-samples zip-shape-files]]
+            [collect-earth-online.generators.external-file :as external-file]
             [collect-earth-online.utils.geom               :refer [make-geo-json-polygon]]
             [collect-earth-online.utils.part-utils         :as pu]
             [triangulum.response                           :refer [data-response]]
@@ -317,7 +317,7 @@
                                 plots]
   (let [plot-count (count plots)
         samples    (if (#{"csv" "shp"} sample-distribution)
-                     (generate-file-samples plots
+                     (external-file/generate-file-samples plots
                                             plot-count
                                             project-id
                                             sample-distribution
@@ -367,7 +367,7 @@
                               design-settings]
   ;; Create plots
   (let [plots (if (#{"csv" "shp"} plot-distribution)
-                (generate-file-plots project-id
+                (external-file/generate-file-plots project-id
                                      plot-distribution
                                      plot-file-name
                                      plot-file-base64)
@@ -939,7 +939,7 @@
 (defn create-shape-files!
   [{:keys [params]}]
   (let [project-id (:projectId params)
-        zip-file (zip-shape-files project-id)
+        zip-file (external-file/zip-shape-files project-id)
         file-name (last (str/split zip-file #"/"))]
     (if zip-file
       {:headers {"Content-Type" "application/zip"
@@ -948,3 +948,8 @@
        :status 200}
       {:status 500
        :body "Error generating shape files."})))
+
+(defn import-collect-projects
+  [file-name]
+  (let [proj-dir 
+        project-properties file-name]))

--- a/src/clj/collect_earth_online/db/projects.clj
+++ b/src/clj/collect_earth_online/db/projects.clj
@@ -948,8 +948,3 @@
        :status 200}
       {:status 500
        :body "Error generating shape files."})))
-
-(defn import-collect-projects
-  [file-name]
-  (let [proj-dir 
-        project-properties file-name]))

--- a/src/clj/collect_earth_online/generators/ce_project.clj
+++ b/src/clj/collect_earth_online/generators/ce_project.clj
@@ -1,0 +1,106 @@
+(ns collect-earth-online.generators.ce-project
+  (:require [clojure.data.xml :as xml]
+            [clojure.java.io  :as io]
+            [clojure.string   :as str]
+            [collect-earth-online.generators.external-file :refer [tmp-dir]]
+            [triangulum.type-conversion :as tc]))
+
+(defn read-xml-file
+  "Reads xml file containing survey information for Collect Earth."
+  [dir-name]
+  (let [dir (str tmp-dir "/" dir-name)]
+    (xml/parse (io/reader (str dir "/placemark.idm.xml")))))
+
+(defn- code-items->answers
+  "Transforms list of items into CEO's answers"
+  [code-items]
+  (map (fn [item]
+         {(keyword (-> item :attrs :id))
+          {:color  "#000000"
+           :answer (-> item :content last :content)}})
+       code-items))
+
+(defn- get-code-list
+  "Retrieves the list of options from the XML."
+  [dir-name]
+   (some (fn [o]
+           (when (= (:tag o) :codeLists)
+             (:content o)))
+         (-> dir-name read-xml-file :content)))
+
+(defn extract-code-lists
+  "Extracts the contents of the code lists from Collect
+   into CEO's answers structure."
+  [dir-name]
+  (let [code-list (get-code-list dir-name)]
+    code-list))
+
+(defn- get-question
+  "Retrieves question name from Collect's XML."
+  [tag-map]
+  (-> (filter (fn [content]
+                (= (:tag content) :label))
+              (:content tag-map))
+      first
+      :content
+      first))
+
+(defn- find-parent-question-id
+  "Looks for the id of the parent question."
+  [question-attr questions]
+  (if (:parent question-attr)
+    (tc/val->int (some (fn [q]
+                         (when (= (:parent question-attr)
+                                  (-> q :attrs :name))
+                           (-> q :attrs :id)))
+                       questions))
+    -1))
+
+(defn define-type
+  "Define component type and data type for CEO's
+   survey questions based on the XML's tag and layout type."
+  [tag attributes]
+  (cond
+    (or (= tag :number) (= tag :text))
+    {:dataType (name tag) :componentType "input"}
+    (= tag :boolean)
+    {:dataType "text" :componentType "button"}
+    (and (= tag :code) (get attributes :ui/layoutType))
+    {:dataType "text" :componentType "dropdown"}
+    (= tag :code)
+    {:dataType "text" :componentType "button"}
+    :else {:dataType nil :componentType nil}))
+
+(defn extract-survey-questions
+  "Parses the XML file and creates a list of CEO's questions
+   based on the schema tag from the XML."
+  [dir-name]
+  (let [survey-content     (-> dir-name read-xml-file :content last :content first :content)
+        filtered-questions (filter (fn [q] (contains? #{:text :code :number :boolean} (:tag q)))
+                                   survey-content)]
+    (map (fn [question]
+           (let [question-tag                     (:tag question)
+                 question-attrs                   (:attrs question)
+                 {:keys [dataType componentType]} (define-type question-tag question-attrs)]
+             {:dataType         dataType
+              :question         (get-question question)
+              :cardOrder        (-> question-attrs :id tc/val->int)
+              :componentType    componentType
+              :parentQuestionId (find-parent-question-id question-attrs filtered-questions)}))
+         filtered-questions)))
+
+(defn parse-properties-file
+  "Parses properties file into edn format. Used to
+   retireve general project information."
+  [dir-name]
+  (let [dir (str tmp-dir "/" dir-name)]
+    (with-open [f (clojure.java.io/reader (str dir "/project_definition.properties"))]
+
+      (reduce (fn [acc line]
+                (let [[k v] (clojure.string/split line #"\=")]
+                  (if v
+                    (assoc acc (keyword k) v)
+                    acc)))
+              {}
+              (line-seq f)))))
+


### PR DESCRIPTION
## Purpose

Parse relevant files from `.cep` zips to enable importing surveys created in Collect.

## Related Issues

Closes COL-553

## Submission Checklist

- [X] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [X] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [X] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Steps

1. Move a `.cep` file to the `/tmp` folder.
2. unzip the file using the function `collect-earth-online.generators.external-file/unzip-project` passing the file name
3. Call the function `collect-earth-online.generators.ce-project/create-project-survey` passing the file name.
4. The result must be the survey data structured in the way CEO is able to process. To grab some reference data to compare, the tester can retrieve some by selecting the column `survey_questions` from the `projects` table[

