### PR TITLE
HOTFIX: Fix percent user assignment and sum of answers check

### DIFF
--- a/src/clj/collect_earth_online/db/projects.clj
+++ b/src/clj/collect_earth_online/db/projects.clj
@@ -1029,7 +1029,7 @@
       (data-response (create-design-settings-from-file updated-plots))
       (data-response  {:userAssignment {:userMethod "none"
                                         :users      []
-                                        :percents   [0]}
+                                        :percents   []}
                        :qaqcAssignment {:qaqcMethod "none"
                                         :smes       []
                                         :overlap    0}}))))

--- a/src/js/survey/SurveyCollection.jsx
+++ b/src/js/survey/SurveyCollection.jsx
@@ -234,8 +234,8 @@ export default class SurveyCollection extends React.Component {
     mapObjectArray(answeredQuestions, ([_sqId, aq]) => aq.answered.map((a) => a.sampleId));
 
   checkRuleSumOfAnswers = (surveyRule, questionIdToSet, answerId, answerText) => {
-    const answerVal =
-      Number(answerText) || Number(this.getSurveyAnswerText(questionIdToSet, answerId));
+    const answerVal = !isNaN(Number(answerText)) ?
+          Number(answerText) : Number(this.getSurveyAnswerText(questionIdToSet, answerId));
     if (surveyRule.questionIds.includes(questionIdToSet)) {
       const answeredQuestions = this.getAnsweredQuestions(surveyRule.questionIds, questionIdToSet);
       if (surveyRule.questionIds.length === lengthObject(answeredQuestions) + 1) {


### PR DESCRIPTION
## Purpose

This PR Fixes the user assignment using the percentage of plots and the check for sum of answers, in which the validation would fail in case the answer was 0, due to 0 being falsy in javascript.