### PR TITLE
Hotfix/PlanetNICFIMenu not updating properly

### DIFF
--- a/src/js/imagery/collectionMenuControls.jsx
+++ b/src/js/imagery/collectionMenuControls.jsx
@@ -258,7 +258,7 @@ export class PlanetNICFIMenu extends React.Component {
       if (newIndex < 0 || newIndex >= nicfiLayers.length) return {};
 
       return { selectedTime: nicfiLayers[newIndex] };
-    });
+    }, this.updatePlanetLayer);
   }
 
   updatePlanetLayer = () => {
@@ -302,8 +302,7 @@ export class PlanetNICFIMenu extends React.Component {
               className="btn btn-outline-lightgreen btn-sm mr-1"
               type="button"
               onClick={() => {
-                this.switchImagery("backward");
-                this.updatePlanetLayer();
+                this.switchImagery("backward")
               }}
               disabled={this.state.isDisabledLeft}
             >
@@ -313,8 +312,7 @@ export class PlanetNICFIMenu extends React.Component {
               className="btn btn-outline-lightgreen btn-sm"
               type="button"
               onClick={() => {
-                this.switchImagery("forward");
-                this.updatePlanetLayer();
+                this.switchImagery("forward")
               }}
               disabled={this.state.isDisabledRight}
             >


### PR DESCRIPTION
## Purpose

Fixing issue where the arrows actions were not making the correct requests. They were making the request for the previous layer. 

The state was updating properly but the dataLayer wasn't. 

## Testing

Please double check that the correct request is being made when either arrow is clicked. 

## Screenshots


https://github.com/openforis/collect-earth-online/assets/47796239/3a149c6a-cb0c-4aa0-942b-dc7f9143a776

