### PR TITLE
Add confirm alert for flagged plot

### DIFF
--- a/src/js/survey/SurveyCollection.jsx
+++ b/src/js/survey/SurveyCollection.jsx
@@ -576,11 +576,19 @@ export default class SurveyCollection extends React.Component {
     </div>
   );
 
+  toggleFlaggedPlot = () => {
+    if (!this.props.flagged && confirm("Are you sure you would like to flag this plot?")) {
+      this.props.toggleFlagged();
+      return
+    }
+    this.props.toggleFlagged();
+  }
+
   renderFlagClearButtons = () => (
     <div className="mb-2 d-flex justify-content-between">
       <input
         className="btn btn-outline-red btn-sm col mr-1"
-        onClick={this.props.toggleFlagged}
+        onClick={this.toggleFlaggedPlot}
         type="button"
         value={this.props.flagged ? "Un-flag Plot" : "Flag Plot"}
       />


### PR DESCRIPTION
Add confirm alert to Flag Plot. 

FAO admins report data collectors flagging plots unintentionally, given that the button is so close to the Save button. Unflagging is possible but in some cases users also hit Save again, also unintentionally. 

![image](https://github.com/openforis/collect-earth-online/assets/47796239/a692f4b5-931d-4502-a347-490770c65f08)
