### PR TITLE
COL-700: Reset confidence slider position for every question.

### DIFF
--- a/src/js/survey/SurveyCollection.jsx
+++ b/src/js/survey/SurveyCollection.jsx
@@ -640,7 +640,7 @@ export default class SurveyCollection extends React.Component {
                     min="0"
                     onChange={(e) => this.props.setConfidence(parseInt(e.target.value))}
                     type="range"
-                    value={this.props.confidence}
+                    value={this.props.confidence || 0}
                   />
                   <label>Plot Confidence: {this.props.confidence}</label>
                 </div>


### PR DESCRIPTION
## Purpose

The confidence slider was not reseting its position after answers were saved from one plot and the user navigated to another. This PR fixes this issue

## Related Issues

Closes COL-700

## Submission Checklist

- [x] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

Collection > Side Panel > Confidence slider

### Role

User

### Steps

1. Create a project with confidence enabled
2. Navigate to the collection page
3. Answer the questions and set the confidence slider
4. Save answers for the plot and navigate to another one

### Desired Outcome

The confidence slider should reset its value and the handle position
