### PR TITLE
unlocks adding questions to published projects for admins

### DIFF
--- a/src/js/survey/SurveyQuestionsDesigner.jsx
+++ b/src/js/survey/SurveyQuestionsDesigner.jsx
@@ -6,14 +6,13 @@ import NewQuestionDesigner from "./NewQuestionDesigner";
 import { ProjectContext } from "../project/constants";
 
 export default function SurveyQuestionsDesigner() {
-  const { setProjectDetails, surveyQuestions, surveyRules, projectId, originalProject, type } =
+  const { setProjectDetails, surveyQuestions, surveyRules, projectId, originalProject, type , isProjectAdmin} =
         useContext(ProjectContext);
-  const editMode =
-    projectId === -1 || originalProject.availability === "unpublished" ? "full" : "partial";
+  const editMode = projectId === -1 || originalProject.availability === "unpublished" ? "full" : "partial";
   return (
-    <div id="survey-design">
+    <div id="survey-design">      
       <SurveyCardList editMode={editMode} />
-      {editMode === "full" && (
+      {editMode === "full" || isProjectAdmin  && (
         <NewQuestionDesigner
           setProjectDetails={setProjectDetails}
           surveyQuestions={surveyQuestions}


### PR DESCRIPTION
## Purpose

adds a check to the survey questions designer so that even if a project is published, if the logged in user has admin privileges to the project, they can still add new questions.

## Related Issues

Closes COL-1140

## Submission Checklist

- [ ] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [ ] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [ ] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

<!-- List the Module > Submodule impacted by this test (e.g. Validation > Project Boundary or Subscriptions > Add) -->
<!-- The current list of all Modules is: Home, Institution, Imagery, Projects, Wizard, Survey & Rules, Collection, GeoDash. -->

### Role

<!-- Admin, User, or Visitor -->

### Steps

<!-- All steps needed to test this PR -->

1.

### Desired Outcome

---

<!-- If needed, add more tests using the format above (Module Impacted, Role, Steps, Desired Outcome) here. -->

## Screenshots

<!-- Add a screen shot when UI changes are included -->
