### PR TITLE
updates default drawtool

### DIFF
--- a/src/js/survey/SurveyCollection.jsx
+++ b/src/js/survey/SurveyCollection.jsx
@@ -11,12 +11,13 @@ import { filterObject, intersection, lengthObject, mapObjectArray } from "../uti
 
 export default class SurveyCollection extends React.Component {
   constructor(props) {
+    let {polygons, lines, points} = props.sampleGeometries;
     super(props);
     this.state = {
       currentNodeIndex: 0,
       topLevelNodeIds: [],
       showSurveyQuestions: true,
-      drawTool: "Point",
+      drawTool: polygons ? "Polygon" : lines? "LineString" : "Point"
     };
   }
 


### PR DESCRIPTION
## Purpose

Refactors code to prevent drawtool on projects where it is not allowed

## Related Issues

Closes COL-595

## Submission Checklist

- [ x] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [x ] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [ x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted
Collection
### Role

Admin

### Steps

<!-- All steps needed to test this PR -->

1. Create a new project or navigate to one in which users are allowed to draw polygons. During Collection, attempt to draw a point on the map. Observe that this is impossible. 

### Desired Outcome

---

<!-- If needed, add more tests using the format above (Module Impacted, Role, Steps, Desired Outcome) here. -->

## Screenshots

<!-- Add a screen shot when UI changes are included -->
