### PR TITLE
default dates for degradation tool

### DIFF
--- a/src/js/widgetLayoutEditor.jsx
+++ b/src/js/widgetLayoutEditor.jsx
@@ -29,6 +29,7 @@ const ReactGridLayout = WidthProvider(RGL);
 class WidgetLayoutEditor extends React.PureComponent {
   constructor(props) {
     super(props);
+    const today = new Date().toISOString().split("T")[0];
     this.state = {
       // Page state
       widgets: [],
@@ -46,7 +47,7 @@ class WidgetLayoutEditor extends React.PureComponent {
     this.widgetTypes = {
       degradationTool: {
         title: "Degradation Tool",
-        blankWidget: { basemapId: "-1", band: "NDFI", endDate: "", startDate: "" },
+        blankWidget: { basemapId: "-1", band: "NDFI", endDate: today, startDate: "2013-01-01" },
         WidgetDesigner: DegradationDesigner,
       },
       dualImagery: {


### PR DESCRIPTION
## Purpose

Adds default dates for geodash degradation tool

## Related Issues

Closes COL-858

## Submission Checklist

- [x] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

<!-- List the Module > Submodule impacted by this test (e.g. Validation > Project Boundary or Subscriptions > Add) -->
<!-- The current list of all Modules is: Home, Institution, Imagery, Projects, Wizard, Survey & Rules, Collection, GeoDash. -->

### Role

Admin

### Steps

<!-- All steps needed to test this PR -->

1. Create a project
2. Go to the project overview page
3. Click configure geodash
4. Add a Degradation widget, check that start date is set to 2013-01-01 and end date is today's date

