### PR TITLE
some updates, fixes toggle to width of sidebar

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -711,7 +711,7 @@ ul.samplevalue {
     text-align: center;
     color: white;
     background-color: rgba(75, 75, 150, 1);
-    z-index: 100;
+    z-index: 5;
 }
 
 #mobile-analysis-pane .ol-zoom {

--- a/src/js/collection.jsx
+++ b/src/js/collection.jsx
@@ -12,7 +12,8 @@ import {
   NavigationBar,
   LearningMaterialModal,
   AcceptTermsModal,
-  ImageryLayerOptions
+  ImageryLayerOptions,
+  BreadCrumbs
 } from "./components/PageComponents";
 import SurveyCollection from "./survey/SurveyCollection";
 import {
@@ -231,56 +232,6 @@ export const Collection = ({ projectId, acceptedTerms, plotId }) => {
       setState((s)=> ({ ...s, referencePlotId: state.currentProject.referencePlotId}));
   }, [state.navigationMode]);
 
-  // API CALLS
-  const getPlotData = (visibleId=1, direction, forcedNavMode = null, reviewMode = null) => {       
-    processModal("Getting plot", () => {
-      return fetch(
-        "/get-collection-plot?" +
-          getQueryString({
-            visibleId,            
-            projectId,
-            navigationMode: forcedNavMode || state.navigationMode,
-            direction,
-            inReviewMode: reviewMode || state.inReviewMode,
-            threshold: state.threshold,
-            currentUserId: state.currentUserId,
-            projectType: state.currentProject.type,
-            referencePlotId: state.referencePlotId || 0
-          })
-      )
-        .then((response) => (response.ok ? response.json() : Promise.reject(response)))
-        .then((data) => {
-          if (data === "not-found") {
-            const err = (direction === "id" ? "Plot not" : "No more plots") +
-                  " found for this navigation mode.";
-            const reviewModeWarning = "\n If you have just changed navigation modes, please click the “Next” or “Back” arrows in order to see the plots for this navigation mode.";
-            setState (prev => ({... prev, modal: {alert: {alertType: "Plot Data Error", alertMessage: state.inReviewMode ? err + reviewModeWarning : err}}}));
-          } else {
-            setState (prev=> ({
-              ... prev,
-	      userPlotList: data,
-	      remainingPlotters: data,
-	      currentPlot: data[0],
-	      currentUserId: data[0].userId,
-	      ...newPlotValues(data[0]),
-	      answerMode: "question",
-	      inReviewMode: reviewMode || state.inReviewMode,
-              newPlotId: data[0].visibleId,
-              usedKML: data[0]?.usedKML ?? false,
-              usedGeodash: data[0]?.usedGeodash ?? false,
-	    }));
-          }
-        })
-        .catch((response) => {
-          console.error(response);
-          setState (prev => ({... prev, modal: {alert: {alertType: "Plot Data Retrieval Error", alertMessage: "Error retrieving plot data. See console for details."}}}));
-        });}
-    );
-  };
-  
-
-  // Functions
-
   const newPlotValues = (newPlot, copyValues = true) => ({	
     newPlotInput: newPlot.visibleId,	
     userSamples: newPlot.samples	
@@ -304,11 +255,62 @@ export const Collection = ({ projectId, acceptedTerms, plotId }) => {
       findObject(	
         state.currentProject.surveyQuestions,	
         ([_id, sq]) => sq.parentQuestionId === -1	
-      )[0]	
+      )	
     ),	
     collectionStart: Date.now(),	
     unansweredColor: "black",	
   });
+ 
+
+  // API CALLS
+  const getPlotData = (visibleId=1, direction, forcedNavMode = null, reviewMode = null) => {       
+    processModal("Getting plot", () => {
+      return fetch(
+        "/get-collection-plot?" +
+          getQueryString({
+            visibleId,            
+            projectId,
+            navigationMode: forcedNavMode || state.navigationMode,
+            direction,
+            inReviewMode: reviewMode || state.inReviewMode,
+            threshold: state.threshold,
+            currentUserId: state.currentUserId,
+            projectType: state.currentProject.type,
+            referencePlotId: state.referencePlotId || 0
+          })
+      )
+        .then((response) => (response.ok ? response.json() : Promise.reject(response)))
+        .then((data) => {
+          console.log(data[0]);          
+          if (data === "not-found") {
+            const err = (direction === "id" ? "Plot not" : "No more plots") +
+                  " found for this navigation mode.";
+            const reviewModeWarning = "\n If you have just changed navigation modes, please click the “Next” or “Back” arrows in order to see the plots for this navigation mode.";
+            setState (prev => ({... prev, modal: {alert: {alertType: "Plot Data Error", alertMessage: state.inReviewMode ? err + reviewModeWarning : err}}}));
+          } else {
+            setState (prev=> ({              
+              ... prev,
+	      userPlotList: data,
+	      remainingPlotters: data,
+	      currentPlot: data[0],
+	      currentUserId: data[0].userId,
+	      ...newPlotValues(data[0]),
+	      answerMode: "question",
+	      inReviewMode: reviewMode || state.inReviewMode,
+              newPlotId: data[0].visibleId,
+              usedKML: data[0]?.usedKML ?? false,
+              usedGeodash: data[0]?.usedGeodash ?? false,
+	    }));
+          }
+        })
+        .catch((response) => {
+          console.error(response);
+          setState (prev => ({... prev, modal: {alert: {alertType: "Plot Data Retrieval Error", alertMessage: "Error retrieving plot data. See console for details."}}}));
+        });}
+    );
+  };
+  
+  // Functions
 
   const processModal = (message, callBack) => {
      setState(prev => ({ ... prev, modalMessage: message }));
@@ -685,8 +687,8 @@ export const Collection = ({ projectId, acceptedTerms, plotId }) => {
             className="d-flex flex-column position-absolute full-height"
             style={{
               top: 0,
-              left: state.isImageryLayersExpanded ? "0px" : "-550px",
-              width: "550px",
+              left: state.isImageryLayersExpanded ? "0px" : "-236.183px",
+              width: "236.183px",
               height: "100%",
               backgroundColor: "#fff",
               boxShadow: "2px 0 5px rgba(0,0,0,.2)",
@@ -773,7 +775,7 @@ function ImageAnalysisPane({}) {
       
       <div className="map-controls"
            style={{position: 'absolute',
-                   bottom: '2em',
+                   bottom: '3.5em',
                    right: '10vw',
                    zIndex: 1}}>
         <div className="ExternalTools__geo-buttons d-flex flex-column" id="plot-nav" style={{ gap: '1rem' }}>

--- a/src/js/components/PageComponents.jsx
+++ b/src/js/components/PageComponents.jsx
@@ -16,7 +16,7 @@ export function LogOutButton({ userName, uri }) {
   const loggedOut = !userName || userName === "guest";
 
   const logout = () =>
-    fetch("/logout", { method: "POST" }).then(() => window.location.assign("/home"));
+        fetch("/logout", { method: "POST" }).then(() => window.location.assign("/home"));
 
   return loggedOut ? (
     <button
@@ -252,7 +252,7 @@ export class NavigationBar extends React.Component {
                     {page}
                   </a>
                 </li>
-             ))}
+              ))}
               {!loggedOut && (
                 <li className={"nav-item" + (uri === "/account" && " active")}>
                   <a className="nav-link" href={"/account?accountId=" + userId}>
@@ -299,13 +299,13 @@ export function Logo({ size, url, name, id, src }) {
     padding: ".5rem",
     margin: "1rem",
     ...(logoSize === "large"
-      ? {
+        ? {
           maxWidth: "180px",
           maxHeight: "180px",
           height: "180px",
           width: "180px",
         }
-      : {
+        : {
           maxWidth: "150px",
           maxHeight: "150px",
           height: "150px",
@@ -449,7 +449,7 @@ export function LoadingModal({ message }) {
 }
 
 export const LearningMaterialModal = ({ learningMaterial, onClose }) => {
-    return (
+  return (
     <div
       className="modal fade show"
       id="quitModal"
@@ -524,12 +524,12 @@ export function AcceptTermsModal ({institutionId, projectId, toggleAcceptTermsMo
             },
           }).then((response) => {
             if (response.ok) {
-              window.location.assign(`/collection?projectId=${projectId}`)
+              window.location.assign(`/collection?projectId=${projectId}&institutionId=${institutionId}`);
             } else {
               console.log(response);
             }
           });
-  }
+  };
   return (
     <div
       className="modal fade show"
@@ -597,164 +597,164 @@ export function AcceptTermsModal ({institutionId, projectId, toggleAcceptTermsMo
   );
 }
 
- export const ImageryLayerOptions = ({
-   imageryList,
-   setImageryList,
-   onDragEnd,
-   onToggleLayer,
-   onChangeOpacity,
-   onReset,
-   isImageryLayersExpanded,
- }) => {
-   const [expandedSections, setExpandedSections] = useState({
-     imagery: true,
-     polygon: true,
-   });
-   
-   const imageryLayers = imageryList.filter((image) => image.sourceConfig.type !== "FeatureCollection");
-   const polygonLayers = imageryList.filter((image) => image.sourceConfig.type === "FeatureCollection");
+export const ImageryLayerOptions = ({
+  imageryList,
+  setImageryList,
+  onDragEnd,
+  onToggleLayer,
+  onChangeOpacity,
+  onReset,
+  isImageryLayersExpanded,
+}) => {
+  const [expandedSections, setExpandedSections] = useState({
+    imagery: true,
+    polygon: true,
+  });
+  
+  const imageryLayers = imageryList.filter((image) => image.sourceConfig.type !== "FeatureCollection");
+  const polygonLayers = imageryList.filter((image) => image.sourceConfig.type === "FeatureCollection");
 
-   const toggleSection = (section) => {
-     setExpandedSections((prev) => ({
-       ...prev,
-       [section]: !prev[section],
-     }));
-   };
+  const toggleSection = (section) => {
+    setExpandedSections((prev) => ({
+      ...prev,
+      [section]: !prev[section],
+    }));
+  };
 
-   return (
-     <div className="sidebar-wrapper" style={{ overflowX: "hidden", overflowY: "auto" }}>
-       <div className={`sidebar-container ${isImageryLayersExpanded ? "" : "collapsed"}`}>
-         {isImageryLayersExpanded && (
-           <div className="sidebar-content">
-             <div className="sidebar-header">
-               <h3>Imagery Layer Options</h3>
-             </div>
-             <hr />
-             <DragDropContext onDragEnd={(result) => onDragEnd(result, imageryList, setImageryList)}>
-               {/* Imagery Layers */}
-               <div className="sidebar-section">
-                 <div className="section-header" onClick={() => toggleSection("imagery")}>
-                   <strong>Imagery Layers</strong>
-                   {expandedSections.imagery ? <FaChevronUp /> : <FaChevronDown />}
-                 </div>
-                 {expandedSections.imagery && (
-                   <Droppable droppableId="imageryLayers">
-                     {(provided, snapshot) => (
-                       <div
-                         className={`layers-list ${snapshot.isDraggingOver ? "dragging-over" : ""}`}
-                         ref={provided.innerRef}
-                         {...provided.droppableProps}
-                       >
-                         {imageryLayers.map((layer, index) => (
-                           <Draggable key={layer.id} draggableId={layer.id.toString()} index={index}>
-                             {(provided, snapshot) => {
-                               const ensureHex = (color) =>
-                                     /^[0-9a-f]{6}$/i.test(color) ? `#${color}` : color;
-                               const visParams = layer.sourceConfig?.visParams
-                                     ? JSON.parse(layer.sourceConfig.visParams)
-                                     : null;
-                               const palette = Array.isArray(visParams?.palette)
-                                     ? visParams.palette
-                                     : [];
-                               const sliderStyle =
-                                     palette.length === 2
-                                     ? {
-                                       '--first-slider-color': ensureHex(palette[0]),
-                                       '--slider-color': ensureHex(palette[1]),
-                                     }
-                                     : palette.length
-                                     ? {
-                                       '--slider-color': ensureHex(palette[0]),
-                                     }
-                                     : {
-                                       '--first-slider-color': '#d1d5db',
-                                       '--slider-color': '#3b82f6',
-                                     };
-                               return (
-                                 <div
-                                   className={`layer-item ${snapshot.isDragging ? "dragging" : ""}`}
-                                   ref={provided.innerRef}
-                                   {...provided.draggableProps}
-                                   {...provided.dragHandleProps}
-                                 >
-                                   <input
-                                     type="checkbox"
-                                     checked={layer.visible}
-                                     onChange={() => onToggleLayer(layer.id, imageryList)}
-                                   />
-                                   <span className="layer-title"> {" "} {layer.title}</span>
-                                   <input
-                                     type="range"
-                                     min="0"
-                                     max="1"
-                                     step="0.01"
-                                     className="layer-range"
-                                     value={layer.opacity || 1}
-                                     onChange={(e) => onChangeOpacity(layer.id, parseFloat(e.target.value))}
-                                     style={{ sliderStyle }}
-                                   />
-                                 </div>
-                               )}}
-                           </Draggable>
-                         ))}
-                         {provided.placeholder && <div className="placeholder"></div>}
-                       </div>
-                     )}
-                   </Droppable>
-                 )}
-               </div>
-               {/* Polygon Layers */}
-               <div className="sidebar-section">
-                 <div className="section-header" onClick={() => toggleSection("polygon")}>
-                   <strong>Polygon Layers</strong>
-                   {expandedSections.polygon ? <FaChevronUp /> : <FaChevronDown />}
-                 </div>
-                 {expandedSections.polygon && (
-                   <Droppable droppableId="polygonLayers">
-                     {(provided, snapshot) => (
-                       <div
-                         className={`layers-list ${snapshot.isDraggingOver ? "dragging-over" : ""}`}
-                         ref={provided.innerRef}
-                         {...provided.droppableProps}
-                       >
-                         {polygonLayers.map((layer, index) => (
-                           <Draggable key={layer.id} draggableId={layer.id.toString()} index={index}>
-                             {(provided, snapshot) => (
-                               <div
-                                 className={`layer-item ${snapshot.isDragging ? "dragging" : ""}`}
-                                 ref={provided.innerRef}
-                                 {...provided.draggableProps}
-                                 {...provided.dragHandleProps}
-                               >
-                                 <input
-                                   type="checkbox"
-                                   checked={layer.visible}
-                                   onChange={() => onToggleLayer(layer.id, imageryList)}
-                                 />
-                                 <span className="layer-title">  {layer.title}</span>
-                                 <input
-                                   type="range"
-                                   min="0"
-                                   max="1"
-                                   step="0.01"
-                                   className="layer-range"
-                                   value={layer.opacity || 1}
-                                   onChange={(e) => onChangeOpacity(layer.id, parseFloat(e.target.value))}
-                                 />
-                               </div>
-                             )}
-                           </Draggable>
-                         ))}
-                         {provided.placeholder && <div className="placeholder"></div>}
-                       </div>
-                     )}
-                   </Droppable>
-                 )}
-               </div>
-             </DragDropContext>
-             <button className="reset-button" onClick={onReset}>
-               Reset All Layers
-             </button>
+  return (
+    <div className="sidebar-wrapper" style={{ overflowX: "hidden", overflowY: "auto" }}>
+      <div className={`sidebar-container ${isImageryLayersExpanded ? "" : "collapsed"}`}>
+        {isImageryLayersExpanded && (
+          <div className="sidebar-content">
+            <div className="sidebar-header">
+              <h3>Imagery Layer Options</h3>
+            </div>
+            <hr />
+            <DragDropContext onDragEnd={(result) => onDragEnd(result, imageryList, setImageryList)}>
+              {/* Imagery Layers */}
+              <div className="sidebar-section">
+                <div className="section-header" onClick={() => toggleSection("imagery")}>
+                  <strong>Imagery Layers</strong>
+                  {expandedSections.imagery ? <FaChevronUp /> : <FaChevronDown />}
+                </div>
+                {expandedSections.imagery && (
+                  <Droppable droppableId="imageryLayers">
+                    {(provided, snapshot) => (
+                      <div
+                        className={`layers-list ${snapshot.isDraggingOver ? "dragging-over" : ""}`}
+                        ref={provided.innerRef}
+                        {...provided.droppableProps}
+                      >
+                        {imageryLayers.map((layer, index) => (
+                          <Draggable key={layer.id} draggableId={layer.id.toString()} index={index}>
+                            {(provided, snapshot) => {
+                              const ensureHex = (color) =>
+                                    /^[0-9a-f]{6}$/i.test(color) ? `#${color}` : color;
+                              const visParams = layer.sourceConfig?.visParams
+                                    ? JSON.parse(layer.sourceConfig.visParams)
+                                    : null;
+                              const palette = Array.isArray(visParams?.palette)
+                                    ? visParams.palette
+                                    : [];
+                              const sliderStyle =
+                                    palette.length === 2
+                                    ? {
+                                      '--first-slider-color': ensureHex(palette[0]),
+                                      '--slider-color': ensureHex(palette[1]),
+                                    }
+                                    : palette.length
+                                    ? {
+                                      '--slider-color': ensureHex(palette[0]),
+                                    }
+                                    : {
+                                      '--first-slider-color': '#d1d5db',
+                                      '--slider-color': '#3b82f6',
+                                    };
+                              return (
+                                <div
+                                  className={`layer-item ${snapshot.isDragging ? "dragging" : ""}`}
+                                  ref={provided.innerRef}
+                                  {...provided.draggableProps}
+                                  {...provided.dragHandleProps}
+                                >
+                                  <input
+                                    type="checkbox"
+                                    checked={layer.visible}
+                                    onChange={() => onToggleLayer(layer.id, imageryList)}
+                                  />
+                                  <span className="layer-title"> {" "} {layer.title}</span>
+                                  <input
+                                    type="range"
+                                    min="0"
+                                    max="1"
+                                    step="0.01"
+                                    className="layer-range"
+                                    value={layer.opacity || 1}
+                                    onChange={(e) => onChangeOpacity(layer.id, parseFloat(e.target.value))}
+                                    style={{ sliderStyle }}
+                                  />
+                                </div>
+                              )}}
+                          </Draggable>
+                        ))}
+                        {provided.placeholder && <div className="placeholder"></div>}
+                      </div>
+                    )}
+                  </Droppable>
+                )}
+              </div>
+              {/* Polygon Layers */}
+              <div className="sidebar-section">
+                <div className="section-header" onClick={() => toggleSection("polygon")}>
+                  <strong>Polygon Layers</strong>
+                  {expandedSections.polygon ? <FaChevronUp /> : <FaChevronDown />}
+                </div>
+                {expandedSections.polygon && (
+                  <Droppable droppableId="polygonLayers">
+                    {(provided, snapshot) => (
+                      <div
+                        className={`layers-list ${snapshot.isDraggingOver ? "dragging-over" : ""}`}
+                        ref={provided.innerRef}
+                        {...provided.droppableProps}
+                      >
+                        {polygonLayers.map((layer, index) => (
+                          <Draggable key={layer.id} draggableId={layer.id.toString()} index={index}>
+                            {(provided, snapshot) => (
+                              <div
+                                className={`layer-item ${snapshot.isDragging ? "dragging" : ""}`}
+                                ref={provided.innerRef}
+                                {...provided.draggableProps}
+                                {...provided.dragHandleProps}
+                              >
+                                <input
+                                  type="checkbox"
+                                  checked={layer.visible}
+                                  onChange={() => onToggleLayer(layer.id, imageryList)}
+                                />
+                                <span className="layer-title">  {layer.title}</span>
+                                <input
+                                  type="range"
+                                  min="0"
+                                  max="1"
+                                  step="0.01"
+                                  className="layer-range"
+                                  value={layer.opacity || 1}
+                                  onChange={(e) => onChangeOpacity(layer.id, parseFloat(e.target.value))}
+                                />
+                              </div>
+                            )}
+                          </Draggable>
+                        ))}
+                        {provided.placeholder && <div className="placeholder"></div>}
+                      </div>
+                    )}
+                  </Droppable>
+                )}
+              </div>
+            </DragDropContext>
+            <button className="reset-button" onClick={onReset}>
+              Reset All Layers
+            </button>
           </div>
         )}
       </div>
@@ -828,13 +828,13 @@ export function PromptModal({title, inputs, callBack, closePrompt}) {
             onClick={() => closePrompt()}
             type="button"
             value="Cancel"
-            />
+          />
           <input
             className="btn btn-outline-lightgreen btn-sm w-100"
             onClick={() => callBack(promptState)}
             type="button"
             value="Confirm"
-            />
+          />
         </div>
       </div>
     </div>
@@ -860,7 +860,7 @@ export const BreadCrumbs = ({crumbs}) => {
               body: JSON.stringify(
                 breadCrumbs.concat(crumbs).map(
                   ({query})=> query).filter((x)=>x)
-                 .reduce((acc, curr)=> (acc[curr [0]]=curr [1], acc), {})
+                  .reduce((acc, curr)=> (acc[curr [0]]=curr [1], acc), {})
               )
             })
         .then((res) => (res.ok ? res.json() : Promise.reject()))
@@ -907,6 +907,6 @@ export const BreadCrumbs = ({crumbs}) => {
         }}
       > <SvgIcon icon="leftArrowSlim" size="2rem" />
       </div>      
-        {breadCrumbs.map(renderCrumb)}
+      {breadCrumbs.map(renderCrumb)}
     </div>);
 };

--- a/src/js/components/ProjectsTab.jsx
+++ b/src/js/components/ProjectsTab.jsx
@@ -35,7 +35,7 @@ export const ProjectsTab = ({
         cell: (row) => (
           <a
             href={
-              isAdmin ? `/collection?projectId={row.id}&institutionId={institutionId}`: `/review-project?projectId=${row.id}`}
+              isAdmin ? `/collection?projectId=${row.id}&institutionId=${institutionId}`: `/review-project?projectId=${row.id}&institutionId=${institutionId}`}
             style={{
               color: "#2f615e",
               textDecoration: "none",


### PR DESCRIPTION
## Purpose

The icon that handles the onclick event that toggles the imagery sidebar in simplified collection was not calibrated to the width of the imagery options sidebar content.

## Related Issues

Closes COL-1134

## Submission Checklist

- [ ] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [ ] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [ ] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

<!-- List the Module > Submodule impacted by this test (e.g. Validation > Project Boundary or Subscriptions > Add) -->
<!-- The current list of all Modules is: Home, Institution, Imagery, Projects, Wizard, Survey & Rules, Collection, GeoDash. -->

### Role

<!-- Admin, User, or Visitor -->

### Steps

<!-- All steps needed to test this PR -->

1.

### Desired Outcome

---

<!-- If needed, add more tests using the format above (Module Impacted, Role, Steps, Desired Outcome) here. -->

## Screenshots

<!-- Add a screen shot when UI changes are included -->
