### PR TITLE
COL-717: Removing wrong validation from project creation

### DIFF
--- a/src/js/utils/validation.js
+++ b/src/js/utils/validation.js
@@ -86,9 +86,6 @@ export default function getErrors (form) {
         percent === 0 &&
         "The assigned Quality Control percentage must be greater than 0%.",
       ["random", "gridded"].includes(plotDistribution) &&
-        qaqcMethod === "overlap" &&
-        users.length > Math.round((totalPlots * (percent / 100)) / users.length) &&
-        `Too few plots per user for Quality Control Overlap. Each user must have at least ${users.length} plots.`,
       qaqcMethod === "sme" && smes.length === 0 && "At least one user must be added as an SME.",
       qaqcMethod === "overlap" &&
         users.length === 1 &&


### PR DESCRIPTION
## Purpose

Removes validation with wrong calculations for assigning users with the QAQC overlap feature.

## Related Issues

Closes COL-717

## Submission Checklist

- [x] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

Wizard > Plot Design > QAQC

### Role

Admin

### Steps

1. Start project creation and navigate to the `Plot Design` tab.
2. Create 10 plots by using the `random` spatial distribution. 
3. Assign 10 users and set QAQC to overlap 100% and 2 reviews (make sure you have access to at least one of the assigned user accounts).
4. Log in an assigned user, and start interpreting plots. Each user must have exactly 2 plots assigned to them.


### Desired Outcome

Make sure the project can be created and that it assigns correctly the number of plots per user

## Screenshots

![plot_assignment](https://github.com/openforis/collect-earth-online/assets/18133069/2202093e-e7ca-4697-b027-d972e09e1e02)

