### PR TITLE
adds help text to band input

### DIFF
--- a/src/js/imagery/imageryOptions.js
+++ b/src/js/imagery/imageryOptions.js
@@ -308,19 +308,19 @@ export const imageryOptions = [
       },
       {
         key: "min",
-        display: "Min",
+        display: "Min (one or three bands, separated by commas)",
         type: "number",
         options: {
-          placeholder: "1-100",
+          placeholder: "[1-100]",
           step: "0.01",
         },
       },
       {
         key: "max",
-        display: "Max",
+        display: "Max (one or three bands, separated by commas)",
         type: "number",
         options: {
-          placeholder: "2800-3200",
+          placeholder: "[0-100]",
           step: "0.01",
         },
       },

--- a/src/js/reviewInstitution.jsx
+++ b/src/js/reviewInstitution.jsx
@@ -1009,7 +1009,7 @@ class NewImagery extends React.Component {
         </div>
         <div className="row">
           <div className="col-6">
-            <buttonp
+            <button
               className="btn btn-sm btn-block btn-outline-lightgreen btn-group py-2 font-weight-bold"
               id="add-imagery-button"
               onClick={() => this.uploadCustomImagery(isNewImagery)}

--- a/src/js/reviewInstitution.jsx
+++ b/src/js/reviewInstitution.jsx
@@ -1009,7 +1009,7 @@ class NewImagery extends React.Component {
         </div>
         <div className="row">
           <div className="col-6">
-            <button
+            <buttonp
               className="btn btn-sm btn-block btn-outline-lightgreen btn-group py-2 font-weight-bold"
               id="add-imagery-button"
               onClick={() => this.uploadCustomImagery(isNewImagery)}


### PR DESCRIPTION
## Purpose

adds placeholder text to prompt the user to input band option, eg "Max (one or three bands, separated by commas)"

## Related Issues

Closes COL-566

## Submission Checklist

- [x ] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [ x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [ x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted
GeoDash
### Role

Admin

### Steps

<!-- All steps needed to test this PR -->

1. navigate to a test project's "configure geodash" page. edit or create a new widget. select "Sentinel 2" as the Image Source. observe the helpful placeholder value of "min" and "max" fields

### Desired Outcome

mild pleasant surprise
---

<!-- If needed, add more tests using the format above (Module Impacted, Role, Steps, Desired Outcome) here. -->

## Screenshots

<!-- Add a screen shot when UI changes are included -->
