### PR TITLE
Andy/col bug/28082025

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -84,6 +84,9 @@
 .full-height {
   height: calc(100vh - 60px);
 }
+.full-width {
+    right: 0;
+}
 .absolute-center {
   position: absolute;
   top: 50%;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -866,7 +866,7 @@ input:checked + .switch-slider:before {
 }
 
 body {
-    margin-left: 10px;
+    /* margin-left: 1rem; */
     margin-top: 60px;
     overflow-x: hidden;
 }

--- a/src/css/sidebar.css
+++ b/src/css/sidebar.css
@@ -276,12 +276,10 @@
 }
 
 .slide-panel-in {
-
     animation: slide-panel-in 0.5s forwards;
 }
 
 .slide-panel-out {
-
     animation: slide-panel-out 0.5s forwards;
 }
 
@@ -304,8 +302,7 @@
     animation: slide-toggle-in 0.5s forwards;
 }
 
-.slide-toggle-out {
-    margin-left:1em;
+.slide-toggle-out {    
     animation: slide-toggle-out 0.5s forwards;
 }
 
@@ -316,6 +313,6 @@
 
 @keyframes slide-toggle-out {
     0% {transform: translateX(25vw);}
-    100% {transform: translateX(0vw);}
+    100% {transform: translateX(0.75vw);}
 }
 

--- a/src/css/sidebar.css
+++ b/src/css/sidebar.css
@@ -305,6 +305,7 @@
 }
 
 .slide-toggle-out {
+    margin-left:1em;
     animation: slide-toggle-out 0.5s forwards;
 }
 

--- a/src/js/collection.jsx
+++ b/src/js/collection.jsx
@@ -174,7 +174,9 @@ export const Collection = ({ projectId, acceptedTerms, plotId }) => {
 
   // GET PLOT DATA WHEN NEEDED - When getNewPlot changes to true, request plot data
   useEffect(() => {
+    console.log('getNewPlot useEffect fires', state.getNewPlot);
     if(state.getNewPlot) {
+      console.log('getting plot data...', state.newPlotId);
       getPlotData(state.newPlotId, state.navDirection);
       setState(s => ({...s, getNewPlot: false}));
     }

--- a/src/js/collection.jsx
+++ b/src/js/collection.jsx
@@ -654,7 +654,7 @@ function ImageAnalysisPane({}) {
       <div className="map-controls"
            style={{position: 'absolute',
                    bottom: '2em',
-                   right: '.5em',
+                   right: '10vw',
                    zIndex: 1}}>
         <div className="ExternalTools__geo-buttons d-flex flex-column" id="plot-nav" style={{ gap: '1rem' }}>
           <input

--- a/src/js/collection.jsx
+++ b/src/js/collection.jsx
@@ -174,10 +174,8 @@ export const Collection = ({ projectId, acceptedTerms, plotId }) => {
 
   // GET PLOT DATA WHEN NEEDED - When getNewPlot changes to true, request plot data
   useEffect(() => {
-    console.log('getNewPlot useEffect fires', state.getNewPlot);
     if(state.getNewPlot) {
-      console.log('getting plot data...', state.newPlotId);
-      getPlotData(state.newPlotId, state.navDirection);
+      getPlotData(state.newPlotId || -999, state.navDirection);
       setState(s => ({...s, getNewPlot: false}));
     }
   }, [state.getNewPlot]);

--- a/src/js/components/CollectionSidebar.jsx
+++ b/src/js/components/CollectionSidebar.jsx
@@ -51,6 +51,7 @@ export const NewPlotNavigation = () => {
     currentPlot,
     inReviewMode,
     navigationMode,
+    newPlotId
   } = useAtomValue(stateAtom);
 
   function hasChanged () {
@@ -73,8 +74,10 @@ export const NewPlotNavigation = () => {
   };
   
   const navToPlotId = () => {
+    console.log("let's nav to plot id!");
     if (!isNaN(newPlot)) {
       if (confirmUnsaved()) {
+        console.log('succesfully confirmed unsaved, setAppState', useAtomValue(stateAtom).newPlotId);
         setAppState(s => ({...s, getNewPlot: true, navDirection: 'id'}));
       }
     } else {
@@ -93,7 +96,7 @@ export const NewPlotNavigation = () => {
       </div>
       <label className="collection-sidebar-label">Navigate</label>
       <select className="collection-sidebar-select"
-              selected={navigationMode}
+              selected={navigationMode}        
               onChange={(e) => setAppState(s => ({...s, navigationMode: e.target.value}))}>
           <option value="natural">Default</option>
           <option value="analyzed">Analyzed plots</option>
@@ -113,7 +116,7 @@ export const NewPlotNavigation = () => {
 
       <div className="collection-sidebar-plot-navigation">
         <input className="flex flex-col-6"
-               value={currentPlot?.visibleId || 0}
+               value={newPlotId || currentPlot?.visibleId ||  0}
                onChange={(e)=>{setAppState(s => ({ ...s, newPlotId: e.target.value}));}}
         ></input>
         <button className="btn outline"

--- a/src/js/components/CollectionSidebar.jsx
+++ b/src/js/components/CollectionSidebar.jsx
@@ -74,10 +74,8 @@ export const NewPlotNavigation = () => {
   };
   
   const navToPlotId = () => {
-    console.log("let's nav to plot id!");
-    if (!isNaN(newPlot)) {
+    if (!isNaN(newPlotId)) {
       if (confirmUnsaved()) {
-        console.log('succesfully confirmed unsaved, setAppState', useAtomValue(stateAtom).newPlotId);
         setAppState(s => ({...s, getNewPlot: true, navDirection: 'id'}));
       }
     } else {
@@ -116,7 +114,10 @@ export const NewPlotNavigation = () => {
 
       <div className="collection-sidebar-plot-navigation">
         <input className="flex flex-col-6"
-               value={newPlotId || currentPlot?.visibleId ||  0}
+               placeholder={currentPlot?.visibleId ?
+                            'Current Plot: ' + currentPlot?.visibleId
+                            : 'Select a Plot to begin'}
+               value={newPlotId}
                onChange={(e)=>{setAppState(s => ({ ...s, newPlotId: e.target.value}));}}
         ></input>
         <button className="btn outline"

--- a/src/js/components/SurveyQuestions.jsx
+++ b/src/js/components/SurveyQuestions.jsx
@@ -28,7 +28,7 @@ export const SurveyQuestions = () => {
 
   //EFFECTS
   useEffect(() => {
-    console.log(state);
+    // console.log(state);
   }, [currentProject, userSamples]);
 
   //FUNCTIONS
@@ -517,8 +517,6 @@ const ConfidenceItem = ({ isOpen, onToggle }) => {
   useEffect(() => {
     calculateConfidenceStatus();
   }, [currentPlot?.confidence, currentPlot?.confidenceComment]);
-
-  console.log(confidenceStatus);
   
   return (
     <div className={`sq-item ${isOpen ? 'open' : ''}`}>

--- a/src/js/home.jsx
+++ b/src/js/home.jsx
@@ -286,7 +286,7 @@ class MapPanel extends React.Component {
   render() {
     return (
       <div
-        className='col-lg-9 col-md-12 pl-0 col-xl-12 col-xl-9 full-height'
+        className="full-height full-width"
         id="mapPanel"
       >
         {this.state.modal?.alert &&
@@ -296,14 +296,15 @@ class MapPanel extends React.Component {
          </Modal>}
         {this.props.showSidePanel == null ?
          (<div
-            className='bg-lightgray'
+            className='bg-lightgray hide-toggle'
             id="toggle-map-button"
             onClick={() => this.props.toggleSidebar(this.state.mapConfig)}
           ><SvgIcon icon="rightDouble" size="1.25rem" /></div>) :
          (<div
-          className={'bg-lightgray ' + (this.props.showSidePanel
-                                        ? 'slide-toggle-in'
-                                        : 'slide-toggle-out')}
+            className={'bg-lightgray ' +
+                       (this.props.showSidePanel 
+                        ? 'slide-toggle-in'
+                        : 'slide-toggle-out')}
           id="toggle-map-button"
           onClick={() => this.props.toggleSidebar(this.state.mapConfig)}
         >
@@ -313,7 +314,7 @@ class MapPanel extends React.Component {
             <SvgIcon icon="rightDouble" size="1.25rem" />
           )}
         </div>)}
-        <div className="full-height" id="home-map-pane" style={{ maxWidth: "inherit" }} />
+        <div className="full-height full-width" id="home-map-pane" style={{ maxWidth: "inherit" }} />
         <ProjectPopup
           clusterExtent={this.state.clusterExtent}
           features={this.state.clickedFeatures}

--- a/src/js/utils/constants.jsx
+++ b/src/js/utils/constants.jsx
@@ -52,7 +52,7 @@ export const stateAtom = atom({
   usedKML: false,
   usedGeodash: false,
   getNewPlot: false,
-  newPlotId: -99999,
+  newPlotId: null,
   navDirection: "next",
 });
 

--- a/src/js/utils/constants.jsx
+++ b/src/js/utils/constants.jsx
@@ -39,7 +39,7 @@ export const stateAtom = atom({
   KMLFeatures: null,
   showBoundary: true,
   showSamples: true,
-  showSidebar: false,
+  showSidebar: null,
   showQuitModal: false,
   answerMode: "question",
   modalMessage: null,


### PR DESCRIPTION
## Purpose

Sprinkles some CSS zhuzh and unhides the mapControls from underneath the collection sidebar.
also restores 'go to plot' functionality in collection mode.

## Related Issues

Closes COL-###

## Submission Checklist

- [ ] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [ ] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [ ] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

<!-- List the Module > Submodule impacted by this test (e.g. Validation > Project Boundary or Subscriptions > Add) -->
<!-- The current list of all Modules is: Home, Institution, Imagery, Projects, Wizard, Survey & Rules, Collection, GeoDash. -->

### Role

<!-- Admin, User, or Visitor -->

### Steps

<!-- All steps needed to test this PR -->

1.

### Desired Outcome

---

<!-- If needed, add more tests using the format above (Module Impacted, Role, Steps, Desired Outcome) here. -->

## Screenshots

<!-- Add a screen shot when UI changes are included -->
