### PR TITLE
COL-1142/public imagery text

### DIFF
--- a/src/js/components/BulkPopups.jsx
+++ b/src/js/components/BulkPopups.jsx
@@ -242,7 +242,7 @@ export function ImageryVisibilityPopup({ selectedImagery, editImageryBulk }) {
               value="public"
               onChange={handleVisibilityChange}
             />
-            <label htmlFor="public">Public</label>
+            <label htmlFor="public">Public Institution Imagery</label>
           </div>
           <div className="popup-option">
             <input

--- a/src/js/project/ImagerySelection.jsx
+++ b/src/js/project/ImagerySelection.jsx
@@ -86,7 +86,7 @@ export function ImagerySelection() {
           )}
         </div>
         <div className="form-group">
-          <label>Public Imagery</label>
+          <label>Public Institution Imagery</label>
           {renderImageryRow(
             institutionImagery.filter((imagery) => imagery.visibility === "public"),
             imageryId,

--- a/src/js/reviewInstitution.jsx
+++ b/src/js/reviewInstitution.jsx
@@ -799,7 +799,7 @@ const ImageryList = (
                   onChange={(e) => handleSelectAllNonPlatform(e.target.checked)}
                 />
               </div>
-              <div className="col-2 pr-0 pl-3">Visibility</div>
+              <div className="col-3 pr-0 pl-3">Visibility</div>
               <div className="col pl-5">Imagery Title</div>
               <div className="col-1 pl-4">Edit</div>
               <div className="col-1 pl-4">Delete</div>
@@ -1303,7 +1303,7 @@ function Imagery({
       </div>
 
       {/* Visibility Button */}
-      <div className="col-2 pr-0 pl-3">
+      <div className="col-3 pr-0 pl-3">
         <div
           className={`btn btn-sm btn-outline-lightgreen btn-block ${
       visibility === "platform" ? "disabled" : ""
@@ -1315,7 +1315,7 @@ function Imagery({
            ? "Platform"
            : visibility === "private"
            ? "Institution"
-           : "Public"}
+           : "Public Institution Imagery"}
         </div>
       </div>
 


### PR DESCRIPTION
## Purpose

updates text in instiution imagery page, new project imagery,and where bulkpopups are invoked.

## Related Issues

Closes COL-1142

## Submission Checklist

- [ ] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [ ] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [ ] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

<!-- List the Module > Submodule impacted by this test (e.g. Validation > Project Boundary or Subscriptions > Add) -->
<!-- The current list of all Modules is: Home, Institution, Imagery, Projects, Wizard, Survey & Rules, Collection, GeoDash. -->

### Role

<!-- Admin, User, or Visitor -->

### Steps

<!-- All steps needed to test this PR -->

1.

### Desired Outcome

---

<!-- If needed, add more tests using the format above (Module Impacted, Role, Steps, Desired Outcome) here. -->

## Screenshots

<!-- Add a screen shot when UI changes are included -->
