### PR TITLE
HOTFIX: Adding visible_ids for exporting shapefiles

### DIFF
--- a/src/sql/functions/plots.sql
+++ b/src/sql/functions/plots.sql
@@ -563,6 +563,7 @@ CREATE OR REPLACE FUNCTION get_plot_shapes(_project_id integer)
  ) AS $$
 
     WITH plot_geoms AS (SELECT project_rid, plot_distribution, plot_shape, plot_size, plot_uid,
+                               visible_id AS plot_visible_id,
                                ST_Transform(plot_geom, 3857) AS plot_geom
                         FROM projects AS pr
                         INNER JOIN plots AS pl
@@ -585,7 +586,7 @@ CREATE OR REPLACE FUNCTION get_plot_shapes(_project_id integer)
                                     END AS plot_boundary
                              FROM plot_geoms)
 
-      SELECT project_rid, plot_uid, ST_Transform(plot_geom, 4326) AS plot_geom
+      SELECT project_rid, plot_visible_id, ST_Transform(plot_geom, 4326) AS plot_geom
       FROM plot_geoms
       INNER JOIN plot_boundaries
       USING (plot_uid)
@@ -594,19 +595,22 @@ $$ LANGUAGE SQL;
 
 -- Get sample shapes for DOI creation
 CREATE OR REPLACE FUNCTION get_sample_shapes(_project_id integer)
- RETURNS TABLE (project_id integer,
-                plot_id integer,
-                sample_id integer,
-                sample_geom geometry(Geometry, 4326)
+ RETURNS TABLE (project_id         integer,
+                plot_id            integer,
+                sample_id          integer,
+                sample_internal_id integer,
+                sample_geom        geometry(Geometry, 4326)
  ) AS $$
 
-    (SELECT project_rid, plot_rid, sample_uid, ST_Buffer(sample_geom, 0.000001)
+    (SELECT project_rid, pl.visible_id AS plot_visible_id, s.visible_id AS sample_visible_id,
+            sample_uid, ST_Buffer(sample_geom, 0)
        FROM samples s
        INNER JOIN plots pl
        ON pl.plot_uid = s.plot_rid
        WHERE pl.project_rid = _project_id)
     UNION
-    (SELECT project_rid, plot_rid, sample_uid as sample_uid, ST_Buffer(sample_geom, 0.000001)
+    (SELECT project_rid, pl.visible_id AS plot_visible_id, s.visible_id AS sample_visible_id,
+            sample_uid, ST_Buffer(sample_geom, 0)
        FROM ext_samples s
        INNER JOIN plots pl
        ON pl.plot_uid = s.plot_rid


### PR DESCRIPTION
## Purpose

Adds the visible_id fields for querying plot and sample tables for exporting shapefiles

## Related Issues

Closes COL-###

## Submission Checklist

- [x] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

Projects > Export shapefiles

### Role

Admin

### Steps

1. Create a project
2. Go to the project overview page and export the shapefiles
3. make sure the shapefiles contain the following properties `sample_id`, `plot_id` and `sample_int`.

### Desired Outcome

`sample_id` and `plot_id` should correspond to the visible_ids present in the `samples` and `plots` tables respectively. `sample_int` is the internal id for the samples
