### PR TITLE
Add confidence_comment field and fix css

### DIFF
--- a/src/clj/collect_earth_online/db/plots.clj
+++ b/src/clj/collect_earth_online/db/plots.clj
@@ -256,22 +256,23 @@
 ;;;
 
 (defn add-user-samples [{:keys [params session]}]
-  (let [project-id       (tc/val->int (:projectId params))
-        plot-id          (tc/val->int (:plotId params))
-        session-user-id  (:userId session -1)
-        current-user-id  (tc/val->int (:currentUserId params -1))
-        review-mode?     (and (tc/val->bool (:inReviewMode params))
+  (let [project-id         (tc/val->int (:projectId params))
+        plot-id            (tc/val->int (:plotId params))
+        session-user-id    (:userId session -1)
+        current-user-id    (tc/val->int (:currentUserId params -1))
+        review-mode?       (and (tc/val->bool (:inReviewMode params))
                               (pos? current-user-id)
                               (is-proj-admin? session-user-id project-id nil))
-        confidence       (tc/val->int (:confidence params))
-        collection-start (tc/val->long (:collectionStart params))
-        user-samples     (:userSamples params)
-        user-images      (:userImages params)
-        new-plot-samples (:newPlotSamples params)
-        user-id          (if review-mode? current-user-id session-user-id)
+        confidence         (tc/val->int (:confidence params))
+        confidence-comment (:confidenceComment params)
+        collection-start   (tc/val->long (:collectionStart params))
+        user-samples       (:userSamples params)
+        user-images        (:userImages params)
+        new-plot-samples   (:newPlotSamples params)
+        user-id            (if review-mode? current-user-id session-user-id)
         ;; Samples created in the UI have IDs starting with 1. When the new sample is created
         ;; in Postgres, it gets different ID.  The user sample ID needs to be updated to match.
-        id-translation   (when new-plot-samples
+        id-translation     (when new-plot-samples
                            (call-sql "delete_user_plot_by_plot" plot-id user-id)
                            (call-sql "delete_samples_by_plot" plot-id)
                            (reduce (fn [acc {:keys [id visibleId sampleGeom]}]
@@ -288,6 +289,7 @@
                 plot-id
                 user-id
                 (when (pos? confidence) confidence)
+                (when confidence-comment confidence-comment)
                 (when-not review-mode? (Timestamp. collection-start))
                 (tc/clj->jsonb (set/rename-keys user-samples id-translation))
                 (tc/clj->jsonb (set/rename-keys user-images id-translation)))

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -541,6 +541,7 @@ a:hover {
 }
 #lPanel ul {
   padding-left: 0;
+  margin-left: 5px;
   list-style: none;
   margin-bottom: 0;
 }
@@ -859,5 +860,7 @@ input:checked + .switch-slider:before {
 }
 
 body {
-    padding-top:60px;
+    margin-left: 10px;
+    margin-top: 60px;
+    overflow-x: hidden;
 }

--- a/src/js/collection.jsx
+++ b/src/js/collection.jsx
@@ -734,6 +734,9 @@ class Collection extends React.Component {
           confidence: this.state.currentProject.projectOptions.collectConfidence
             ? this.state.currentPlot.confidence
             : -1,
+          confidenceComment: this.state.currentProject.projectOptions.collectConfidence
+            ? this.state.currentPlot.confidenceComment
+            : null,
           collectionStart: this.state.collectionStart,
           userSamples: this.state.userSamples,
           userImages: this.state.userImages,
@@ -970,6 +973,9 @@ class Collection extends React.Component {
   setFlaggedReason = (flaggedReason) =>
     this.setState({ currentPlot: { ...this.state.currentPlot, flaggedReason } });
 
+  setConfidenceComment = (confidenceComment) =>
+    this.setState({ currentPlot: { ...this.state.currentPlot, confidenceComment } });
+
   render() {
     return (
       <div className="row" style={{ height: "-webkit-fill-available" }}>
@@ -1014,6 +1020,7 @@ class Collection extends React.Component {
           surveyQuestions={this.state.currentProject.surveyQuestions}
           toggleQuitModal={this.toggleQuitModal}
           userName={this.props.userName}
+          collectConfidence={this.state.currentProject.projectOptions?.collectConfidence}
         >
           <PlotNavigation
             collectConfidence={this.state.currentProject.projectOptions?.collectConfidence}
@@ -1071,6 +1078,7 @@ class Collection extends React.Component {
               answerMode={this.state.answerMode}
               collectConfidence={this.state.currentProject.projectOptions.collectConfidence}
               confidence={this.state.currentPlot.confidence}
+              confidenceComment={this.state.currentPlot.confidenceComment}
               flagged={this.state.currentPlot.flagged}
               flaggedReason={this.state.currentPlot.flaggedReason}
               getSelectedSampleIds={this.getSelectedSampleIds}
@@ -1085,6 +1093,7 @@ class Collection extends React.Component {
               }
               setAnswerMode={this.setAnswerMode}
               setConfidence={this.setConfidence}
+              setConfidenceComment={this.setConfidenceComment}
               setCurrentValue={this.setCurrentValue}
               setFlaggedReason={this.setFlaggedReason}
               setSelectedQuestion={this.setSelectedQuestion}
@@ -1127,7 +1136,8 @@ function ImageAnalysisPane({ imageryAttribution }) {
 
 class SideBar extends React.Component {
   checkCanSave = () => {
-    const { answerMode, currentPlot, inReviewMode, surveyQuestions } = this.props;
+    const { answerMode, currentPlot, inReviewMode, surveyQuestions, collectConfidence } = this.props;
+    const { confidence, confidenceComment } = currentPlot;
     const visibleSurveyQuestions = filterObject(surveyQuestions, ([_id, val]) => val.hideQuestion != true);
     const noneAnswered = everyObject(visibleSurveyQuestions, ([_id, sq]) => safeLength(sq.answered) === 0);
     const hasSamples = safeLength(currentPlot.samples) > 0;
@@ -1153,6 +1163,9 @@ class SideBar extends React.Component {
       return false;
     } else if (!allAnswered) {
       alert("All questions must be answered to save the collection.");
+      return false;
+    } else if (!(collectConfidence && (confidence && confidenceComment))) {
+      alert("You must input a confidence and write a comment about it before saving the interpretation.");
       return false;
     } else {
       return true;

--- a/src/js/survey/SurveyCollection.jsx
+++ b/src/js/survey/SurveyCollection.jsx
@@ -625,6 +625,7 @@ export default class SurveyCollection extends React.Component {
                 ? this.renderQuestions()
                 : this.renderDrawTools()}
               {this.props.collectConfidence && !this.props.flagged && (
+                <>
                 <div
                   className="row mb-3 mx-1 slide-container py-3"
                   style={{
@@ -642,6 +643,22 @@ export default class SurveyCollection extends React.Component {
                   />
                   <label>Plot Confidence: {this.props.confidence}</label>
                 </div>
+                <div
+                  className="row mb-3 mx-1 slide-container py-3"
+                  style={{
+                    borderRadius: "6px",
+                    boxShadow: "0 0 2px 1px rgba(0, 0, 0, 0.15)",
+                  }}
+                >
+                  <label>Comment on the confidence:</label>
+                  <textarea
+                    className="form-control"
+                    id="confidenceComment"
+                    onChange={(e) => this.props.setConfidenceComment(e.target.value)}
+                    value={this.props.confidenceComment}
+                  />
+                </div>
+                </>
               )}
               {this.renderFlagClearButtons()}
             </>

--- a/src/js/utils/validation.js
+++ b/src/js/utils/validation.js
@@ -111,11 +111,9 @@ export default function getErrors (form) {
         !sampleResolution &&
         "A sample spacing is required for gridded sample distribution.",
       sampleDistribution === "csv" &&
-        sampleFileNeeded &&
         !(sampleFileName || "").includes(".csv") &&
         "A sample CSV (.csv) file is required.",
       sampleDistribution === "shp" &&
-        sampleFileNeeded &&
         !(sampleFileName || "").includes(".zip") &&
         "A sample SHP (.zip) file is required.",
       sampleDistribution === "gridded" &&

--- a/src/sql/changes/2023-04-17-lowercase-user-emails.sql
+++ b/src/sql/changes/2023-04-17-lowercase-user-emails.sql
@@ -1,1 +1,0 @@
-UPDATE users SET email = LOWER(email);

--- a/src/sql/changes/2023-04-29-create-doi-table.sql
+++ b/src/sql/changes/2023-04-29-create-doi-table.sql
@@ -1,8 +1,0 @@
-CREATE TABLE doi(
-       doi_uid INTEGER NOT NULL PRIMARY KEY,
-       project_rid INTEGER NOT NULL REFERENCES projects (project_uid) ON DELETE CASCADE ON UPDATE CASCADE,
-       user_id INTEGER NOT NULL REFERENCES users (user_uid) ON DELETE CASCADE ON UPDATE CASCADE,
-       doi_path TEXT,
-       full_data jsonb NOT NULL,
-       created timestamp DEFAULT NOW()
-);

--- a/src/sql/changes/2023-06-05-add-constraints.sql
+++ b/src/sql/changes/2023-06-05-add-constraints.sql
@@ -1,4 +1,0 @@
-ALTER TABLE IF EXISTS public.plot_locks DROP CONSTRAINT plot_locks_pkey;
-
-ALTER TABLE IF EXISTS public.plot_locks ADD CONSTRAINT plot_locks_plot_rid_key UNIQUE (plot_rid);
-ALTER TABLE IF EXISTS public.plot_locks ADD CONSTRAINT plot_locks_user_rid_key UNIQUE (user_rid);

--- a/src/sql/changes/2023-11-20-add-confidence-comment-column.sql
+++ b/src/sql/changes/2023-11-20-add-confidence-comment-column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE user_plots ADD COLUMN confidence_comment text;

--- a/src/sql/functions/plots.sql
+++ b/src/sql/functions/plots.sql
@@ -419,6 +419,7 @@ CREATE OR REPLACE FUNCTION upsert_user_samples(
     _plot_id             integer,
     _user_id             integer,
     _confidence          integer,
+    _confidence_comment  text,
     _collection_start    timestamp,
     _samples             jsonb,
     _images              jsonb
@@ -426,12 +427,13 @@ CREATE OR REPLACE FUNCTION upsert_user_samples(
 
     WITH user_plot_table AS (
         INSERT INTO user_plots AS up
-            (user_rid, plot_rid, confidence, collection_start, collection_time)
+            (user_rid, plot_rid, confidence, confidence_comment ,collection_start, collection_time)
         VALUES
-            (_user_id, _plot_id, _confidence, _collection_start, Now())
+            (_user_id, _plot_id, _confidence, _confidence_comment , _collection_start, Now())
         ON CONFLICT (user_rid, plot_rid) DO
             UPDATE
             SET confidence = coalesce(excluded.confidence, up.confidence),
+                confidence_comment = _confidence_comment,
                 collection_start = coalesce(excluded.collection_start, up.collection_start),
                 collection_time = CASE WHEN excluded.collection_start IS NOT NULL THEN localtimestamp ELSE up.collection_time END,
                 flagged = FALSE,


### PR DESCRIPTION
## Purpose

Add a confidence comment in case the confidence slider is present during collection phase.

## Related Issues

Closes COL-

## Submission Checklist

- [x] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

Collection > Confidence

### Role

User

### Steps

<!-- All steps needed to test this PR -->

1. As an admin, set the option for a confidence slider to true;
2. As a user, go to the collection page;
3. answer all the questions (with the exception of the confidence comment box) and click save;
4. An alert should pop up telling the user that they need to answer the comment;
5. answer the comment;
6. The user should be able to save the questions now. 

### Desired Outcome

If there's a confidence slider set for the project, a text box should also be present so that the users can input their comment about the project. This comment is required.

## Screenshots
ALERT:
![confidence_1](https://github.com/openforis/collect-earth-online/assets/18133069/113ef343-d6a6-46c5-bad2-e99df61f857d)

WITH COMMENT:
![confidence_2](https://github.com/openforis/collect-earth-online/assets/18133069/548d02b6-34f5-4782-a134-59516c799ab2)




