### PR TITLE
WIP: andy/COL-561/plot-locks

### DIFF
--- a/src/sql/functions/plots.sql
+++ b/src/sql/functions/plots.sql
@@ -255,10 +255,15 @@ $$ LANGUAGE SQL;
 CREATE OR REPLACE FUNCTION lock_plot(_plot_id integer, _user_id integer, _lock_end timestamp)
  RETURNS VOID AS $$
 
-    INSERT INTO plot_locks
-        (user_rid, plot_rid, lock_end)
-    VALUES
-        (_user_id, _plot_id, _lock_end)
+ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM plot_rid where plot_rid = _plot_id) THEN
+ 
+       INSERT INTO plot_locks
+           (user_rid, plot_rid, lock_end)
+       VALUES
+           (_user_id, _plot_id, _lock_end)
+    END IF;
+ END
 
 $$ LANGUAGE SQL;
 


### PR DESCRIPTION
## Purpose

Currently, plots get locked during collection to prevent such bugs as represented by COL-561 and COL-562. They do this by creating a plot_lock based on the current plot and user ids. This leads to unexpected behavior when multiple users lock the same plot, as in qaqc; multiple plot_locks get generated for the same plot, which leads to the generation of duplicate user_plots. This PR prevents the creation of multiple plot_locks with the same plot_rid, thereby preventing errors as above.

## Related Issues

Closes COL-###

## Submission Checklist

- [ ] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [ ] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [ ] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted
Collection

### Role

Admin, User

### Steps

create a project with a 10% qaqc overlap. observe the database while multiple sample users collect for the project. 

1.

exactly the same number of user_plots get created.

---

<!-- If needed, add more tests using the format above (Module Impacted, Role, Steps, Desired Outcome) here. -->

## Screenshots

<!-- Add a screen shot when UI changes are included -->
