### PR TITLE
COL-596: Enhancement/keep extra info in order

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,14 +1,15 @@
 {:paths ["src/clj" "resources" "dist"]
 
- :deps {clj-http/clj-http         {:mvn/version "3.10.3"}
-        clj-python/libpython-clj  {:git/url "https://github.com/clj-python/libpython-clj"
-                                   :git/sha "f39c78c281d68cc29ed819ad3763e0417ae1952c"}
-        org.clojure/clojure       {:mvn/version "1.11.1"}
-        org.clojure/data.json     {:mvn/version "1.0.0"}
-        org.clojure/data.xml      {:mvn/version "0.0.8"}
-        ring/ring                 {:mvn/version "1.8.2"}
-        sig-gis/triangulum        {:git/url "https://github.com/sig-gis/triangulum"
-                                   :git/sha "3d41dab63e1bc8ebe046f64db44ae3df986f5bdf"}}
+ :deps {clj-http/clj-http        {:mvn/version "3.10.3"}
+        clj-python/libpython-clj {:git/url "https://github.com/clj-python/libpython-clj"
+                                  :git/sha "f39c78c281d68cc29ed819ad3763e0417ae1952c"}
+        org.clojure/clojure      {:mvn/version "1.11.1"}
+        org.flatland/ordered     {:mvn/version "1.15.11"}
+        org.clojure/data.json    {:mvn/version "1.0.0"}
+        org.clojure/data.xml     {:mvn/version "0.0.8"}
+        ring/ring                {:mvn/version "1.8.2"}
+        sig-gis/triangulum       {:git/url "https://github.com/sig-gis/triangulum"
+                                  :git/sha "3d41dab63e1bc8ebe046f64db44ae3df986f5bdf"}}
 
  :aliases {:build-db         {:main-opts ["-m" "triangulum.build-db"]}
            :config           {:main-opts ["-m" "triangulum.config"]}
@@ -19,7 +20,7 @@
            :systemd          {:main-opts ["-m" "triangulum.systemd"]}
            :rebel            {:extra-deps {com.bhauman/rebel-readline {:mvn/version "0.1.4"}}
                               :main-opts  ["-m" "rebel-readline.main"]}
-           :production       {:jvm-opts  ["-XX:MaxRAMPercentage=90" "-XX:+PrintFlagsFinal"]}
+           :production       {:jvm-opts ["-XX:MaxRAMPercentage=90" "-XX:+PrintFlagsFinal"]}
            :check-reflection {:main-opts ["-e" "(do,(set!,*warn-on-reflection*,true),nil)"
                                           "-e" "(require,'collect-earth-online.routing)"]}
            :check-deps       {:deps      {olical/depot {:mvn/version "1.8.4"}}

--- a/src/clj/collect_earth_online/db/projects.clj
+++ b/src/clj/collect_earth_online/db/projects.clj
@@ -368,9 +368,9 @@
   ;; Create plots
   (let [plots (if (#{"csv" "shp"} plot-distribution)
                 (external-file/generate-file-plots project-id
-                                     plot-distribution
-                                     plot-file-name
-                                     plot-file-base64)
+                                                   plot-distribution
+                                                   plot-file-name
+                                                   plot-file-base64)
                 (generate-point-plots project-id
                                       plot-distribution
                                       num-plots

--- a/src/sql/changes/2023-12-12-change-extra-infos-column-types.sql
+++ b/src/sql/changes/2023-12-12-change-extra-infos-column-types.sql
@@ -1,0 +1,5 @@
+alter table plots alter column extra_plot_info type json;
+
+alter table samples alter column extra_sample_info type json;
+
+alter table ext_samples alter  column extra_sample_info type json;

--- a/src/sql/functions/plots.sql
+++ b/src/sql/functions/plots.sql
@@ -104,7 +104,7 @@ CREATE TYPE collection_return AS (
     confidence         integer,
     visible_id         integer,
     plot_geom          text,
-    extra_plot_info    jsonb,
+    extra_plot_info    json,
     user_id            integer,
     email              text
 );

--- a/src/sql/functions/project.sql
+++ b/src/sql/functions/project.sql
@@ -889,7 +889,7 @@ CREATE OR REPLACE FUNCTION dump_project_plot_data(_project_id integer)
     samples                    text,
     common_securewatch_date    text,
     total_securewatch_dates    integer,
-    extra_plot_info            jsonb
+    extra_plot_info            json
  ) AS $$
 
     SELECT pl.visible_id,
@@ -926,7 +926,7 @@ CREATE OR REPLACE FUNCTION dump_project_plot_data(_project_id integer)
     LEFT JOIN users u
         ON u.user_uid = up.user_rid
     WHERE project_rid = _project_id
-    GROUP BY project_uid, plot_uid, user_plot_uid, email, extra_plot_info
+    GROUP BY project_uid, plot_uid, user_plot_uid, email, extra_plot_info::text
     ORDER BY plot_uid
 
 $$ LANGUAGE SQL;
@@ -948,7 +948,7 @@ CREATE OR REPLACE FUNCTION dump_project_plot_qaqc_data(_project_id integer)
     samples                    text,
     common_securewatch_date    text,
     total_securewatch_dates    integer,
-    extra_plot_info            jsonb
+    extra_plot_info            json
  ) AS $$
 
     WITH assigned_count AS (
@@ -996,7 +996,7 @@ CREATE OR REPLACE FUNCTION dump_project_plot_qaqc_data(_project_id integer)
         ON u.user_uid = up.user_rid
     WHERE project_rid = _project_id
         AND ac.users > 1
-    GROUP BY project_uid, plot_uid, user_plot_uid, email, extra_plot_info
+    GROUP BY project_uid, plot_uid, user_plot_uid, email, extra_plot_info::text
     ORDER BY plot_uid
 
 $$ LANGUAGE SQL;
@@ -1016,8 +1016,8 @@ CREATE OR REPLACE FUNCTION dump_project_sample_data(_project_id integer)
         imagery_attributes    text,
         sample_geom           text,
         saved_answers         jsonb,
-        extra_plot_info       jsonb,
-        extra_sample_info     jsonb
+        extra_plot_info       json,
+        extra_sample_info     json
  ) AS $$
 
     SELECT pl.visible_id,


### PR DESCRIPTION
## Purpose

Extra fields in CSV and SHP files for plots and samples were not being stored in order. This PR aims to fix it by changing the column types from jsonb to json and using ordered maps.

## Related Issues

Closes COL-596

## Submission Checklist

- [x] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

Project Wizard > Plot design
Collection > Plot information

### Role

Admin/User

### Steps

<!-- All steps needed to test this PR -->

1. Create a CSV using the example given by CEO
2. Add some extra columns to the CSV
3. Upload the CSV for plot design and finish project creation
4. Go to the collection page and check the `Plot Information`, the data here should be in the same order as it was in the CSV.

### Desired Outcome


## Screenshots

<!-- Add a screen shot when UI changes are included -->
