### PR TITLE
Andy/col 549/assigned navigation

### DIFF
--- a/src/clj/collect_earth_online/db/plots.clj
+++ b/src/clj/collect_earth_online/db/plots.clj
@@ -228,7 +228,7 @@
                                          (->> sorted-plots
                                               (first)
                                               (second)
-                                              (when-not (= navigation-mode "assigned"))))
+                                              (when-not (= navigation-mode "natural"))))
                           "previous" (or (->> sorted-plots
                                               (sort-by first #(compare %2 %1))
                                               (some (fn [[visible-id plots]]

--- a/src/clj/collect_earth_online/db/plots.clj
+++ b/src/clj/collect_earth_online/db/plots.clj
@@ -220,13 +220,15 @@
                                grouped-plots)
                              (sort-by first))
         plots-info      (case direction
-                          "next"     (or (some (fn [[visible-id plots]]
-                                                 (and (> visible-id old-visible-id)
-                                                      plots))
-                                               sorted-plots)
+                          "next"     (or 
+                                         (->> sorted-plots
+                                              (some (fn [[visible-id plots]]
+                                                      (and (> visible-id old-visible-id)
+                                                           plots))))
                                          (->> sorted-plots
                                               (first)
-                                              (second)))
+                                              (second)
+                                              (when-not (= navigation-mode "assigned"))))
                           "previous" (or (->> sorted-plots
                                               (sort-by first #(compare %2 %1))
                                               (some (fn [[visible-id plots]]
@@ -247,8 +249,8 @@
                   user-id
                   (time-plus-five-min))
         (data-response (map #(build-collection-plot % user-id review-mode?) plots-info))
-       (catch Exception _e
-         (data-response "Unable to get the requested plot.  Please try again.")))
+        (catch Exception _e
+          (data-response "Unable to get the requested plot.  Please try again.")))
       (data-response "not-found"))))
 
 ;;;
@@ -261,8 +263,8 @@
         session-user-id    (:userId session -1)
         current-user-id    (tc/val->int (:currentUserId params -1))
         review-mode?       (and (tc/val->bool (:inReviewMode params))
-                              (pos? current-user-id)
-                              (is-proj-admin? session-user-id project-id nil))
+                                (pos? current-user-id)
+                                (is-proj-admin? session-user-id project-id nil))
         confidence         (tc/val->int (:confidence params))
         confidence-comment (:confidenceComment params)
         collection-start   (tc/val->long (:collectionStart params))
@@ -273,17 +275,17 @@
         ;; Samples created in the UI have IDs starting with 1. When the new sample is created
         ;; in Postgres, it gets different ID.  The user sample ID needs to be updated to match.
         id-translation     (when new-plot-samples
-                           (call-sql "delete_user_plot_by_plot" plot-id user-id)
-                           (call-sql "delete_samples_by_plot" plot-id)
-                           (reduce (fn [acc {:keys [id visibleId sampleGeom]}]
-                                     (let [new-id (sql-primitive (call-sql "create_project_plot_sample"
-                                                                           {:log? false}
-                                                                           plot-id
-                                                                           visibleId
-                                                                           (tc/json->jsonb sampleGeom)))]
-                                       (assoc acc (str id) (str new-id))))
-                                   {}
-                                   new-plot-samples))]
+                             (call-sql "delete_user_plot_by_plot" plot-id user-id)
+                             (call-sql "delete_samples_by_plot" plot-id)
+                             (reduce (fn [acc {:keys [id visibleId sampleGeom]}]
+                                       (let [new-id (sql-primitive (call-sql "create_project_plot_sample"
+                                                                             {:log? false}
+                                                                             plot-id
+                                                                             visibleId
+                                                                             (tc/json->jsonb sampleGeom)))]
+                                         (assoc acc (str id) (str new-id))))
+                                     {}
+                                     new-plot-samples))]
     (if (some seq (vals user-samples))
       (call-sql "upsert_user_samples"
                 plot-id

--- a/src/sql/functions/plots.sql
+++ b/src/sql/functions/plots.sql
@@ -254,16 +254,14 @@ $$ LANGUAGE SQL;
 -- Lock plot to user
 CREATE OR REPLACE FUNCTION lock_plot(_plot_id integer, _user_id integer, _lock_end timestamp)
  RETURNS VOID AS $$
-
- BEGIN
-    IF NOT EXISTS (SELECT 1 FROM plot_rid where plot_rid = _plot_id) THEN
+    
  
        INSERT INTO plot_locks
            (user_rid, plot_rid, lock_end)
-       VALUES
-           (_user_id, _plot_id, _lock_end)
-    END IF;
- END
+       SELECT
+           _user_id, _plot_id, _lock_end
+       WHERE NOT EXISTS (SELECT 1 FROM plot_locks WHERE plot_rid = _plot_id);
+
 
 $$ LANGUAGE SQL;
 


### PR DESCRIPTION
## Purpose

fixes a bug in plots.sql related to plot_locks and fixes get-collection-plot so that assigned users are not routed to the first plot when done collecting the last one

## Related Issues

Closes COL-549

## Submission Checklist

- [ x] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [ x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [ x No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

Collection
### Role

User

### Steps

<!-- All steps needed to test this PR -->

1. Create a project. assign overlapping QAQC to at least one other user. log in as that user and collect required plots. 

### Desired Outcome

upon collection of the final plot, a js/alert appears apprising user there are no more plots to collect



## Screenshots

<!-- Add a screen shot when UI changes are included -->
