### PR TITLE
adds onclose fxnality to modals

### DIFF
--- a/src/js/account.jsx
+++ b/src/js/account.jsx
@@ -37,8 +37,10 @@ class UserStats extends React.Component {
       .then((stats) => this.setState({ stats }))
       .catch((response) => {
         console.log(response);
-        this.setState ({modal: {alert: {alertType: "User Stats Alert", alertMessage: "No user found with ID " + this.props.accountId}}});
-        window.location = "/home";
+        this.setState ({modal: {alert: {alertType: "User Stats Alert",
+                                        onClose: ()=>{window.location = "/home";},
+                                        alertMessage: "No user found with ID " + this.props.accountId}}});
+        
       });
   };
 
@@ -48,7 +50,8 @@ class UserStats extends React.Component {
       <SectionBlock title="User Stats">
         {this.state.modal?.alert &&
          <Modal title={this.state.modal.alert.alertType}
-                onClose={()=>{this.setState({modal: null});}}>
+                onClose={()=>{this.setState({modal: null});
+                              this.state.modal.alert.onClose();}}>
            {this.state.modal.alert.alertMessage}
          </Modal>}
         <div className="table table-sm" id="user-stats-table">
@@ -118,10 +121,10 @@ class AccountForm extends React.Component {
       .then((response) => Promise.all([response.ok, response.json()]))
       .then((data) => {
         if (data[0] && data[1] === "") {
-          this.setState ({modal: {alert: {alertType: "Update Account Success", alertMessage: "Your account details have been updated."}}});
-
-          // userName comes from the session, so we need to reload to update the props.
-          window.location.reload();
+          this.setState ({modal: {alert: {alertType: "Update Account Success",
+                                          onClose: ()=>{window.location.reload();},
+                                          alertMessage: "Your account details have been updated."}}});
+          // userName comes from the session, so we need to reload to update the props.          
         } else {
           this.setState ({modal: {alert: {alertType: "Update Account Error", alertMessage: data[1]}}});
         }

--- a/src/js/passwordRequest.jsx
+++ b/src/js/passwordRequest.jsx
@@ -24,8 +24,9 @@ class PasswordRequest extends React.Component {
       .then((response) => Promise.all([response.ok, response.json()]))
       .then((data) => {
         if (data[0] && data[1] === "") {
-          this.setState ({modal: {alert: {alertType: "Password Reset Request", alertMessage: "The reset key has been sent to your email."}}});
-          window.location = "/home";
+          this.setState ({modal: {alert: {alertType: "Password Reset Request",
+                                          onClose: ()=>{window.location = "/home";},
+                                          alertMessage: "The reset key has been sent to your email."}}});          
         } else {
           this.setState ({modal: {alert: {alertType: "Password Reset Error", alertMessage: data[1]}}});
         }
@@ -38,7 +39,8 @@ class PasswordRequest extends React.Component {
       <div className="d-flex justify-content-center">
         {this.state.modal?.alert &&
          <Modal title={this.state.modal.alert.alertType}
-                onClose={()=>{this.setState({modal: null});}}>
+                onClose={()=>{this.setState({modal: null});
+                              this.state.modal.alert.onClose();}}>
            {this.state.modal.alert.alertMessage}
          </Modal>}
 

--- a/src/js/passwordReset.jsx
+++ b/src/js/passwordReset.jsx
@@ -27,8 +27,10 @@ class PasswordReset extends React.Component {
       .then((response) => Promise.all([response.ok, response.json()]))
       .then((data) => {
         if (data[0] && data[1] === "") {
-          this.setState ({modal: {alert: {alertType: "Password Reset Success", alertMessage: "You have successfully reset your password."}}});
-          window.location = "/login";
+          this.setState ({modal: {alert: {alertType: "Password Reset Success",
+                                          onClose: ()=>{window.location = "/login";},
+                                          alertMessage: "You have successfully reset your password."}}});
+          
         } else {
           this.setState ({modal: {alert: {alertType: "Reset Password Alert", alertMessage: data[1]}}});
         }
@@ -41,7 +43,8 @@ class PasswordReset extends React.Component {
       <div className="d-flex justify-content-center">
         {this.state.modal?.alert &&
          <Modal title={this.state.modal.alert.alertType}
-                onClose={()=>{this.setState({modal: null});}}>
+                onClose={()=>{this.setState({modal: null});
+                              this.state.modal.alert.onClose();}}>
            {this.state.modal.alert.alertMessage}
          </Modal>}
 

--- a/src/js/project/CreateProjectWizard.jsx
+++ b/src/js/project/CreateProjectWizard.jsx
@@ -160,16 +160,19 @@ export default class CreateProjectWizard extends React.Component {
       .then((response) => (response.ok ? response.json() : Promise.reject(response)))
       .then((data) => {
         if (!data) {
-          this.setState ({modal: {alert: {alertType: "Get Draft Error", alertMessage: "No draft found with ID " + projectDraftId + "."}}});
-          window.location = "/home";
+          this.setState ({modal: {alert: {alertType: "Get Draft Error",
+                                          onClose: ()=>{window.location = "/home";},
+                                          alertMessage: "No draft found with ID " + projectDraftId + "."}}});          
         } else {
           this.context.setProjectDetails(data);
           this.context.setContextState({ originalProject: data });
           return data.institution;
         }
       }).catch(() => {
-        this.setState ({modal: {alert: {alertType: "Get Draft Error", alertMessage: "No draft found with ID " + projectDraftId + "."}}});
-        window.location = "/home";
+        this.setState ({modal: {alert: {alertType: "Get Draft Error",
+                                        onClose: ()=>{window.location = "/home";},
+                                        alertMessage: "No draft found with ID " + projectDraftId + "."}}});
+        
       })
       
     buildDraftObject = () => ({
@@ -631,7 +634,8 @@ export default class CreateProjectWizard extends React.Component {
       <div className="d-flex pb-5 full-height align-items-center flex-column" id="wizard">
         {this.state.modal?.alert &&
          <Modal title={this.state.modal.alert.alertType}
-                onClose={()=>{this.setState({modal: null});}}>
+                onClose={()=>{this.setState({modal: null});
+                              this.state.modal.alert.onClose();}}>
            {this.state.modal.alert.alertMessage}
          </Modal>}
         <div style={{ display: "flex", margin: ".75rem" }}>

--- a/src/js/project/ManageProject.jsx
+++ b/src/js/project/ManageProject.jsx
@@ -35,8 +35,10 @@ export default class ManageProject extends React.Component {
       .then((response) => (response.ok ? response.json() : Promise.reject(response)))
       .then((data) => {
         if (data === "") {
-          this.setState ({modal: {alert: {alertType: "Get Project Error", alertMessage: "No project found with ID " + projectId + "."}}});
-          window.location = "/home";
+          this.setState ({modal: {alert: {alertType: "Get Project Error",
+                                          onClose: ()=>{window.location = "/home";},
+                                          alertMessage: "No project found with ID " + projectId + "."}}});
+          
         } else {
           this.context.setProjectDetails(data);
           this.context.setContextState({ originalProject: data });
@@ -69,7 +71,8 @@ export default class ManageProject extends React.Component {
       <div className="d-flex flex-column full-height align-items-center p-3" id="review-project">
         {this.state.modal?.alert &&
          <Modal title={this.state.modal.alert.alertType}
-                onClose={()=>{this.setState({modal: null});}}>
+                onClose={()=>{this.setState({modal: null});
+                              this.state.modal.alert.onClose();}}>
            {this.state.modal.alert.alertMessage}
          </Modal>}
         <div
@@ -187,8 +190,10 @@ class ProjectManagement extends React.Component {
         fetch(`/archive-project?projectId=${this.context.id}`, { method: "POST" }).then(
           (response) => {
             if (response.ok) {
-              this.setState ({modal: {alert: {alertType: "Delete Project Alert", alertMessage: "Project " + this.context.id + " has been deleted."}}});
-              window.location = `/review-institution?institutionId=${this.context.institution}`;
+              this.setState ({modal: {alert: {alertType: "Delete Project Alert",
+                                              onClose: ()=>{window.location = `/review-institution?institutionId=${this.context.institution}`;},
+                                              alertMessage: "Project " + this.context.id + " has been deleted."}}});
+
             } else {
               console.log(response);
               this.setState ({modal: {alert: {alertType: "Delete Project Error", alertMessage: "Error deleting project. See console for details."}}});

--- a/src/js/projectDashboard.jsx
+++ b/src/js/projectDashboard.jsx
@@ -58,8 +58,9 @@ class ProjectDashboard extends React.Component {
       .then((response) => (response.ok ? response.json() : Promise.reject(response)))
       .then((data) => {
         if (data === "") {
-          this.setState ({modal: {alert: {alertType: "Project Error", alertMessage: "No project found with ID " + projectId + "."}}});
-          window.location = "/home";
+          this.setState ({modal: {alert: {alertType: "Project Error",
+                                          onClose: ()=>{window.location = "/home";},
+                                          alertMessage: "No project found with ID " + projectId + "."}}});          
         } else {
           this.setState({ projectDetails: data });
           return this.getImageryList(data.institution);
@@ -125,7 +126,8 @@ class ProjectDashboard extends React.Component {
         {this.state.modalMessage && <LoadingModal message={this.state.modalMessage} />}
         {this.state.modal?.alert &&
          <Modal title={this.state.modal.alert.alertType}
-                onClose={()=>{this.setState({modal: null});}}>
+                onClose={()=>{this.setState({modal: null});
+                              this.state.modal.alert.onClose();}}>
            {this.state.modal.alert.alertMessage}
          </Modal>}
         <div className="bg-darkgreen">

--- a/src/js/projectQaqcDashboard.jsx
+++ b/src/js/projectQaqcDashboard.jsx
@@ -99,8 +99,10 @@ class ProjectDashboardQaqc extends React.Component {
     .then((response) => (response.ok ? response.json() : Promise.reject(response)))
     .then((data) => {
       if (data === "") {
-        this.setState ({modal: {alert: {alertType: "Project Error", alertMessage: "No project found with ID " + projectId + "."}}});
-        window.location = "/home";
+        this.setState ({modal: {alert: {alertType: "Project Error",
+                                        onClose: ()=>{window.location = "/home";},
+                                        alertMessage: "No project found with ID " + projectId + "."}}});
+        
       } else {
         this.setState({ projectDetails: data });
         return this.getImageryList(data.institution);

--- a/src/js/register.jsx
+++ b/src/js/register.jsx
@@ -53,8 +53,8 @@ class Register extends React.Component {
         .then((data) => {
           if (data[0] && data[1] === "") {
             this.setState({modal: {alert: {alertType: "Registration Alert",
-                                           alertMessage: "You have successfully created an account.  Please check your email for a link to verify your account."}}});           
-            window.location = "/home";
+                                           onClose: ()=>{window.location = "/home";},
+                                           alertMessage: "You have successfully created an account.  Please check your email for a link to verify your account."}}});            
           } else {
             this.setState({modal: {alert: {alertType: "Registration Alert",
                                            alertMessage: data[1]}}});
@@ -69,7 +69,8 @@ class Register extends React.Component {
       <div className="d-flex justify-content-center">
         {this.state.modal?.alert
          && (<Modal title={this.state.modal?.alert?.alertType}
-                    onClose={()=>{this.setState({modal: null});}}>
+                    onClose={()=>{this.setState({modal: null});                                  
+                                  this.state.modal.alert.onClose();}}>
                {this.state.modal?.alert?.alertMessage}
              </Modal>)}
         <div className="card card-lightgreen" id="register-form">

--- a/src/js/reviewInstitution.jsx
+++ b/src/js/reviewInstitution.jsx
@@ -412,8 +412,9 @@ class InstitutionDescription extends React.Component {
         method: "POST",
       }).then((response) => {
         if (response.ok) {
-          this.setState ({modal: {alert: {alertType: "Institution Update", alertMessage: "Institution " + this.state.institutionDetails.name + " has been deleted."}}});
-          window.location = "/home";
+          this.setState ({modal: {alert: {alertType: "Institution Update",
+                                          onClose: ()=>{window.location = "/home";},
+                                          alertMessage: "Institution " + this.state.institutionDetails.name + " has been deleted."}}});
         } else {
           console.log(response);
           this.setState ({modal: {alert: {alertType: "Institution Update Error", alertMessage: "Error deleting institution. See console for details."}}});

--- a/src/js/verifyEmail.jsx
+++ b/src/js/verifyEmail.jsx
@@ -26,11 +26,14 @@ class VerifyEmail extends React.Component {
       .then((response) => Promise.all([response.ok, response.json()]))
       .then((data) => {
         if (data[0] && data[1] === "") {
-          this.setState ({modal: {alert: {alertType: "Verify Email", alertMessage: "You have successfully verified your email."}}});
-          window.location = "/login";
+          this.setState ({modal: {alert: {alertType: "Verify Email",
+                                          onClose: ()=> {window.location = "/login";},
+                                          alertMessage: "You have successfully verified your email."}}});
+          
         } else {
-          this.setState ({modal: {alert: {alertType: "Verify Email", alertMessage: data[1]}}});       
-          window.location = "/password-request";
+          this.setState ({modal: {alert: {alertType: "Verify Email",
+                                          onClose: ()=>{ window.location = "/password-request";},
+                                          alertMessage: data[1]}}});          
         }
       })
       .catch((err) => console.log(err));
@@ -41,7 +44,8 @@ class VerifyEmail extends React.Component {
       <div className="d-flex justify-content-center">
         {this.state.modal?.alert &&
          <Modal title={this.state.modal.alert.alertType}
-                onClose={()=>{this.setState({modal: null});}}>
+                onClose={()=>{this.setState({modal: null});
+                              this.state.modal.alerts.onClose();}}>
            {this.state.modal.alert.alertMessage}
          </Modal>}
         <div className="card card-lightgreen" id="reset-form">


### PR DESCRIPTION
## Purpose

Our new modal alerts, which superseded the previous js-window alerts functionality, would occasionally exhibit misbehavior in which the modal message would render, but the window would immediately navigate away. this PR wraps the 'onClose' behavior of given alert-modals into their definition so that window navigation is queued off the user interacting with the modal, rather than the modal rendering.

## Related Issues

Closes COL-###

## Submission Checklist

- [x ] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [ x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [ x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted
All
### Role

All

### Steps

<!-- All steps needed to test this PR -->

1. Register a new user, update a password, or otherwise complete any step on the platform that results in window redirection after a status message modal. for our purposes, register a new user or request to change the password of an existing user.
2. remark along the way that success message modals tend to hang around as long as you're interacting with them. read them leisurely, perhaps with a cup of tea or your window open. take your time. breathe. meet your neighbor. the modal is going to stay put.
3. close the modal and --behold!-- the window navigates away. Nothing begins nor ends, and yet nothing stays-- even precious golden moments of stillness become a digital palimpsest against a clamoring sea. Appreciate the cosmic irony in appreciating the perfect stillness of constant change.

### Desired Outcome

---

<!-- If needed, add more tests using the format above (Module Impacted, Role, Steps, Desired Outcome) here. -->

## Screenshots

<!-- Add a screen shot when UI changes are included -->
