### PR TITLE
includes frontend toggle for plot and samples in collection

### DIFF
--- a/src/js/collection.jsx
+++ b/src/js/collection.jsx
@@ -63,6 +63,8 @@ class Collection extends React.Component {
       userImages: {},
       storedInterval: null,
       KMLFeatures: null,
+      showBoundary: true,
+      showSamples: true,
       showSidebar: false,
       showQuitModal: false,
       answerMode: "question",
@@ -121,7 +123,11 @@ class Collection extends React.Component {
     //
 
     // Initialize when new plot
-    if (this.state.currentPlot.id && this.state.currentPlot.id !== prevState.currentPlot.id) {
+    if (this.state.currentPlot.id && (
+      this.state.currentPlot.id !== prevState.currentPlot.id
+      || this.state.showBoundary !== prevState.showBoundary
+    )
+       ) {
       this.showProjectPlot();
       if (
         this.state.currentProject.hasGeoDash &&
@@ -147,7 +153,9 @@ class Collection extends React.Component {
         this.state.selectedQuestionId !== prevState.selectedQuestionId ||
         this.state.unansweredColor !== prevState.unansweredColor ||
         this.state.userSamples !== prevState.userSamples ||
-        selectedQuestion.visible !== prevSelectedQuestion.visible
+        selectedQuestion.visible !== prevSelectedQuestion.visible ||
+          this.state.showSamples !== prevState.showSamples ||
+          this.state.showBoundary !== prevState.showBoundary
       ) {
         this.showPlotSamples();
         this.highlightSamplesByQuestion();
@@ -314,7 +322,7 @@ class Collection extends React.Component {
     mercator.addVectorLayer(
       mapConfig,
       "currentAOI",
-      mercator.geomArrayToVectorSource(this.state.currentProject.aoiFeatures),
+      mercator.geomArrayToVectorSource(this.state.currentProject.aoiFeatures,),
       mercator.ceoMapStyles("geom", "yellow")
     );
     mercator.zoomMapToLayer(mapConfig, "currentAOI", 48);
@@ -528,7 +536,7 @@ class Collection extends React.Component {
   zoomToPlot = () => mercator.zoomMapToLayer(this.state.mapConfig, "currentPlot", 36);
 
   showProjectPlot = () => {
-    const { currentPlot, mapConfig, currentProject } = this.state;
+    const { currentPlot, mapConfig, currentProject, showBoundary} = this.state;
     mercator.disableSelection(mapConfig);
     mercator.removeLayerById(mapConfig, "currentPlots");
     mercator.removeLayerById(mapConfig, "currentPlot");
@@ -546,14 +554,14 @@ class Collection extends React.Component {
             )
           : mercator.parseGeoJson(currentPlot.plotGeom, true)
       ),
-      mercator.ceoMapStyles("geom", "yellow")
+      mercator.ceoMapStyles("geom", (showBoundary ? "yellow" : "transparent")
+                           )
     );
-
     this.zoomToPlot();
   };
 
   showPlotSamples = () => {
-    const { mapConfig, unansweredColor, currentProject, selectedQuestionId } = this.state;
+    const { mapConfig, unansweredColor, currentProject, selectedQuestionId, showSamples} = this.state;
     const { visible } = currentProject.surveyQuestions[selectedQuestionId];
     mercator.disableSelection(mapConfig);
     mercator.disableDrawing(mapConfig);
@@ -563,7 +571,7 @@ class Collection extends React.Component {
       mapConfig,
       "currentSamples",
       mercator.samplesToVectorSource(visible),
-      mercator.ceoMapStyles("geom", unansweredColor)
+      mercator.ceoMapStyles("geom", (showSamples ? unansweredColor : "transparent"))
     );
     mercator.enableSelection(
       mapConfig,
@@ -615,6 +623,18 @@ class Collection extends React.Component {
         {}
       ),
     });
+  };
+
+  toggleShowBoundary = () => {
+    this.setState ({...this.state,
+                    showBoundary: !this.state.showBoundary
+                   });
+  };
+
+  toggleShowSamples = () => {
+    this.setState ({...this.state,
+                    showSamples: !this.state.showSamples
+                   });
   };
 
   showGeoDash = () => {
@@ -1055,6 +1075,11 @@ class Collection extends React.Component {
             KMLFeatures={this.state.KMLFeatures}
             showGeoDash={this.showGeoDash}
             zoomMapToPlot={this.zoomToPlot}
+            toggleShowBoundary={this.toggleShowBoundary}
+            toggleShowSamples={this.toggleShowSamples}
+            state={{showBoundary: this.state.showBoundary,
+                    showSamples: this.state.showSamples}}
+            
           />
           {this.state.currentPlot.id &&
             this.state.currentProject.projectOptions.showPlotInformation && (
@@ -1454,7 +1479,7 @@ class ExternalTools extends React.Component {
     super(props);
     this.state = {
       showExternalTools: true,
-      auxWindow: null,
+      auxWindow: null
     };
   }
 
@@ -1471,6 +1496,23 @@ class ExternalTools extends React.Component {
         onClick={this.props.showGeoDash}
         type="button"
         value="GeoDash"
+      />
+    </div>
+  );
+
+  toggleViewButtons = () => (
+    <div className="ExternalTools__geo-buttons d-flex justify-content-between mb-2" id="plot-nav">
+      <input
+        className={`btn btn-outline-${this.props.state.showSamples ? "red" : "lightgreen"} btn-sm col-6 mr-1`}
+        onClick={this.props.toggleShowSamples}
+        type="button"
+        value={`${this.props.state.showSamples ? "Hide" : "Show"} Samples`}
+      />
+      <input
+        className={`btn btn-outline-${this.props.state.showBoundary ? "red" : "lightgreen"} btn-sm col-6`}
+        onClick={this.props.toggleShowBoundary}
+        type="button"
+        value={`${this.props.state.showBoundary ? "Hide" : "Show"} Boundary`}
       />
     </div>
   );
@@ -1544,6 +1586,7 @@ class ExternalTools extends React.Component {
         {this.state.showExternalTools && (
           <div className="mx-1">
             {this.geoButtons()}
+            {this.toggleViewButtons()}
             {this.props.KMLFeatures && this.kmlButton()}
             {this.props.currentProject.projectOptions.showGEEScript && this.geeButton()}
           </div>

--- a/src/js/utils/mercator.js
+++ b/src/js/utils/mercator.js
@@ -910,6 +910,7 @@ const ceoMapPresets = {
   red: "#8b2323",
   white: "#ffffff",
   yellow: "yellow",
+  transparent: "transparent"
 };
 
 const ceoMapStyleFunctions = {
@@ -1066,7 +1067,7 @@ mercator.addPlotOverviewLayers = (mapConfig, plots) => {
       color: "lightBlue",
     },
     {
-      id: "unanalyzed",
+      id: "unanalyzedn",
       layerPlots: notFlagged.filter((plot) => plot.status === "unanalyzed"),
       color: "yellow",
     },
@@ -1298,6 +1299,11 @@ mercator.highlightSampleGeometry = (sample, color) => {
   sample.setStyle(mercator.ceoMapStyles("answered", color));
   return sample;
 };
+
+mercator.setFeatureStyle = (mapConfig,featureId, color) => {
+  const feature = mercator.getLayerById(mapConfig, featureId);
+  feature.setStyle(mercator.ceoMapStyles)
+}
 
 /*****************************************************************************
  ***

--- a/src/js/utils/mercator.js
+++ b/src/js/utils/mercator.js
@@ -1067,7 +1067,7 @@ mercator.addPlotOverviewLayers = (mapConfig, plots) => {
       color: "lightBlue",
     },
     {
-      id: "unanalyzedn",
+      id: "unanalyzed",
       layerPlots: notFlagged.filter((plot) => plot.status === "unanalyzed"),
       color: "yellow",
     },


### PR DESCRIPTION
## Purpose

adds a UI element to the collection page that toggles the visibility of the plot boundary or samples

## Related Issues

Closes COL-639

## Submission Checklist

- [x ] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [ x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [ x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted
Collection

### Role

Admin

### Steps

Navigate to the collection page of an open project. observe the "show/hide plot/samples" buttons in the "External Tools." Enjoy a moment of serenity. Click the button.

1.

### Desired Outcome

observe the plot boundary and samples toggle visibility

<!-- If needed, add more tests using the format above (Module Impacted, Role, Steps, Desired Outcome) here. -->

## Screenshots

<!-- Add a screen shot when UI changes are included -->
