### PR TITLE
COL-989: Fix issue with geodash validation

### DIFF
--- a/src/clj/collect_earth_online/routing.clj
+++ b/src/clj/collect_earth_online/routing.clj
@@ -250,7 +250,7 @@
    [:post "/geo-dash/create-widget"]        {:handler geodash/create-dashboard-widget-by-id}
    [:post "/geo-dash/delete-widget"]        {:handler geodash/delete-dashboard-widget-by-id}
    [:post "/geo-dash/gateway-request"]      {:handler geodash/gateway-request}
-   [:get "/geo-dash/validate-vis-params"]   {:handler geodash/validate-vis-params}
+   [:get "/geo-dash/validate-vis-params"]   {:handler geodash/gateway-request}
    [:post "/geo-dash/update-widget"]        {:handler geodash/update-dashboard-widget-by-id}
    ;; Proxy Routes
    [:get  "/get-tile"]                      {:handler     proxy/proxy-imagery


### PR DESCRIPTION
## Purpose

This PR replaces `validate-vis-params` call for the `gateway-request` call, this way, we correctly instance asset types with the object types expected.

## Related Issues

Closes COL-989

## Submission Checklist

- [x] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

<!-- List the Module > Submodule impacted by this test (e.g. Validation > Project Boundary or Subscriptions > Add) -->
<!-- The current list of all Modules is: Home, Institution, Imagery, Projects, Wizard, Survey & Rules, Collection, GeoDash. -->

### Role

Admin

### Steps


1. Try creating a geodash with correct vis-params, see that it works
2. Try creating a geodash with incorrect vis-params and confirm you get an error
