### PR TITLE
Andy/col 1021/dynamic degradation widget

### DIFF
--- a/src/clj/collect_earth_online/db/geoai.clj
+++ b/src/clj/collect_earth_online/db/geoai.clj
@@ -9,8 +9,8 @@
 
 (defonce gcs-resource
   (st/init
-   {:project-id  (get-config :gcs-integration :project-name)
-    :credentials (get-config :gcs-integration :credentials)}))
+   #_{:project-id  (get-config :gcs-integration :project-name)
+     :credentials (get-config :gcs-integration :credentials)}))
 
 (defonce gs-url (get-config :gcs-integration :bucket-url))
 

--- a/src/clj/collect_earth_online/db/geodash.clj
+++ b/src/clj/collect_earth_online/db/geodash.clj
@@ -52,9 +52,11 @@
    "imageCollection"        gee/imageCollection
    "imageCollectionByIndex" gee/imageCollectionByIndex
    "statistics"             gee/statistics
-   "timeSeriesByIndex"      gee/timeSeriesByIndex})
-
+   "timeSeriesByIndex"      gee/timeSeriesByIndex
+   "dynamicWorld"           gee/dynamicWorld})
+(require '[clojure.pprint :refer [pprint]])
 (defn gateway-request [{:keys [params json-params]}]
+  (pprint {:params params :json-params json-params})
   (check-initialized)
   (data-response (if-let [py-fn (some-> params :path path->python)]
                    (binding [*item-tuple-cutoff* 0]
@@ -79,9 +81,12 @@
   (let [project-id (tc/val->int (:projectId params))]
     (data-response (return-widgets project-id))))
 
+(require '[clojure.pprint :refer [pprint]])
 (defn create-dashboard-widget-by-id [{:keys [params]}]
   (let [project-id (tc/val->int (:projectId params))
         widget     (tc/json->jsonb (:widgetJSON params))]
+    (pprint ["widget"
+             (tc/jsonb->clj widget)])
     (call-sql "add_project_widget"
               project-id
               widget)

--- a/src/clj/collect_earth_online/db/geodash.clj
+++ b/src/clj/collect_earth_online/db/geodash.clj
@@ -54,9 +54,8 @@
    "statistics"             gee/statistics
    "timeSeriesByIndex"      gee/timeSeriesByIndex
    "dynamicWorld"           gee/dynamicWorld})
-(require '[clojure.pprint :refer [pprint]])
+
 (defn gateway-request [{:keys [params json-params]}]
-  (pprint {:params params :json-params json-params})
   (check-initialized)
   (data-response (if-let [py-fn (some-> params :path path->python)]
                    (binding [*item-tuple-cutoff* 0]
@@ -81,12 +80,9 @@
   (let [project-id (tc/val->int (:projectId params))]
     (data-response (return-widgets project-id))))
 
-(require '[clojure.pprint :refer [pprint]])
 (defn create-dashboard-widget-by-id [{:keys [params]}]
   (let [project-id (tc/val->int (:projectId params))
         widget     (tc/json->jsonb (:widgetJSON params))]
-    (pprint ["widget"
-             (tc/jsonb->clj widget)])
     (call-sql "add_project_widget"
               project-id
               widget)

--- a/src/js/components/CollectionSidebar.jsx
+++ b/src/js/components/CollectionSidebar.jsx
@@ -429,13 +429,6 @@ export const ImageryOptions = () => {
   const [open, setOpen] = useState(true);
   const [enableGrid, setEnableGrid] = useState(false);
 
-  useEffect(() => {
-    console.log(imageryList);
-    console.log(imagery);
-    console.log(currentPlot);
-  }, [currentPlot]);
-
-
   const setBaseMapSource = (id) => {
     const img = imageryList.find((i) => Number(i.id) === Number(id)) || null;
     setAppState((s) => ({

--- a/src/js/geodash/DynamicWorldDesigner.jsx
+++ b/src/js/geodash/DynamicWorldDesigner.jsx
@@ -1,0 +1,38 @@
+import React, { useContext, useState } from "react";
+import _ from "lodash";
+
+import GDDateRange from "./form/GDDateRange";
+import GDInput from "./form/GDInput";
+import GDTextArea from "./form/GDTextArea";
+import GDSelect from "./form/GDSelect";
+import ImageCollectionAssetDesigner from "./ImageCollectionAssetDesigner";
+
+
+export default function DynamicWorldDesigner({prefixPath = ""}) {
+
+  return (
+    <>      
+
+      <GDInput
+        dataKey="assetId"
+        placeholder="GOOGLE/DYNAMICWORLD/V1"
+        prefixPath={prefixPath}
+        title="HARDCODE THIS TO DYNAMICWORLD"
+      />
+        
+      <GDSelect
+        dataKey="reducer"
+        items={["Mode"]}
+        prefixPath={prefixPath}
+        title="Collection Reducer"
+      />
+      <GDTextArea
+        dataKey="visParams"
+        defaultValue={'{"min":0, "max": 0.3}'}
+        prefixPath={prefixPath}
+        title="HARDCODE THESE FOR NOW, BUT MAYBE ALLOW USERS TO CUSTOMIZE PALLET"
+      />
+      <GDDateRange optional prefixPath={prefixPath} />
+    </>
+  );
+}

--- a/src/js/geodash/DynamicWorldDesigner.jsx
+++ b/src/js/geodash/DynamicWorldDesigner.jsx
@@ -11,28 +11,18 @@ import ImageCollectionAssetDesigner from "./ImageCollectionAssetDesigner";
 export default function DynamicWorldDesigner({prefixPath = ""}) {
 
   return (
-    <>      
-
-      <GDInput
-        dataKey="assetId"
-        placeholder="GOOGLE/DYNAMICWORLD/V1"
-        prefixPath={prefixPath}
-        title="HARDCODE THIS TO DYNAMICWORLD"
-      />
-        
-      <GDSelect
-        dataKey="reducer"
-        items={["Mode"]}
-        prefixPath={prefixPath}
-        title="Collection Reducer"
-      />
+    <>
       <GDTextArea
         dataKey="visParams"
-        defaultValue={'{"min":0, "max": 0.3}'}
+        placeholder={'{"min":0, "max": 8}'}
         prefixPath={prefixPath}
-        title="HARDCODE THESE FOR NOW, BUT MAYBE ALLOW USERS TO CUSTOMIZE PALLET"
+        title="Image Parameters (JSON format)"
       />
-      <GDDateRange optional prefixPath={prefixPath} />
+      <GDDateRange prefixPath={prefixPath} />
     </>
   );
 }
+
+/*
+{'{"min":0, "max": 8, "palette": ["#419BDF", "#397D49", "#88B053", "#7A87C6", "#E49635", "#DFC35A", "#C4281B", "#A59B8F", "#B39FE1"]}'}
+ */

--- a/src/js/geodash/MapWidget.jsx
+++ b/src/js/geodash/MapWidget.jsx
@@ -355,10 +355,10 @@ export default class MapWidget extends React.Component {
   renderSliderControls = () => {
     const { overlayValue, opacityValue } = this.state;
     const { widget } = this.props;
-    const dualVector = ["dualImagery", "dynamicWorld"];
+    
     return (
       <div className="d-flex">
-        {dualVector.includes(widget.type) ? (
+        {(widget.type === "dualImagery") ? (
           <>
             {this.renderSlider(opacityValue, this.updateOpacity, "opacity", "Opacity")}
             {this.renderSlider(overlayValue, this.updateOverlay, "overlay", "Overlay Layers")}

--- a/src/js/geodash/MapWidget.jsx
+++ b/src/js/geodash/MapWidget.jsx
@@ -61,7 +61,6 @@ export default class MapWidget extends React.Component {
       body: JSON.stringify(postObject),
     });
     const data = await (res.ok ? res.json() : Promise.reject());
-    console.log("fetched source url:", data);
     if (data && data.hasOwnProperty("url")) {
       this.setCache(postObject, data.url);
       return data.url;
@@ -122,10 +121,8 @@ export default class MapWidget extends React.Component {
   /// Cache
 
   wrapCache = async (widget) => {
-    console.log("wrapping cache widget", widget);
     const postObject = this.getPostObject(widget);
-    console.log("wrapping cache postObject", postObject);
-    const cacheUrl = null; //this.checkForCache(postObject);
+    const cacheUrl = this.checkForCache(postObject);
     if (cacheUrl) {
       return cacheUrl;
     } else {
@@ -322,12 +319,8 @@ export default class MapWidget extends React.Component {
   };
 
   loadWidgetSource = async () => {
-    console.log("loading widget source...");
-    const dualVector = ["dualImagery", "dynamicWorld"];
     const { widget, idx } = this.props;
-    // if (dualVector.includes(widget.type)) {
     if (widget.type === "dualImagery") {
-      console.log("wrapping cache", this.props);
       const [url1, url2] = await Promise.all([
         this.wrapCache(widget.image1),
         this.wrapCache(widget.image2),

--- a/src/js/geodash/constants.js
+++ b/src/js/geodash/constants.js
@@ -10,6 +10,7 @@ export const mapWidgetList = [
   "dualImagery",
   "polygonCompare",
   "preImageCollection",
+  "dynamicWorld"
 ];
 
 export const graphWidgetList = ["timeSeries"];

--- a/src/js/project/PlotDesign.jsx
+++ b/src/js/project/PlotDesign.jsx
@@ -158,7 +158,6 @@ export function NewPlotDesign ({aoiFeatures, institutionUserList, totalPlots, pr
         id={property}
         min="0"
         onChange={(e) =>{
-          console.log(e.target.value, property);
           setNewPlotSize(e.target.value);
           setPlotDetails({ [property]: Number(e.target.value) });}}
         step="1"

--- a/src/js/widgetLayoutEditor.jsx
+++ b/src/js/widgetLayoutEditor.jsx
@@ -9,6 +9,7 @@ import RGL, { WidthProvider } from "react-grid-layout";
 import CopyDialog from "./geodash/CopyDialog";
 import DegradationDesigner from "./geodash/DegradationDesigner";
 import DualImageryDesigner from "./geodash/DualImageryDesigner";
+import DynamicWorldDesigner from "./geodash/DynamicWorldDesigner";
 import GeoDashModal from "./geodash/GeoDashModal";
 import GeoDashNavigationBar from "./geodash/GeoDashNavigationBar";
 import ImageAssetDesigner from "./geodash/ImageAssetDesigner";
@@ -47,9 +48,16 @@ class WidgetLayoutEditor extends React.PureComponent {
     };
 
     this.widgetTypes = {
+      dynamicWorld: {
+        title: "Dynamic World",
+        blankWidget: {startDate: "2013-01-01",
+                      endDate:    today,
+                      basemapId: "-1"},
+        WidgetDesigner: DynamicWorldDesigner
+      },
       degradationTool: {
         title: "Degradation Tool",
-        blankWidget: { basemapId: "-1", band: "NDFI", endDate: today, startDate: "2013-01-01" },
+        blankWidget: { basemapId: "-1", band: "NDFI", endDate: today, startDate: "2013-01-01"},
         WidgetDesigner: DegradationDesigner,
       },
       dualImagery: {

--- a/src/py/gee/routes.py
+++ b/src/py/gee/routes.py
@@ -5,7 +5,7 @@ from gee.utils import initialize, listAvailableBands, imageToMapId, imageCollect
     filteredImageCompositeToMapId, filteredSentinelComposite, filteredSentinelSARComposite, \
     filteredImageByIndexToMapId, getFeatureCollectionTileUrl, getTimeSeriesByCollectionAndIndex, \
     getTimeSeriesByIndex, getStatistics, getDegradationPlotsByPoint, getDegradationPlotsByPointS1, \
-    getDegradationTileUrlByDate, getDegradationTileUrlByDateS1, safeParseJSON, filteredNicfiCompositeToMapId, getDynamicWorldUrls
+    getDegradationTileUrlByDate, getDegradationTileUrlByDateS1, safeParseJSON, filteredNicfiCompositeToMapId
 from gee.planet import getPlanetMapID
 from gee.inputs import getLandsatToa, getTFO
 

--- a/src/py/gee/routes.py
+++ b/src/py/gee/routes.py
@@ -5,7 +5,7 @@ from gee.utils import initialize, listAvailableBands, imageToMapId, imageCollect
     filteredImageCompositeToMapId, filteredSentinelComposite, filteredSentinelSARComposite, \
     filteredImageByIndexToMapId, getFeatureCollectionTileUrl, getTimeSeriesByCollectionAndIndex, \
     getTimeSeriesByIndex, getStatistics, getDegradationPlotsByPoint, getDegradationPlotsByPointS1, \
-    getDegradationTileUrlByDate, getDegradationTileUrlByDateS1, safeParseJSON, filteredNicfiCompositeToMapId
+    getDegradationTileUrlByDate, getDegradationTileUrlByDateS1, safeParseJSON, filteredNicfiCompositeToMapId, getDynamicWorldUrls
 from gee.planet import getPlanetMapID
 from gee.inputs import getLandsatToa, getTFO
 
@@ -235,10 +235,23 @@ def degradationTileUrl(requestDict):
         }
     return values
 
+# ########## DynamicWorld ##########
+
+def dynamicWorld(requestDict):
+    geometry = getDefault(requestDict, 'geometry')
+    startDate="2021-01-01"
+    endDate="2022-01-01"
+    visParams = safeParseJSON(getDefault(requestDict, 'visParams', {}))
+    return getDynamicWorldUrls(
+        getDefault(requestDict, 'geometry'),
+        getDefault(requestDict, 'startDate'),
+        getDefault(requestDict, 'endDate'),
+        visParams)
+
 
 # ########## Stats ##########
 
 
 def statistics(requestDict):
-    values = getStatistics(getDefault(requestDict, 'extent', None))
-    return values
+    values = getStatistics(getDefault(requestDict, 'extent', None))    
+    return {url: values}

--- a/src/py/gee/routes.py
+++ b/src/py/gee/routes.py
@@ -237,16 +237,12 @@ def degradationTileUrl(requestDict):
 
 # ########## DynamicWorld ##########
 
-def dynamicWorld(requestDict):
+def dynamicWorld(requestDict):    
     geometry = getDefault(requestDict, 'geometry')
     startDate="2021-01-01"
     endDate="2022-01-01"
     visParams = safeParseJSON(getDefault(requestDict, 'visParams', {}))
-    return getDynamicWorldUrls(
-        getDefault(requestDict, 'geometry'),
-        getDefault(requestDict, 'startDate'),
-        getDefault(requestDict, 'endDate'),
-        visParams)
+    return imageCollectionToMapId("GOOGLE/DYNAMICWORLD/V1", visParams, 'Mode', startDate, endDate)
 
 
 # ########## Stats ##########

--- a/src/py/gee/utils.py
+++ b/src/py/gee/utils.py
@@ -641,3 +641,6 @@ def getStatistics(extent):
         populationResults = reducePop()
 
     return elevationResults.combine(populationResults).getInfo()
+
+def getDynamicWorldUrls(geometry, startDate, endDate, visParams):
+    return  ee.ImageCollection("GOOGLE/DYNAMICWORLD/V1").filterDate(startDate, endDate).filterBounds(geometry).select('label').reduce(ee.Reducer.mode())

--- a/src/py/gee/utils.py
+++ b/src/py/gee/utils.py
@@ -641,6 +641,3 @@ def getStatistics(extent):
         populationResults = reducePop()
 
     return elevationResults.combine(populationResults).getInfo()
-
-def getDynamicWorldUrls(geometry, startDate, endDate, visParams):
-    return  ee.ImageCollection("GOOGLE/DYNAMICWORLD/V1").filterDate(startDate, endDate).filterBounds(geometry).select('label').reduce(ee.Reducer.mode())


### PR DESCRIPTION
## Purpose

Adds "Dynamic World" as a widget type in the geo-dash.

## Related Issues

Closes COL-1021

## Submission Checklist

- [ ] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [ ] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [ ] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

Collection
GeoDash

### Role

User

### Steps

<!-- All steps needed to test this PR -->

1. From the app homepage, click the arrow on the left side of the screen to open the slider pane. select your institution from the list and click to navigate to the institution page.
2. from the institution page, choose a project and click the yellow edit button.
3. from the project page, click "configure geo-dash"
4. from geodash configuration, click "add widget" and select "dynamic world" from the list
5. Choose a start and end date, then click "create"
6. navigate back to the project page. it may be in a different browser tab.
7. click "collect"
8. from the project collection page, click the next arrow to begin collection. click "go to geo-dash."
9. identify the widget created in step 5 and expand it.
10. observe the dynamicworld image collection and opacity slider.

### Desired Outcome

---

<!-- If needed, add more tests using the format above (Module Impacted, Role, Steps, Desired Outcome) here. -->

## Screenshots

<!-- Add a screen shot when UI changes are included -->
