### PR TITLE
Fix degradation tool imagery when selecting a point in time

### DIFF
--- a/src/py/gee/utils.py
+++ b/src/py/gee/utils.py
@@ -486,13 +486,12 @@ def getDegradationTileUrlByDate(geometry, date, visParams):
         geometry = ee.Geometry.Polygon(geometry)
     else:
         geometry = ee.Geometry.Point(geometry)
-    landsatData = getLandsat({
-        "start": startDate.strftime('%Y-%m-%d'),
-        "end": endDate.strftime('%Y-%m-%d'),
-        "targetBands": ['RED', 'GREEN', 'BLUE', 'SWIR1', 'NIR'],
-        "region": geometry,
-        "sensors": {"l4": False, "l5": False, "l7": False, "l8": True}
-    })
+
+    landsatData = getLandsatToa(
+        startDate.strftime('%Y-%m-%d'),
+        endDate.strftime('%Y-%m-%d'),
+        geometry
+    )
 
     selectedImage = landsatData.first()
     unmasked = ee.Image(selectedImage).multiply(10000).toInt16().unmask()


### PR DESCRIPTION
## Purpose

Fixes imagery displayed in the degradation tool widget when a user clicks on a point in time in the time series graph

## Related Issues

Closes COL-698

## Submission Checklist

- [x] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

Geodash

### Role

<!-- User -->

### Steps

1. Create a project
2. Add a Degradation Tool widget in the geodash page
3. Start interpreting plots, go to geodash and click in a few points in the time series of the widget.

### Desired Outcome

Widget should display the image correctly.