### PR TITLE
Improve sample selection in collection

### DIFF
--- a/src/js/collection.jsx
+++ b/src/js/collection.jsx
@@ -493,7 +493,6 @@ class Collection extends React.Component {
 
   resetPlotValues = () => {
     this.setState(this.newPlotValues(this.state.currentPlot, false));
-    this.resetUnsavedWarning();
   };
 
   newPlotValues = (newPlot, copyValues = true) => ({
@@ -786,16 +785,25 @@ class Collection extends React.Component {
       : [currentQuestionId];
   };
 
+  keyDifference = (o1, features) => {
+    const objKeys = o1.map(i => i.sampleId);
+    const sampleIds = features.map(f => f.get("sampleId"));
+    const unansweredKeys = sampleIds.filter(k => !objKeys.includes(k));
+    return features.filter(f => unansweredKeys.includes(f.get("sampleId")));
+  };
+
   getSelectedSampleIds = (questionId) => {
     const { answered } = this.state.currentProject.surveyQuestions[questionId];
     const allFeatures = mercator.getAllFeatures(this.state.mapConfig, "currentSamples") || [];
+    const unansweredFeatures = this.keyDifference(answered, allFeatures);
     const selectedSamples = mercator.getSelectedSamples(this.state.mapConfig);
     const selectedFeatures = selectedSamples ? selectedSamples.getArray() : [];
     return (
-      (selectedFeatures.length === 0 && answered.length === 0) ||
-      lengthObject(this.state.userSamples) === 1
+      (selectedFeatures.length === 0 && answered.length === 0)
         ? allFeatures
-        : selectedFeatures
+        : selectedFeatures.length !== 0
+        ? selectedFeatures
+        : unansweredFeatures
     ).map((sf) => sf.get("sampleId"));
   };
 

--- a/src/js/survey/SurveyCollectionAnswers.jsx
+++ b/src/js/survey/SurveyCollectionAnswers.jsx
@@ -136,7 +136,7 @@ class AnswerInput extends React.Component {
         newInput: this.props.surveyNode.answered[0] ? answerText : ""});
     } else {
       this.setState({
-        newInput: matchingNode.answerText ? matchingNode.answerText : ""
+        newInput: matchingNode?.answerText ? matchingNode.answerText : ""
       });
     }
   };


### PR DESCRIPTION
## Purpose

Users had to keep selecting the same samples for every question. This PR fixes this issue by allowing no samples to be selected and only answering for the ones that are visible but have no answers.


## Submission Checklist

- [x] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

Collection > survey answers

### Role

User

### Steps

1. Create a project with several samples per plot and at least a few questions and subquestions
2. Go to the collection page
3. Select a couple of samples and try answering all the questions for them.
4. Repeat item 3 untill all samples have been answered

### Desired Outcome

Users should be able to answer questions for the samples selected earlier. if no samples are selected for child questions, the answer will be set for every unanswered samples present in the map

