### PR TITLE
COL-517: Change authorization level for qaqc checking of csv

### DIFF
--- a/src/clj/collect_earth_online/routing.clj
+++ b/src/clj/collect_earth_online/routing.clj
@@ -109,7 +109,7 @@
                                               :auth-type   :user
                                               :auth-action :block}
    [:post "/check-plot-csv"]                 {:handler     projects/check-plot-csv
-                                              :auth-type   :admin
+                                              :auth-type   :user
                                               :auth-action :block}
 
    ;; DOI API


### PR DESCRIPTION
## Purpose

bugfix for setting QAQC configuration with plot CSV

## Related Issues

Closes COL-517

## Submission Checklist

- [x] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

Same as https://github.com/openforis/collect-earth-online/pull/1698

