### PR TITLE
Changing permissions for imagery

### DIFF
--- a/src/js/collection.jsx
+++ b/src/js/collection.jsx
@@ -318,13 +318,10 @@ class Collection extends React.Component {
       .then((response) => (response.ok ? response.json() : Promise.reject(response)))
       .then((data) => {
         if (data.length > 0) {
-          const updatedImagery = data.map((imagery) => {
-            if(imagery.title === "CEO: Mapbox Satellite") {
-              return { ...imagery, visible: true};
-            } else {
-              return imagery;
-            }
-          });
+          const updatedImagery = data.map((imagery, index) => ({
+            ...imagery,
+            visible: index === 0
+          }));
           this.setState({ imageryList: updatedImagery });
           return Promise.resolve("resolved");
         } else {

--- a/src/js/project/CreateProjectWizard.jsx
+++ b/src/js/project/CreateProjectWizard.jsx
@@ -53,10 +53,7 @@ export default class CreateProjectWizard extends React.Component {
           <AOIMap
             canDrag={false}
             context={this.context}
-            imagery={this.context.institutionImagery.filter(
-              ({ title }) => (title === "CEO: Mapbox Satellite") ||
-                (title === "CEO: Open Street Maps")
-            )}
+            imagery={[this.context.institutionImagery[0]]}
           />
         ),
         validate: this.validateImagery,
@@ -78,10 +75,7 @@ export default class CreateProjectWizard extends React.Component {
                 this.context.boundaryType === "manual"
             }
             context={this.context}
-            imagery={this.context.institutionImagery.filter(
-              ({ title }) => (title === "CEO: Mapbox Satellite") ||
-                (title === "CEO: Open Street Maps")
-            )}
+            imagery={[this.context.institutionImagery[0]]}
           />
         ),
         validate: this.validatePlotData,

--- a/src/js/project/PlotDesign.jsx
+++ b/src/js/project/PlotDesign.jsx
@@ -604,7 +604,7 @@ export function PlotDesignReview() {
       </div>
       <div className="col-6">
         <AOIReview
-          imagery={institutionImagery.filter(({ title }) => title === "CEO: Mapbox Satellite")}
+          imagery={[institutionImagery[0]]}
         />
       </div>
     </div>

--- a/src/js/project/ReviewForm.jsx
+++ b/src/js/project/ReviewForm.jsx
@@ -59,8 +59,7 @@ export default function ReviewForm() {
         <AOIMap
           canDrag={false}
           context={context}
-          imagery={context.institutionImagery.filter(({ title }) => (title === "CEO: Mapbox Satellite") ||
-                                                                    (title === "CEO: Open Street Maps"))}
+          imagery={[context.institutionImagery[0]]}
         />
         <div className="row" style={{ borderBottom: "1px solid lightgray" }}>
           <div className="col-6 pt-3" style={{ borderRight: "1px solid lightgray" }}>

--- a/src/sql/changes/2025-06-23-shared-imagery-table.sql
+++ b/src/sql/changes/2025-06-23-shared-imagery-table.sql
@@ -1,0 +1,12 @@
+CREATE TABLE shared_imagery (
+    shared_imagery_uid  SERIAL PRIMARY KEY,
+    visibility          text NOT NULL,
+    title               text NOT NULL,
+    attribution         text NOT NULL,
+    extent              jsonb,
+    source_config       jsonb,
+    archived            boolean DEFAULT FALSE,
+    created_date        date DEFAULT NOW(),
+    archived_date       date,
+    is_proxied          boolean DEFAULT FALSE
+);

--- a/src/sql/functions/imagery.sql
+++ b/src/sql/functions/imagery.sql
@@ -162,72 +162,97 @@ $$ LANGUAGE SQL;
 CREATE OR REPLACE FUNCTION select_public_imagery()
  RETURNS setOf imagery_return AS $$
 
-    SELECT imagery_uid,
-        institution_rid,
+    SELECT shared_imagery_uid AS imagery_uid,
+        -1 AS institution_rid,
         visibility,
         title,
         attribution,
         extent,
         is_proxied,
         source_config
-    FROM imagery
-    WHERE visibility = 'public'
-        AND archived = FALSE
+    FROM shared_imagery
+    WHERE archived = FALSE
 
 $$ LANGUAGE SQL;
 
 -- Returns all rows in imagery associated with institution_rid
 CREATE OR REPLACE FUNCTION select_imagery_by_institution(_institution_id integer, _user_id integer)
- RETURNS setOf imagery_return AS $$
+ RETURNS setof imagery_return AS $$
 
-    SELECT imagery_uid,
-        institution_rid,
-        visibility,
-        title,
-        attribution,
-        extent,
-        is_proxied,
-        source_config
-    FROM imagery
-    WHERE archived = FALSE
+    (SELECT imagery_uid AS imagery_uid,
+             institution_rid,
+             visibility,
+             title,
+             attribution,
+             extent,
+             is_proxied,
+             source_config
+      FROM imagery
+      WHERE archived = FALSE
         AND (visibility = 'public'
-            OR (institution_rid = _institution_id
-                AND ((SELECT count(*) > 0
-                        FROM get_all_users_by_institution_id(_institution_id)
-                        WHERE user_id = _user_id)
-                    OR _user_id = 1)))
-    ORDER BY visibility DESC, title
+              OR (institution_rid = _institution_id
+                  AND ((SELECT count(*) > 0
+                         FROM get_all_users_by_institution_id(_institution_id)
+                         WHERE user_id = _user_id)
+                      OR _user_id = 1))))
+
+    UNION
+
+    (SELECT shared_imagery_uid AS imagery_uid,
+             -1 AS institution_rid,
+             visibility,
+             title,
+             attribution,
+             extent,
+             is_proxied,
+             source_config
+      FROM shared_imagery
+      WHERE archived = FALSE)
+
+    ORDER BY imagery_uid;
 
 $$ LANGUAGE SQL;
 
 -- Returns all rows in imagery associated with institution_rid
 CREATE OR REPLACE FUNCTION select_imagery_by_project(_project_id integer, _user_id integer, _token_key text)
- RETURNS setOf imagery_return AS $$
+ RETURNS setof imagery_return AS $$
 
-    SELECT DISTINCT imagery_uid,
-        p.institution_rid,
-        visibility,
-        title,
-        attribution,
-        extent,
-        is_proxied,
-        source_config
+  (SELECT DISTINCT i.imagery_uid AS imagery_uid,
+           p.institution_rid,
+           i.visibility,
+           i.title,
+           i.attribution,
+           i.extent,
+           i.is_proxied,
+           i.source_config
     FROM projects p
-    LEFT JOIN project_imagery pi
-        ON pi.project_rid = p.project_uid
-    INNER JOIN imagery i
-        ON pi.imagery_rid = i.imagery_uid
-            OR p.imagery_rid = i.imagery_uid
-    WHERE project_uid = _project_id
-        AND archived = FALSE
-        AND (visibility = 'public'
-             OR (i.institution_rid = p.institution_rid
-                 AND ((SELECT count(*) > 0
-                        FROM get_all_users_by_institution_id(p.institution_rid)
-                        WHERE user_id = _user_id)
-                      OR (token_key IS NOT NULL AND token_key = _token_key)))
-             OR _user_id = 1)
-    ORDER BY title
+    LEFT JOIN project_imagery pi ON pi.project_rid = p.project_uid
+    INNER JOIN imagery i ON i.imagery_uid = pi.imagery_rid OR i.imagery_uid = p.imagery_rid
+    WHERE p.project_uid = _project_id
+      AND i.archived = FALSE
+      AND (
+        i.visibility = 'public'
+        OR (
+          i.institution_rid = p.institution_rid
+          AND (
+            (SELECT count(*) > 0
+               FROM get_all_users_by_institution_id(p.institution_rid)
+               WHERE user_id = _user_id)
+            OR (_token_key IS NOT NULL AND _token_key = token_key)))
+        OR _user_id = 1))
+  UNION (
+    SELECT shared_imagery_uid AS imagery_uid,
+           -1 AS institution_rid,
+           visibility,
+           title,
+           attribution,
+           extent,
+           is_proxied,
+           source_config
+    FROM shared_imagery
+    WHERE archived = FALSE)
+
+  ORDER BY imagery_uid;
 
 $$ LANGUAGE SQL;
 


### PR DESCRIPTION
## Purpose

This PR creates a new table for shared imagery that are public for everyone on the platform and changes the meaning of `visibility` to allow either the imagery to be accessed by everyone or only by institution members.

## Related Issues

Closes COL-969

## Submission Checklist

- [x] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

<!-- List the Module > Submodule impacted by this test (e.g. Validation > Project Boundary or Subscriptions > Add) -->
<!-- The current list of all Modules is: Home, Institution, Imagery, Projects, Wizard, Survey & Rules, Collection, GeoDash. -->

### Role

<!-- Admin, User, or Visitor -->

### Steps

<!-- All steps needed to test this PR -->

1.

### Desired Outcome

---

<!-- If needed, add more tests using the format above (Module Impacted, Role, Steps, Desired Outcome) here. -->

## Screenshots

<!-- Add a screen shot when UI changes are included -->
