### PR TITLE
Andy/col 928/resend reset email

### DIFF
--- a/src/clj/collect_earth_online/db/users.clj
+++ b/src/clj/collect_earth_online/db/users.clj
@@ -292,3 +292,24 @@
            (data-response true))
          (catch Exception e           
            (data-response false)))))
+
+(defn resend-validation-email [{:keys [params]}]
+  (let [email          (:email params)    
+        reset-key      (str (UUID/randomUUID))
+        timestamp      (-> (DateTimeFormatter/ofPattern "yyyy/MM/dd HH:mm:ss")
+                           (.format (LocalDateTime/now)))
+        email-msg      (format (str "Dear %s,\n\n"
+                                    "Thank you for signing up for CEO!\n\n"
+                                    "Your Account Summary Details:\n\n"
+                                    "  Email: %s\n"
+                                    "  Created on: %s\n\n"
+                                    "  Click the following link to verify your email:\n"
+                                    "  %sverify-email?email=%s&passwordResetKey=%s\n\n"
+                                    "Kind Regards,\n"
+                                    "  The CEO Team")
+                               email email timestamp (get-base-url) (URLEncoder/encode email) reset-key)]  
+        (try
+          (do (send-mail email nil nil "Welcome to CEO!" email-msg :text)
+              (data-response (format "Email Sent. Please check all inboxes at %s for a new email with further instructions." email)))
+          (catch Exception _
+	    (data-response  "A server error interrupted your request. Please try again or contact an administrator.")))))

--- a/src/clj/collect_earth_online/db/users.clj
+++ b/src/clj/collect_earth_online/db/users.clj
@@ -285,3 +285,10 @@
           (data-response {:message "success"} {:session (assoc session :acceptedTerms true)})))
       (catch Exception e
         (data-response {:message "error when accepting data sharing terms."} {:status 500})))))
+
+(defn check-email-taken [{:keys [params]}]
+  (let [email (:email params)]    
+    (try (when (sql-primitive (call-sql"get_user_by_email" email))           
+           (data-response true))
+         (catch Exception e           
+           (data-response false)))))

--- a/src/clj/collect_earth_online/db/users.clj
+++ b/src/clj/collect_earth_online/db/users.clj
@@ -288,7 +288,7 @@
 
 (defn check-email-taken [{:keys [params]}]
   (let [email (:email params)]    
-    (try (when (sql-primitive (call-sql"get_user_by_email" email))           
+    (try (when (sql-primitive (call-sql "get_user_by_email" email))           
            (data-response true))
          (catch Exception e           
            (data-response false)))))

--- a/src/clj/collect_earth_online/routing.clj
+++ b/src/clj/collect_earth_online/routing.clj
@@ -66,7 +66,8 @@
                                               :auth-action :redirect}
 
    ;; Users API
-   [:get  "/check-email-taken"]        {:handler     users/check-email-taken}
+   [:get  "/check-email-taken"]              {:handler     users/check-email-taken}
+   [:post "/resend-validation-email"]        {:handler     users/resend-validation-email}
    [:get  "/get-institution-users"]          {:handler     users/get-institution-users
                                               :auth-type   :user
                                               :auth-action :block}

--- a/src/clj/collect_earth_online/routing.clj
+++ b/src/clj/collect_earth_online/routing.clj
@@ -66,6 +66,7 @@
                                               :auth-action :redirect}
 
    ;; Users API
+   [:get  "/check-email-taken"]        {:handler     users/check-email-taken}
    [:get  "/get-institution-users"]          {:handler     users/get-institution-users
                                               :auth-type   :user
                                               :auth-action :block}

--- a/src/js/register.jsx
+++ b/src/js/register.jsx
@@ -16,15 +16,28 @@ class Register extends React.Component {
       userId: null
     };
   }
+
   fetchUserIfExists = () => {    
     fetch(`/check-email-taken?email=${this.state.email}`)
       .then((response) => Promise.all([response.ok, response.text()]))
       .then(([response, data]) => {
         console.log("email-exists-check response", {userId: data === "true"});
 	this.setState ({userId: data === "true"});
-      });
-    
+      });    
   };
+
+  resendValidationEmail = () => {
+    fetch (`/resend-validation-email?email=${this.state.email}`, {
+      method: "POST"
+    })
+      .then((response) => Promise.all([response.ok, response.text()]))
+      .then ((response) => {
+	this.setState ({modal: {alert: {alertType: "Resend Validation Alert",
+                                         alertMessage: response[1]}}});
+      });
+  };
+
+
   register = () => {
     if (!this.state.acceptTOS || !this.state.acceptDataTOS) {
       this.setState({modal: {alert: {alertType: "Registration Alert",
@@ -67,7 +80,7 @@ class Register extends React.Component {
             <form
               onSubmit={(e) => {
                 e.preventDefault();
-                this.register();
+                this.state.userId ? this.resendValidationEmail () : this.register() ;
               }}
             >
               <div className="form-group">

--- a/src/js/register.jsx
+++ b/src/js/register.jsx
@@ -16,9 +16,14 @@ class Register extends React.Component {
       userId: null
     };
   }
-  fetchUserIfExists = () => {
-    console.log(this.state.email);
-    this.setState ({userId: 1});
+  fetchUserIfExists = () => {    
+    fetch(`/check-email-taken?email=${this.state.email}`)
+      .then((response) => Promise.all([response.ok, response.text()]))
+      .then(([response, data]) => {
+        console.log("email-exists-check response", {userId: data === "true"});
+	this.setState ({userId: data === "true"});
+      });
+    
   };
   register = () => {
     if (!this.state.acceptTOS || !this.state.acceptDataTOS) {
@@ -71,14 +76,15 @@ class Register extends React.Component {
                   autoComplete="off"
                   className="form-control"
                   id="email"
-                  onChange={(e) => this.setState({ email: e.target.value })}
+                  onChange={(e) => this.setState({ email: e.target.value ,
+                                                   userId: null})}
                   onBlur={() => this.fetchUserIfExists()}
                   placeholder="Email"
                   type="email"
                   value={this.state.email}
                 />
               </div>
-              {this.state.userId === 0 && 
+              {this.state.userId === false && 
                <React.Fragment>
                  <div className="form-group">
                    <label htmlFor="password">Enter your password</label>
@@ -129,17 +135,16 @@ class Register extends React.Component {
                      onChange={() => this.setState({ acceptDataTOS: !this.state.acceptDataTOS })}
                      type="checkbox"
                    />
-                 </div>
+                   <label>{this.state.userId}</label>
+                     </div>
                </React.Fragment>}
               
               <button className="btn btn-lightgreen float-right mb-2"
                        type="submit"
-                       disabled={!this.state.userId}>
-                 { this.state.userId && this.state.userId > 0 ? "Resend Validation Email" : "Register"}
+                       disabled={this.state.userId === null}>
+                 { this.state.userId ? "Resend Validation Email" : "Register"}
 		 </button>
-              
-              
-              
+
               </form>
           </div>
         </div>

--- a/src/js/register.jsx
+++ b/src/js/register.jsx
@@ -98,7 +98,7 @@ class Register extends React.Component {
                 />
               </div>
               {this.state.userId === false && 
-               <React.Fragment>
+               <>
                  <div className="form-group">
                    <label htmlFor="password">Enter your password</label>
                    <input
@@ -150,7 +150,7 @@ class Register extends React.Component {
                    />
                    <label>{this.state.userId}</label>
                      </div>
-               </React.Fragment>}
+               </>}
               
               <button className="btn btn-lightgreen float-right mb-2"
                        type="submit"

--- a/src/js/register.jsx
+++ b/src/js/register.jsx
@@ -12,10 +12,14 @@ class Register extends React.Component {
       passwordConfirmation: "",
       acceptTOS: false,
       acceptDataTOS: false,
-      modal: null
+      modal: null,
+      userId: null
     };
   }
-
+  fetchUserIfExists = () => {
+    console.log(this.state.email);
+    this.setState ({userId: 1});
+  };
   register = () => {
     if (!this.state.acceptTOS || !this.state.acceptDataTOS) {
       this.setState({modal: {alert: {alertType: "Registration Alert",
@@ -68,64 +72,75 @@ class Register extends React.Component {
                   className="form-control"
                   id="email"
                   onChange={(e) => this.setState({ email: e.target.value })}
+                  onBlur={() => this.fetchUserIfExists()}
                   placeholder="Email"
                   type="email"
                   value={this.state.email}
                 />
               </div>
-              <div className="form-group">
-                <label htmlFor="password">Enter your password</label>
-                <input
-                  autoComplete="off"
-                  className="form-control"
-                  id="password"
-                  onChange={(e) => this.setState({ password: e.target.value })}
-                  placeholder="Password"
-                  type="password"
-                  value={this.state.password}
-                />
-              </div>
-              <div className="form-group">
-                <label htmlFor="password-confirmation">Confirm your password</label>
-                <input
-                  autoComplete="off"
-                  className="form-control"
-                  id="password-confirmation"
-                  onChange={(e) => this.setState({ passwordConfirmation: e.target.value })}
-                  placeholder="Password confirmation"
-                  type="password"
-                  value={this.state.passwordConfirmation}
-                />
-              </div>
-              <div className="form-check">
-                <input
-                  checked={this.state.acceptTOS}
-                  className="form-check-input"
-                  id="tos-check"
-                  onChange={() => this.setState({ acceptTOS: !this.state.acceptTOS })}
-                  type="checkbox"
-                />
-                <label className="form-check-label" htmlFor="tos-check">
-                  I agree to the{" "}
-                  <a href="/terms-of-service" target="_blank">
-                    Terms of Service
-                  </a>
-                  .
-                </label>
-              </div>
-              <div className="form-check mb-3">
-                <input
-                  checked={this.state.acceptDataTOS}
-                  className="form-check-input"
-                  id="data-tos-check"
-                  onChange={() => this.setState({ acceptDataTOS: !this.state.acceptDataTOS })}
-                  type="checkbox"
-                />
-              </div>
-              <button className="btn btn-lightgreen float-right mb-2" type="submit">
-                Register
-              </button>
-            </form>
+              {this.state.userId === 0 && 
+               <React.Fragment>
+                 <div className="form-group">
+                   <label htmlFor="password">Enter your password</label>
+                   <input
+                     autoComplete="off"
+                     className="form-control"
+                     id="password"
+                     onChange={(e) => this.setState({ password: e.target.value })}
+                     placeholder="Password"
+                     type="password"
+                     value={this.state.password}
+                   />
+                 </div>
+                 
+                 <div className="form-group">
+                   <label htmlFor="password-confirmation">Confirm your password</label>
+                   <input
+                     autoComplete="off"
+                     className="form-control"
+                     id="password-confirmation"
+                     onChange={(e) => this.setState({ passwordConfirmation: e.target.value })}
+                     placeholder="Password confirmation"
+                     type="password"
+                     value={this.state.passwordConfirmation}
+                   />
+                 </div>
+                 <div className="form-check">
+                   <input
+                     checked={this.state.acceptTOS}
+                     className="form-check-input"
+                     id="tos-check"
+                     onChange={() => this.setState({ acceptTOS: !this.state.acceptTOS })}
+                     type="checkbox"
+                   />
+                   <label className="form-check-label" htmlFor="tos-check">
+                     I agree to the{" "}
+                     <a href="/terms-of-service" target="_blank">
+                       Terms of Service
+                     </a>
+                     .
+                   </label>
+                 </div>
+                 <div className="form-check mb-3">
+                   <input
+                     checked={this.state.acceptDataTOS}
+                     className="form-check-input"
+                     id="data-tos-check"
+                     onChange={() => this.setState({ acceptDataTOS: !this.state.acceptDataTOS })}
+                     type="checkbox"
+                   />
+                 </div>
+               </React.Fragment>}
+              
+              <button className="btn btn-lightgreen float-right mb-2"
+                       type="submit"
+                       disabled={!this.state.userId}>
+                 { this.state.userId && this.state.userId > 0 ? "Resend Validation Email" : "Register"}
+		 </button>
+              
+              
+              
+              </form>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Purpose

Adds resend-validation-email functionality so that existing users (by email) can attempt to validate again.

## Related Issues

Closes COL-928

## Submission Checklist

- [ x] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [ x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [x ] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted
Login/Registration

### Role

User

### Steps

<!-- All steps needed to test this PR -->

1. click the "login" button in the top corner to navigate to the login page.
2. click the "register" button to ogin to registration
3. type in an email that does not correspond to a real or existing user.
4. observe the registration page as normal.
5. replace the email with that of an existing user.
6. click the "resend email" button.
7. observe the helpful popupmodal.

### Desired Outcome

---

<!-- If needed, add more tests using the format above (Module Impacted, Role, Steps, Desired Outcome) here. -->

## Screenshots

<!-- Add a screen shot when UI changes are included -->
