### PR TITLE
COL-759: Adding sentry integration to ceo

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -3,6 +3,7 @@
  :deps {clj-http/clj-http        {:mvn/version "3.10.3"}
         clj-python/libpython-clj {:git/url "https://github.com/clj-python/libpython-clj"
                                   :git/sha "f39c78c281d68cc29ed819ad3763e0417ae1952c"}
+        io.sentry/sentry-clj     {:mvn/version "7.11.216"}
         org.clojure/clojure      {:mvn/version "1.11.1"}
         org.flatland/ordered     {:mvn/version "1.15.11"}
         org.clojure/data.json    {:mvn/version "1.0.0"}


### PR DESCRIPTION
## Purpose

Sentry integration to CEO to make it easier tracking requests and errors

## Related Issues

Closes COL-759

## Submission Checklist

- [x] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [x] No new reflection warnings (`clojure -M:check-reflection`)
