### PR TITLE
Bugfix: 2024 planet dates

### DIFF
--- a/src/clj/collect_earth_online/proxy.clj
+++ b/src/clj/collect_earth_online/proxy.clj
@@ -25,7 +25,7 @@
 ;;; Fill cache
 
 (defn nicfi-dates []
-  (as-> (client/get (str "https://api.planet.com/basemaps/v1/mosaics?api_key=" (get-config :proxy :nicfi-key))) $
+  (as-> (client/get (str "https://api.planet.com/basemaps/v1/mosaics?_page_size=150&api_key=" (get-config :proxy :nicfi-key))) $
     (:body $)
     (json/read-str $ :key-fn keyword)
     (:mosaics $)


### PR DESCRIPTION
## Purpose

We weren't fetching any of the 2024 dates for planet nicfi. This was due to the request being limited to a few entries only. This PR sets the page_size to 150 entries.

## Related Issues

Closes COL-###

## Submission Checklist

- [ ] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

Collection > Imagery

### Role

Admin/User

### Steps

1. Enable planet NICFI imagery in a project
2. Navigate to the collection page as an user or admin
3. change the imagery to Planet NICFI
4. See that the dropdown now has 2024 dates listed
5. choose a date and check that the imagery is displayed

