### PR TITLE
validates projects from db and fixes broken cardOrders

### DIFF
--- a/src/js/survey/SurveyCardList.jsx
+++ b/src/js/survey/SurveyCardList.jsx
@@ -1,22 +1,24 @@
-import React, { useContext } from "react";
+import React, { useContext , useEffect} from "react";
 
 import SurveyCard from "./SurveyCard";
 
-import { mapObjectArray } from "../utils/sequence";
+import { mapObjectArray, mapVals } from "../utils/sequence";
 import { ProjectContext } from "../project/constants";
 import { isNumber } from "../utils/generalUtils";
 
 export default function SurveyCardList({ editMode }) {
-  const { surveyQuestions } = useContext(ProjectContext);
+  const {setProjectDetails, surveyQuestions, validateCardOrder } = useContext(ProjectContext);
+
   const topLevelNodes = mapObjectArray(surveyQuestions, ([id, sq]) => ({
     nodeId: id,
     cardOrder: sq.cardOrder,
   }))
-    .filter(({ cardOrder }) => isNumber(cardOrder))
-    .sort((a, b) => a.cardOrder - b.cardOrder)
-    .map(({ nodeId }) => Number(nodeId));
+        .filter(({ cardOrder }) => isNumber(cardOrder))
+        .sort((a, b) => a.cardOrder - b.cardOrder)
+        .map(({ nodeId }) => Number(nodeId));
 
-  return topLevelNodes.map((nodeId, idx) => (
+  return topLevelNodes.map((nodeId, idx) => {
+    return (
     <SurveyCard
       key={nodeId}
       cardNumber={idx + 1} // card order saved in the DB isn't necessarily sequential
@@ -24,5 +26,5 @@ export default function SurveyCardList({ editMode }) {
       surveyQuestionId={nodeId}
       topLevelNodeIds={topLevelNodes}
     />
-  ));
+  );});
 }


### PR DESCRIPTION
## Purpose

Some projects, including those referenced in COL-577, are saved in our db so that each answer in its survey_questions jsonb data has a cardOrder value of 0. this munges the order of survey_question data on export and makes further rearranging of cards impossible on the frontend as well. As it is now, it is not possible to recapture the intended order of projects for which this is the case. This PR proposes a method by which users may still update the frontend order of survey question cards.

## Related Issues

Closes COL-577

## Submission Checklist

- [ x] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [x ] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [x ] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted
Projects
### Role

Admin

### Steps

<!-- All steps needed to test this PR -->

1. Identify or create a project that bears munged survey_question data (that is, each question has a "cardOrder" of 0). Navigate to the window to edit the survey questions. re-arrange them as suits one's desires. Admire one's own creativity. Export the data of the project. not the order of the questions should be the same.

### Desired Outcome

---

<!-- If needed, add more tests using the format above (Module Impacted, Role, Steps, Desired Outcome) here. -->

## Screenshots

<!-- Add a screen shot when UI changes are included -->
