### PR TITLE
Add check-initialized on the validate visparams func

### DIFF
--- a/src/clj/collect_earth_online/db/geodash.clj
+++ b/src/clj/collect_earth_online/db/geodash.clj
@@ -107,6 +107,7 @@
     (data-response (return-widgets project-id))))
 
 (defn validate-vis-params [{:keys [params]}]
+  (check-initialized)
   (let [img-path (:imgPath params)
         vis-params (tc/json->clj (:visParams params))
         vis-errors (utils/validateJSON img-path vis-params)]


### PR DESCRIPTION
## Purpose

Adds check-initialized function call to make sure the ee library was initialized

## Related Issues

Closes COL-###

## Submission Checklist

- [x] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [x] No new reflection warnings (`clojure -M:check-reflection`)

