### PR TITLE
updates survey create and copy methods to smooth child copying

### DIFF
--- a/src/js/survey/NewQuestionDesigner.jsx
+++ b/src/js/survey/NewQuestionDesigner.jsx
@@ -104,6 +104,7 @@ export default class NewQuestionDesigner extends React.Component {
       ...copyQuestion,
       question: `${copyQuestion.question} (${repeatedQuestions})`,
       parentQuestionId: parentId,
+      cardOrder: -1,
       ...(answerIds && { parentAnswerIds: answerIds }),
     };
     const newId = idOffset + copyQuestionId;
@@ -126,16 +127,33 @@ export default class NewQuestionDesigner extends React.Component {
     }
   };
 
+  newParentQuestion = (surveyQuestions, selectedCopyId, selectedParentId, selectedAnswerIds, setProjectDetails) => {
+    const idOffset = getNextInSequence(Object.keys(surveyQuestions)) - selectedCopyId;
+    const copies = this.getCopy(idOffset, selectedCopyId, selectedParentId, selectedAnswerIds);
+    setProjectDetails({ surveyQuestions: { ...surveyQuestions, ...copies } });
+  };
+
+  newChildQuestion = (surveyQuestions, selectedParentId, selectedCopyId, selectedAnswerIds, setProjectDetails) => {
+    const newId = getNextInSequence(Object.keys(surveyQuestions));
+    const newChild =  {
+      ...surveyQuestions[selectedCopyId],
+      parentQuestionId: selectedParentId,
+      parentAnswerIds: selectedAnswerIds
+    };
+    const newParent = surveyQuestions[selectedParentId];
+    setProjectDetails({surveyQuestions: {...surveyQuestions, [newId]: newChild}});
+  };
+
+  
   copySurveyQuestion = () => {
     const { selectedCopyId, selectedParentId, selectedAnswerIds } = this.state;
     const { surveyQuestions, setProjectDetails } = this.props;
-    if (selectedCopyId >= 0) {
-      const idOffset = getNextInSequence(Object.keys(surveyQuestions)) - selectedCopyId;
-      const copies = this.getCopy(idOffset, selectedCopyId, selectedParentId, selectedAnswerIds);
-      setProjectDetails({ surveyQuestions: { ...surveyQuestions, ...copies } });
-    } else {
-      alert("Please select a question to copy");
-    }
+    (selectedCopyId >= 0) ?
+      (selectedParentId >= 0) ?    
+      this.newChildQuestion(surveyQuestions, selectedParentId, selectedCopyId, selectedAnswerIds, setProjectDetails) :
+      this.newParentQuestion(surveyQuestions, selectedCopyId, selectedParentId, selectedAnswerIds, setProjectDetails) :
+    alert("Please select a question to copy") ;
+    
   };
 
   renderOptions = () => {

--- a/src/js/survey/SurveyCardList.jsx
+++ b/src/js/survey/SurveyCardList.jsx
@@ -11,8 +11,10 @@ export default function SurveyCardList({ editMode }) {
   const topLevelNodes = mapObjectArray(surveyQuestions, ([id, sq]) => ({
     nodeId: id,
     cardOrder: sq.cardOrder,
+    parentQuestionId: sq.parentQuestionId
   }))
     .filter(({ cardOrder }) => isNumber(cardOrder))
+    .filter(({parentQuestionId}) => parentQuestionId < 0)
     .sort((a, b) => a.cardOrder - b.cardOrder)
     .map(({ nodeId }) => Number(nodeId));
 


### PR DESCRIPTION
## Purpose

Currently, survey creation is awkward when users try to copy child questions to use as new parent questions, or when users try to copy existing questions to use as child questions. This PR allows for child question copying both ways.

## Related Issues

Closes COL-588

## Submission Checklist

- [x ] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [x ] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [ x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted
Survey
### Role

Admin

### Steps



1. Create a new project. navigate directly to "survey questions"
2. create two questions: "a parent question" and "a child question"
3. copy "a child question" as a child of "a parent question"
4. observe the new child question nestled gently under the wing of the existing parent question, and not elsewhere.
5. next, copy that child question that was just created under "a parent question". set no question as the new parent question.
6. observe that, though the question title or text may have new text appended to it, it is nevertheless beautifully visible and editable.

### Desired Outcome

---

<!-- If needed, add more tests using the format above (Module Impacted, Role, Steps, Desired Outcome) here. -->

## Screenshots

<!-- Add a screen shot when UI changes are included -->
