### PR TITLE
both file uploads update corresponding plot count appropriately

### DIFF
--- a/src/clj/collect_earth_online/db/geoai.clj
+++ b/src/clj/collect_earth_online/db/geoai.clj
@@ -9,7 +9,7 @@
 
 (defonce gcs-resource
   (st/init
-   {:project-id  (get-config :gcs-integration :project-name)
+   #_{:project-id  (get-config :gcs-integration :project-name)
     :credentials (get-config :gcs-integration :credentials)}))
 
 

--- a/src/clj/collect_earth_online/db/projects.clj
+++ b/src/clj/collect_earth_online/db/projects.clj
@@ -1140,6 +1140,7 @@
       (data-response  {:userAssignment {:userMethod "none"
                                         :users      []
                                         :percents   []}
+                       :filePlotCount (count plots)
                        :fileAoi       file-aoi
                        :fileBoundary  file-bounds
                        :qaqcAssignment {:qaqcMethod "none"


### PR DESCRIPTION
## Purpose

adds a new associative pair to the data-reponse for check-plot-file on the PlotDesignStep. This is merely a count of the plots included with the parameter file. In the case of "Add New Plots" appending new plots, the response updates the value in state which renders the updated plot count to the client. In the case of "Add Plots" overwriting old plots, this value updates the state value to be rendered with the value returned in the data response.

## Related Issues

Closes COL-734

## Submission Checklist

- [ ] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [ ] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [ ] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

Projects

### Role

User

### Steps

<!-- All steps needed to test this PR -->

1. navigate to an existing project.
2. edit that project and click forward to the plot design step.
3. take note of the "this project will contain {X} plots" value.
4. In the first file input, upload a file-- notice how the value in step 3 is equal to the number of plots in the file.
5. In the second file input, upload a file-- make note that the aforementioned value has increased by the umber of plots in the file.

### Desired Outcome

---

<!-- If needed, add more tests using the format above (Module Impacted, Role, Steps, Desired Outcome) here. -->

## Screenshots

<!-- Add a screen shot when UI changes are included -->
