### PR TITLE
COL-715: Select plot from map

### DIFF
--- a/src/clj/collect_earth_online/db/plots.clj
+++ b/src/clj/collect_earth_online/db/plots.clj
@@ -33,7 +33,8 @@
 (defn get-project-plots [{:keys [params]}]
   (let [project-id (tc/val->int (:projectId params))
         max-plots  (tc/val->int (:max params) 100000)] ; 100000 loads in ~1.5 seconds.
-    (data-response (mapv #(set/rename-keys % {:plot_id :id})
+    (data-response (mapv #(set/rename-keys % {:visible_id :id
+                                              :plot_id :plotId})
                          (call-sql "select_limited_project_plots" project-id max-plots)))))
 
 (defn get-plotters

--- a/src/js/utils/mercator.js
+++ b/src/js/utils/mercator.js
@@ -1434,7 +1434,7 @@ mercator.projectsToVectorSource = (projects) => {
 // on clusters with more than one plot zooms the map view to the
 // extent covered by these plots. If a cluster only contains one plot,
 // the callBack function will be called on the cluster feature.
-mercator.addPlotLayer = (mapConfig, plots, _callback) => {
+mercator.addPlotLayer = (mapConfig, plots, callback) => {
   mercator.addVectorLayer(
     mapConfig,
     "currentPlots",
@@ -1453,11 +1453,11 @@ mercator.addPlotLayer = (mapConfig, plots, _callback) => {
             mercator.zoomMapToExtent(mapConfig, mercator.getClusterExtent(feature));
           }
           // / Disable due to miss coordinated plot_id vs plotId
-          // else {
-          //     mercator.removeLayerById(mapConfig, "currentPlots");
-          //     mapConfig.map.un("click", clickHandler);
-          //     callBack.call(null, feature);
-          // }
+          else {
+              mercator.removeLayerById(mapConfig, "currentPlots");
+              mapConfig.map.un("click", clickHandler);
+              callback.call(null, feature);
+          }
         }
       },
       { hitTolerance: 10 }

--- a/src/sql/functions/plots.sql
+++ b/src/sql/functions/plots.sql
@@ -10,6 +10,7 @@
 CREATE OR REPLACE FUNCTION select_limited_project_plots(_project_id integer, _maximum integer)
  RETURNS table (
     plot_id    integer,
+    visible_id integer,
     center     text,
     flagged    boolean,
     status     text
@@ -17,6 +18,7 @@ CREATE OR REPLACE FUNCTION select_limited_project_plots(_project_id integer, _ma
 
     WITH plot_sums AS (
         SELECT plot_uid,
+            pl.visible_id AS visible_id,
             ST_AsGeoJSON(ST_Centroid(plot_geom)) AS center,
             sum(coalesce(flagged, false)::int) > 0 AS flagged,
             sum((pa.user_rid IS NOT NULL)::int) AS assigned,
@@ -33,6 +35,7 @@ CREATE OR REPLACE FUNCTION select_limited_project_plots(_project_id integer, _ma
     )
 
     SELECT plot_uid,
+        visible_id,
         center,
         flagged,
         CASE WHEN (assigned = 0 AND collected = 1) OR (assigned > 0 AND assigned = collected)


### PR DESCRIPTION
## Purpose

This PR changes the application to allow users to click in a plot (if the cluster has only 1 plot) and go to its interpretation.

## Related Issues

Closes COL-715

## Submission Checklist

- [x] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

Collection > Plot Navigation

### Role

User

### Steps

1. Create a project and go to the collection page
2. Click on a cluster of plots that is marked with '1'
3. Collect data for that plot

### Desired Outcome

After clicking the cluster, the map should zoom in that area and open the survey collection for that specific plot.

