### PR TITLE
COL-572: Fix NDFI time series from degradation tool

### DIFF
--- a/src/py/gee/inputs.py
+++ b/src/py/gee/inputs.py
@@ -11,7 +11,9 @@ LANDSAT_BAND_DICT = {
     'L4': [0, 1, 2, 3, 4, 5, 6],
 }
 LANDSAT_BAND_NAMES = ['BLUE', 'GREEN',
-                        'RED', 'NIR', 'SWIR1', 'TEMP', 'SWIR2']
+                      'RED', 'NIR',
+                      'SWIR1', 'TEMP',
+                      'SWIR2']
 
 def getBitMask(image:ee.Image, bandName:str, bitMasks:dict):
     """ creates a binary mask from an images bitmask. Expects a dictionary where each item

--- a/src/py/gee/utils.py
+++ b/src/py/gee/utils.py
@@ -505,13 +505,8 @@ def getDegradationPlotsByPoint(geometry, start, end, band):
         geometry = ee.Geometry.Polygon(geometry)
     else:
         geometry = ee.Geometry.Point(geometry)
-    landsatData = getLandsat({
-        "start": start,
-        "end": end,
-        "targetBands": [band],
-        "region": geometry,
-        "sensors": {"l4": True, "l5": True, "l7": True, "l8": True}
-    })
+
+    landsatData = getLandsatToa(start, end, geometry)
 
     def myImageMapper(img):
         theReducer = ee.Reducer.mean()


### PR DESCRIPTION
## Purpose

The NDFI timeseries displayed in the degradation tool was showing wrong data. This PR fixes it by using TOA imagery instead of L2 imagery.

## Related Issues

Closes COL-572

## Submission Checklist

- [x] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

Geodash > Degradation tool

### Role

Admin/User

### Steps


1. Create a project and configure the degradation tool in geodash widget creation
2. Navigate to the collection page
3. Open the geodash widget
4. Check that numbers in the degradation time series are not all tending to 1 and instead, are showing correct values.