### PR TITLE
Sort plot info alphabetically and add formatting

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -864,3 +864,37 @@ body {
     margin-top: 60px;
     overflow-x: hidden;
 }
+
+/********************/
+/* Plot Information */
+/********************/
+.plot-info__list {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0;
+  background: #f9f9f9;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.plot-info__item {
+  padding: 0.5rem 1rem;
+  border-bottom: 1px solid #eaeaea;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.plot-info__item:last-child {
+  border-bottom: none;
+}
+
+.plot-info__key {
+  font-weight: bold;
+  margin-right: 0.5rem;
+}
+
+.plot-info__value {
+  color: #555;
+  font-style: italic;
+}

--- a/src/js/collection.jsx
+++ b/src/js/collection.jsx
@@ -1646,7 +1646,6 @@ class PlotInformation extends React.Component {
   }
 }
 
-
 class ImageryOptions extends React.Component {
   constructor(props) {
     super(props);

--- a/src/js/collection.jsx
+++ b/src/js/collection.jsx
@@ -1626,13 +1626,15 @@ class PlotInformation extends React.Component {
         />
         {this.state.showInfo ? (
           hasExtraInfo ? (
-            <ul className="mb-3 mx-1">
+            <ul className="plot-info__list mb-3 mx-1">
               {Object.entries(this.props.extraPlotInfo)
                 .filter(([_key, value]) => value && !(value instanceof Object))
+                .sort((a, b) => a[0].localeCompare(b[0])) // Sorting the array by keys alphabetically
                 .map(([key, value]) => (
-                  <li key={key}>
-                    {key} - {value}
-                  </li>
+                  <li key={key} className="plot-info__item">
+                  <span className="plot-info__key">{key}</span>
+                  <span className="plot-info__value">{value}</span>
+                </li>
                 ))}
             </ul>
           ) : (
@@ -1643,6 +1645,7 @@ class PlotInformation extends React.Component {
     );
   }
 }
+
 
 class ImageryOptions extends React.Component {
   constructor(props) {


### PR DESCRIPTION
## Purpose

Sort Plot Info fields alphabetically, requested at FAO. Also changed formatting, I can revert if ugly.

![image](https://github.com/openforis/collect-earth-online/assets/47796239/3d95b927-4538-46e0-882c-c52f7d8a6b28)

### Role

Users

### Testing

Add a plot file with props and check if sorted properly in collection view. 
