### PR TITLE
Fix confidence_comment not reseting its state

### DIFF
--- a/src/clj/collect_earth_online/db/plots.clj
+++ b/src/clj/collect_earth_online/db/plots.clj
@@ -170,24 +170,26 @@
   (let [{:keys [plot_id
                 flagged
                 confidence
+                confidence_comment
                 flagged_reason
                 plot_geom
                 extra_plot_info
                 visible_id
                 user_id
                 email]} plot-info]
-    {:id            plot_id
-     :flagged       flagged
-     :flaggedReason (or flagged_reason "")
-     :confidence    confidence
-     :visibleId     visible_id
-     :plotGeom      plot_geom
-     :extraPlotInfo (tc/jsonb->clj extra_plot_info {})
-     :samples       (prepare-samples-array plot_id (if (and review-mode? (pos? user_id))
+    {:id                plot_id
+     :flagged           flagged
+     :flaggedReason     (or flagged_reason "")
+     :confidence        confidence
+     :confidenceComment confidence_comment
+     :visibleId         visible_id
+     :plotGeom          plot_geom
+     :extraPlotInfo     (tc/jsonb->clj extra_plot_info {})
+     :samples           (prepare-samples-array plot_id (if (and review-mode? (pos? user_id))
                                                      user_id
                                                      user-id))
-     :userId        user_id
-     :email         email}))
+     :userId            user_id
+     :email             email}))
 
 (defn get-collection-plot
   "Gets plot information needed for the collections page.  The plot

--- a/src/js/survey/SurveyCollection.jsx
+++ b/src/js/survey/SurveyCollection.jsx
@@ -655,7 +655,7 @@ export default class SurveyCollection extends React.Component {
                     className="form-control"
                     id="confidenceComment"
                     onChange={(e) => this.props.setConfidenceComment(e.target.value)}
-                    value={this.props.confidenceComment}
+                    value={this.props.confidenceComment || ""}
                   />
                 </div>
                 </>

--- a/src/sql/functions/plots.sql
+++ b/src/sql/functions/plots.sql
@@ -82,14 +82,16 @@ $$ LANGUAGE SQL;
 -- Get user plots for a plot
 CREATE OR REPLACE FUNCTION select_user_plots_info( _plot_id integer)
  RETURNS table (
-    user_id       integer,
-    flagged       boolean,
-    confidence    integer
+    user_id            integer,
+    flagged            boolean,
+    confidence         integer,
+    confidence_comment text
  ) AS $$
 
     SELECT user_rid,
         flagged,
-        confidence
+        confidence,
+        confidence_comment
     FROM user_plots
     WHERE plot_rid = _plot_id
 
@@ -102,6 +104,7 @@ CREATE TYPE collection_return AS (
     flagged            boolean,
     flagged_reason     text,
     confidence         integer,
+    confidence_comment text,
     visible_id         integer,
     plot_geom          text,
     extra_plot_info    json,
@@ -116,6 +119,7 @@ CREATE OR REPLACE FUNCTION select_unanalyzed_plots(_project_id integer, _user_id
         flagged,
         flagged_reason,
         confidence,
+        confidence_comment,
         visible_id,
         ST_AsGeoJSON(plot_geom) as plot_geom,
         extra_plot_info,
@@ -149,6 +153,7 @@ CREATE OR REPLACE FUNCTION select_analyzed_plots(_project_id integer, _user_id i
         flagged,
         flagged_reason,
         confidence,
+        confidence_comment,
         visible_id,
         ST_AsGeoJSON(plot_geom) as plot_geom,
         extra_plot_info,
@@ -172,6 +177,7 @@ CREATE OR REPLACE FUNCTION select_flagged_plots(_project_id integer, _user_id in
         flagged,
         flagged_reason,
         confidence,
+        confidence_comment,
         visible_id,
         ST_AsGeoJSON(plot_geom) as plot_geom,
         extra_plot_info,
@@ -200,6 +206,7 @@ CREATE OR REPLACE FUNCTION select_confidence_plots(
         flagged,
         flagged_reason,
         confidence,
+        confidence_comment,
         visible_id,
         ST_AsGeoJSON(plot_geom) as plot_geom,
         extra_plot_info,
@@ -232,6 +239,7 @@ CREATE OR REPLACE FUNCTION select_qaqc_plots(_project_id integer)
         up.flagged,
         up.flagged_reason,
         confidence,
+        confidence_comment,
         visible_id,
         ST_AsGeoJSON(plot_geom) as plot_geom,
         extra_plot_info,
@@ -408,6 +416,7 @@ CREATE OR REPLACE FUNCTION flag_plot(
         SET flagged = excluded.flagged,
             user_rid = excluded.user_rid,
             confidence = NULL,
+            confidence_comment = NULL,
             collection_start = excluded.collection_start,
             collection_time = Now(),
             flagged_reason = excluded.flagged_reason


### PR DESCRIPTION
## Purpose

Confidence comment was not being reset when navigating to another plot. This PR fixes this bug.

## Related Issues

Closes COL-597

## Submission Checklist

- [x] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

collection > sidebar

### Role

User

### Steps

1. Create a project with confidence enabled
2. Navigate to the collection page and collect some plots
3. Observe that now, the confidence comment gets reset
4. Navigate back to a plot that was already collected, check that the correct confidence comment shows up.

### Desired Outcome

confidence comment should be empty when navigating to uninterpreted plots.
