### PR TITLE
adds alert to plotdesign step

### DIFF
--- a/src/js/project/PlotDesign.jsx
+++ b/src/js/project/PlotDesign.jsx
@@ -430,6 +430,7 @@ export class PlotDesign extends React.Component {
       },
       shp: {
         display: "SHP File",
+        alert: "CEO may overestimate the number of project plots when using a ShapeFile.",
         description:
           "Specify your own plot boundaries by uploading a zipped Shapefile (containing SHP, SHX, DBF, and PRJ files) of polygon features. Each feature must have a unique PLOTID value.",
         layout: this.renderFileInput("shp"),
@@ -456,6 +457,8 @@ export class PlotDesign extends React.Component {
               </select>
             </div>
             <p className="font-italic ml-2">{`- ${plotOptions[plotDistribution].description}`}</p>
+            {plotOptions[plotDistribution].alert &&
+              <p className="alert">- {plotOptions[plotDistribution].alert}</p>}
           </div>
           <div>{plotOptions[plotDistribution].layout}</div>
           <p


### PR DESCRIPTION
## Purpose

adds an alert when creating a project that has a custom shape.

## Related Issues

Closes COL-350

## Submission Checklist

- [x ] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [x ] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [ x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted
Wizard

### Role

Admin

### Steps


1. Create a new Institution Project. Procedd through the Wizard to the "Plot Design" Step. In the "Spatial Distribution" dropdown, select "SHP File"

### Desired Outcome
Observe the helpful alert text which briefly appears.
---

<!-- If needed, add more tests using the format above (Module Impacted, Role, Steps, Desired Outcome) here. -->

## Screenshots

![image](https://github.com/openforis/collect-earth-online/assets/43738264/91ba362b-5e90-4ae0-912d-cbadfa1e90fd)

