### PR TITLE
Recover reorder sub questions

### DIFF
--- a/src/js/components/svg/SvgIcon.jsx
+++ b/src/js/components/svg/SvgIcon.jsx
@@ -78,7 +78,7 @@ export const iconMap = {
   zoomIn: zoomInIcon,
 };
 
-function SvgIcon({ icon, color, cursor, size, verticalAlign }) {
+function SvgIcon({ icon, color, cursor, size, verticalAlign, transform }) {
   const Icon = iconMap[icon];
   return (
     <Icon
@@ -86,7 +86,7 @@ function SvgIcon({ icon, color, cursor, size, verticalAlign }) {
       cursor={cursor}
       fill={color}
       height={size}
-      style={{ verticalAlign }}
+      style={{ verticalAlign, transform }}
       width={size}
     />
   );
@@ -98,12 +98,14 @@ SvgIcon.propTypes = {
   icon: PropTypes.string.isRequired,
   size: PropTypes.string.isRequired,
   verticalAlign: PropTypes.string,
+  transform: PropTypes.string,
 };
 
 SvgIcon.defaultProps = {
   color: "currentColor",
   cursor: "unset",
   verticalAlign: "middle",
+  transform: "",
 };
 
 export default SvgIcon;

--- a/src/js/survey/AnswerDesigner.jsx
+++ b/src/js/survey/AnswerDesigner.jsx
@@ -1,44 +1,46 @@
-import React from "react";
+import React, { useState, useContext, useEffect } from "react";
 
 import SvgIcon from "../components/svg/SvgIcon";
-
 import { ProjectContext } from "../project/constants";
 import { findObject, getNextInSequence } from "../utils/sequence";
 
-export default class AnswerDesigner extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      selectedColor: this.props.color || "#1527f6",
-      newAnswerText: this.props.answer || "",
-      required: this.props.required || false,
-      hide: this.props.hide || false,
-    };
-  }
+const AnswerDesigner = ({
+  answer,
+  answerId,
+  color,
+  editMode,
+  required,
+  hide,
+  surveyQuestion,
+  surveyQuestionId }) => {
+  const { surveyQuestions, setProjectDetails, surveyRules } = useContext(ProjectContext);
 
-  removeAnswer = () => {
-    const { surveyQuestionId, answerId } = this.props;
-    const { surveyQuestions, setProjectDetails } = this.context;
-    const answerHasRule = this.answerRule(surveyQuestionId, parseInt(answerId));
+  const [selectedColor, setSelectedColor] = useState( surveyQuestion.answers[answerId]?.color || "#1527f6");
+  const [newAnswerText, setNewAnswerText] = useState(surveyQuestion.answers[answerId]?.answer || "");
+  const [req, setReq] = useState(surveyQuestion.answers[answerId]?.required || false);
+  const [hideAnswer, setHideAnswer] = useState(surveyQuestion.answers[answerId]?.hide || false);
+
+  useEffect(() => {
+    setNewAnswerText(surveyQuestions[surveyQuestionId].answers[answerId]?.answer);
+    setReq(surveyQuestion.answers[answerId]?.required);
+    setSelectedColor(surveyQuestion.answers[answerId]?.color);
+    setHideAnswer(surveyQuestions[surveyQuestionId]?.hide);
+  }, [surveyQuestionId, surveyQuestion, answerId]);
+
+  const removeAnswer = () => {
+    const answerHasRule = answerRule(surveyQuestionId, parseInt(answerId));
     if (answerHasRule) {
-      alert(
-        "This answer is being used in a rule. Please either delete or update the rule before removing the answer.");
+      alert("This answer is being used in a rule. Please either delete or update the rule before removing the answer.");
       return null;
     }
     const matchingQuestion = findObject(
       surveyQuestions,
-      ([_id, sq]) =>
-        sq.parentQuestionId === surveyQuestionId && sq.parentAnswerIds.includes(answerId)
+      ([_id, sq]) => sq.parentQuestionId === surveyQuestionId && sq.parentAnswerIds.includes(answerId)
     );
     if (matchingQuestion) {
-      alert(
-        "You cannot remove this answer because a sub question (" +
-          matchingQuestion[1].question +
-          ") is referencing it."
-      );
+      alert("You cannot remove this answer because a sub question (" + matchingQuestion[1].question + ") is referencing it.");
     } else {
       const surveyQuestion = surveyQuestions[surveyQuestionId];
-      // eslint-disable-next-line no-unused-vars
       const { [answerId]: _id, ...remainingAnswers } = surveyQuestion.answers;
       setProjectDetails({
         surveyQuestions: {
@@ -49,35 +51,31 @@ export default class AnswerDesigner extends React.Component {
     }
   };
 
-  answerRule = (questionId, answerId) => {
-    const { surveyRules } = this.context;
+  const answerRule = (questionId, answerId) => {
     const matchingAnswer = findObject(
       surveyRules,
-      ([_id, rl]) => (
-      (rl.questionId1 === questionId && (rl.answerId1 === answerId ||
-                                         rl.answerId2 === answerId) ||
-      (rl.questionId2 === questionId && (rl.answerId1 === answerId ||
-                                         rl.answerId2 === answerId)))));
+      ([_id, rl]) =>
+        (rl.questionId1 === questionId &&
+          (rl.answerId1 === answerId || rl.answerId2 === answerId)) ||
+        (rl.questionId2 === questionId &&
+          (rl.answerId1 === answerId || rl.answerId2 === answerId))
+    );
     return matchingAnswer;
-  }
+  };
 
-  saveSurveyAnswer = () => {
-    const { surveyQuestionId, surveyQuestion, answerId } = this.props;
-    const { surveyQuestions, setProjectDetails } = this.context;
-    if (this.state.newAnswerText.length > 0) {
+  const saveSurveyAnswer = () => {
+    if (newAnswerText.length > 0) {
       const newId = answerId || getNextInSequence(Object.keys(surveyQuestion.answers));
       const newAnswer = {
-        answer: this.state.newAnswerText,
-        color: this.state.selectedColor,
-        hide: this.state.hide,
-        ...(surveyQuestion.componentType === "input" && { required: this.state.required }),
+        answer: newAnswerText,
+        color: selectedColor,
+        hide: hideAnswer,
+        ...(surveyQuestion.componentType === "input" && { required: req }),
       };
-      const answerHasRule = this.answerRule(surveyQuestionId, parseInt(answerId));
-      if(this.state.hide && answerHasRule) {
-        alert(
-          "This answer is being used in a rule. Please either delete or update the rule before hiding the answer");
+      const answerHasRule = answerRule(surveyQuestionId, parseInt(answerId));
+      if (hide && answerHasRule) {
+        alert("This answer is being used in a rule. Please either delete or update the rule before hiding the answer");
         return null;
-
       }
       setProjectDetails({
         surveyQuestions: {
@@ -91,14 +89,16 @@ export default class AnswerDesigner extends React.Component {
           },
         },
       });
-      if (answerId == null) this.setState({ selectedColor: "#1527f6", newAnswerText: "" });
+      if (answerId == null) {
+        setSelectedColor("#1527f6");
+        setNewAnswerText("");
+      }
     } else {
       alert("Please enter a value for the answer.");
     }
   };
 
-  renderExisting = () => {
-    const { answer, color, required, surveyQuestion } = this.props;
+  const renderExisting = () => {
     return (
       <div className="d-flex flex-column">
         <div className="d-flex">
@@ -115,8 +115,7 @@ export default class AnswerDesigner extends React.Component {
     );
   };
 
-  renderNew = () => {
-    const { surveyQuestion, answerId, editMode, surveyQuestionId } = this.props;
+  const renderNew = () => {
     return (
       <div className="d-flex flex-column">
         <div className="d-flex mb-1 align-items-center">
@@ -125,7 +124,7 @@ export default class AnswerDesigner extends React.Component {
               {editMode === "full" && (
                 <button
                   className="btn btn-outline-red py-0 px-2 mr-1"
-                  onClick={this.removeAnswer}
+                  onClick={removeAnswer}
                   type="button"
                 >
                   <SvgIcon icon="trash" size="0.9rem" />
@@ -133,7 +132,7 @@ export default class AnswerDesigner extends React.Component {
               )}
               <button
                 className="btn btn-lightgreen py-0 px-2 mr-1"
-                onClick={this.saveSurveyAnswer}
+                onClick={saveSurveyAnswer}
                 type="button"
               >
                 <SvgIcon icon="save" size="0.9rem" />
@@ -142,7 +141,7 @@ export default class AnswerDesigner extends React.Component {
           ) : (
             <button
               className="btn btn-lightgreen py-0 px-2 mr-1"
-              onClick={this.saveSurveyAnswer}
+              onClick={saveSurveyAnswer}
               type="button"
             >
               <SvgIcon icon="plus" size="0.9rem" />
@@ -150,30 +149,30 @@ export default class AnswerDesigner extends React.Component {
           )}
           <input
             className="mr-1"
-            onChange={(e) => this.setState({ selectedColor: e.target.value })}
+            onChange={(e) => setSelectedColor(e.target.value)}
             type="color"
-            value={surveyQuestion.answers[answerId]?.color}
+            value={selectedColor}
           />
           <input
             autoComplete="off"
             maxLength="120"
-            onChange={(e) => this.setState({ newAnswerText: e.target.value })}
+            onChange={(e) => setNewAnswerText(e.target.value)}
             onKeyDown={(e) => {
               if (e.key === "e" && surveyQuestion.dataType === "number") e.preventDefault();
             }}
             type={surveyQuestion.dataType === "number" ? "number" : "text"}
-            value={surveyQuestion.answers[answerId]?.answer}
+            value={newAnswerText}
           />
         </div>
         {surveyQuestion.componentType != "input" && (
           <div className="d-flex ml-4 mb-1 align-items-center">
             <input
               type="checkbox"
-              checked={this.state.hide}
+              checked={hideAnswer}
               id="hideAnswer"
-              onChange = {() => this.setState({ hide: !this.state.hide })}
+              onChange={() => setHideAnswer(!hideAnswer)}
             />
-            <label className="mb-0 ml-1 mr-1" htmlFor="hideAnswer" >
+            <label className="mb-0 ml-1 mr-1" htmlFor="hideAnswer">
               Hide Answer?
             </label>
           </div>
@@ -181,9 +180,9 @@ export default class AnswerDesigner extends React.Component {
         {surveyQuestion.componentType === "input" && (
           <div className="d-flex ml-4 align-items-center">
             <input
-              checked={this.state.required}
+              checked={req}
               id="required"
-              onChange={() => this.setState({ required: !this.state.required })}
+              onChange={() => setReq(!req)}
               type="checkbox"
             />
             <label className="mb-0 ml-1" htmlFor="required">
@@ -195,13 +194,11 @@ export default class AnswerDesigner extends React.Component {
     );
   };
 
-  render() {
-    const { editMode } = this.props;
-    return (
-      <div id="new-answer-designer">
-        {editMode === "review" ? this.renderExisting() : this.renderNew()}
-      </div>
-    );
-  }
-}
-AnswerDesigner.contextType = ProjectContext;
+  return (
+    <div id="new-answer-designer">
+      {editMode === "review" ? renderExisting() : renderNew()}
+    </div>
+  );
+};
+
+export default AnswerDesigner;

--- a/src/js/survey/AnswerDesigner.jsx
+++ b/src/js/survey/AnswerDesigner.jsx
@@ -116,8 +116,7 @@ export default class AnswerDesigner extends React.Component {
   };
 
   renderNew = () => {
-    const { surveyQuestion, answerId, editMode } = this.props;
-    const { newAnswerText, selectedColor } = this.state;
+    const { surveyQuestion, answerId, editMode, surveyQuestionId } = this.props;
     return (
       <div className="d-flex flex-column">
         <div className="d-flex mb-1 align-items-center">
@@ -153,7 +152,7 @@ export default class AnswerDesigner extends React.Component {
             className="mr-1"
             onChange={(e) => this.setState({ selectedColor: e.target.value })}
             type="color"
-            value={selectedColor}
+            value={surveyQuestion.answers[answerId]?.color}
           />
           <input
             autoComplete="off"
@@ -163,7 +162,7 @@ export default class AnswerDesigner extends React.Component {
               if (e.key === "e" && surveyQuestion.dataType === "number") e.preventDefault();
             }}
             type={surveyQuestion.dataType === "number" ? "number" : "text"}
-            value={newAnswerText}
+            value={surveyQuestion.answers[answerId]?.answer}
           />
         </div>
         {surveyQuestion.componentType != "input" && (

--- a/src/js/survey/SurveyCard.jsx
+++ b/src/js/survey/SurveyCard.jsx
@@ -30,7 +30,7 @@ export default function SurveyCard({ cardNumber, editMode, surveyQuestionId, top
     });
   };
 
-  const { question } = surveyQuestions[surveyQuestionId];
+  const surveyQuestion = surveyQuestions[surveyQuestionId];
 
   return (
     <div className="border rounded border-dark">
@@ -51,7 +51,7 @@ export default function SurveyCard({ cardNumber, editMode, surveyQuestionId, top
             <h2 className="font-weight-bold mt-2 pt-1 ml-2">Survey Card Number {cardNumber}</h2>
             <h3 className="m-3">
               {!showQuestions &&
-                `-- ${editMode === "review" ? removeEnumerator(question) : question}`}
+                `-- ${editMode === "review" ? removeEnumerator(surveyQuestion.question) : surveyQuestion.question}`}
             </h3>
           </div>
           {editMode !== "review" && (
@@ -84,6 +84,7 @@ export default function SurveyCard({ cardNumber, editMode, surveyQuestionId, top
               editMode={editMode}
               indentLevel={0}
               surveyQuestionId={surveyQuestionId}
+              question={surveyQuestion}
             />
           </div>
         )}

--- a/src/js/survey/SurveyCard.jsx
+++ b/src/js/survey/SurveyCard.jsx
@@ -63,7 +63,7 @@ export default function SurveyCard({ cardNumber, editMode, surveyQuestionId, top
                 style={{ opacity: surveyQuestionId === topLevelNodeIds[0] ? "0.25" : "1.0" }}
                 type="button"
               >
-                <SvgIcon icon="upCaret" size="1rem" />
+                <SvgIcon icon="upCaret" size="1rem" transform="rotate(180deg)"/>
               </button>
               <button
                 className="btn btn-outline-lightgreen my-1 px-3 py-0"

--- a/src/js/survey/SurveyDesignQuestion.jsx
+++ b/src/js/survey/SurveyDesignQuestion.jsx
@@ -35,7 +35,6 @@ export default function SurveyDesignQuestion({ indentLevel, editMode, surveyQues
     setHideQuestion(surveyQuestions[surveyQuestionId].hideQuestion);
   }, [surveyQuestionId, surveyQuestions]);
 
-
   const getSameLevelQuestions = () => filterObject(surveyQuestions, ([_id, sq]) =>
     sq.parentQuestionId === surveyQuestion.parentQuestionId);
 

--- a/src/sql/functions/plots.sql
+++ b/src/sql/functions/plots.sql
@@ -256,13 +256,10 @@ CREATE OR REPLACE FUNCTION lock_plot(_plot_id integer, _user_id integer, _lock_e
  RETURNS VOID AS $$
 
  BEGIN
-    IF NOT EXISTS (SELECT 1 FROM plot_rid where plot_rid = _plot_id) THEN
- 
        INSERT INTO plot_locks
            (user_rid, plot_rid, lock_end)
        VALUES
            (_user_id, _plot_id, _lock_end)
-    END IF;
  END
 
 $$ LANGUAGE SQL;


### PR DESCRIPTION
## Purpose

Recovering reorder of subquestions

## Related Issues

Closes COL-###

## Submission Checklist

- [x] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

Wizard > Survey Questions

### Role

Admin

### Steps

1. Create a project and go to the survey questions page
2. Create a few questions and add child questions to some of them
3. Click on the up and down arrows in front of the subquestions 
4. The questions should be reordered

### Desired Outcome

Only questions of the same level can be reordered. Once they are reordered, the survey preview should correctly display the order of the questions.
