### PR TITLE
Change redirect page

### DIFF
--- a/src/js/collection.jsx
+++ b/src/js/collection.jsx
@@ -1159,10 +1159,14 @@ class Collection extends React.Component {
           </Modal>
         )}
         {(!this.props.acceptedTerms && (this.state.currentProject?.type === 'simplified')) && (
-          <AcceptTermsModal projectId={this.props.projectId} toggleAcceptTermsModal={this.toggleAcceptTermsModal} />
+          <AcceptTermsModal institutionId={this.state.currentProject.institution}
+                            projectId={this.props.projectId}
+                            toggleAcceptTermsModal={this.toggleAcceptTermsModal} />
         )}
         {this.state.showQuitModal && (
-          <QuitMenu projectId={this.props.projectId} toggleQuitModal={this.toggleQuitModal} />
+          <QuitMenu institutionId={this.state.currentProject.institution}
+                    projectId={this.props.projectId}
+                    toggleQuitModal={this.toggleQuitModal} />
         )}
       </div>
     );
@@ -1944,7 +1948,8 @@ class ProjectStats extends React.Component {
 }
 
 // remains hidden, shows a styled menu when the quit button is clicked
-function QuitMenu({ projectId, toggleQuitModal }) {
+function QuitMenu({ institutionId, projectId, toggleQuitModal }) {
+  console.log(institutionId);
   return (
     <div
       className="modal fade show"
@@ -1980,7 +1985,7 @@ function QuitMenu({ projectId, toggleQuitModal }) {
               id="quit-button"
               onClick={() =>
                 fetch(`/release-plot-locks?projectId=${projectId}`, { method: "POST" }).then(() =>
-                  window.location.assign("/home")
+                  window.location.assign(`/review-institution?institutionId=${institutionId}`)
                 )
               }
               type="button"

--- a/src/js/components/PageComponents.jsx
+++ b/src/js/components/PageComponents.jsx
@@ -505,7 +505,7 @@ export function SuccessModal({ message, onClose }) {
   );
 }
 
-export function AcceptTermsModal ({ projectId, toggleAcceptTermsModal }) {
+export function AcceptTermsModal ({institutionId, projectId, toggleAcceptTermsModal }) {
   const [interpreterName, setInterpreterName] = useState("");
 
   const acceptTerms = () => {
@@ -545,7 +545,7 @@ export function AcceptTermsModal ({ projectId, toggleAcceptTermsModal }) {
             <button aria-label="Close"
                     className="close"
                     onClick={() =>
-                      window.location.assign(`/home`)
+                      window.location.assign(`/review-institution?institutionId=${institutionId}`)
                     }
                     type="button">
               &times;
@@ -579,7 +579,7 @@ export function AcceptTermsModal ({ projectId, toggleAcceptTermsModal }) {
               className="btn btn-danger btn-sm"
               id="quit-button"
               onClick={() =>
-                window.location.assign(`/home`)
+                window.location.assign(`/review-institution?institutionId=${institutionId}`)
               }
               type="button"
             >


### PR DESCRIPTION
## Purpose

Changes the redirect when exiting the collection page for a project. Now instead of being redirected to home, the user that exits the collection page (either by rejecting the data sharing terms or by clicking the quit button), will be redirected to the institution page for that project.

## Related Issues

Closes COL-857

## Submission Checklist

- [x] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

<!-- List the Module > Submodule impacted by this test (e.g. Validation > Project Boundary or Subscriptions > Add) -->
<!-- The current list of all Modules is: Home, Institution, Imagery, Projects, Wizard, Survey & Rules, Collection, GeoDash. -->

### Role

User

### Steps

<!-- All steps needed to test this PR -->

1. Navigate to a project and enter the collection page
2. Click the quit button
3. Check that you were redirected to the institution page
4. Navigate now to the collection page of a simplified project
5. reject the data sharing terms
6. check that you were redirected to the institution page instead of home
