### PR TITLE
Clarify public and private imagery descriptions in popup

### DIFF
--- a/src/js/components/BulkPopups.jsx
+++ b/src/js/components/BulkPopups.jsx
@@ -232,7 +232,7 @@ export function ImageryVisibilityPopup({ selectedImagery, editImageryBulk }) {
       {isPopupOpen && (
         <div className="popup-container">
           <div className="popup-header">
-            **Public imagery will be available for any project in CEO to use them, and private imagery will only be available to projects from this institution.
+            Public Institution Imagery is visible to all CEO users who can view the project. Private Institution Imagery is visible only to institution members, regardless of project visibility.
           </div>
           <div className="popup-option">
             <input
@@ -252,7 +252,7 @@ export function ImageryVisibilityPopup({ selectedImagery, editImageryBulk }) {
               value="private"
               onChange={handleVisibilityChange}
             />
-            <label htmlFor="private">Private</label>
+            <label htmlFor="private">Private Institution Imagery</label>
           </div>
 
           <button className="popup-button" onClick={handleSave}>


### PR DESCRIPTION
Updated popup text to clarify visibility of public and private imagery.

## Purpose

<!-- Description of what has been added/changed -->

## Related Issues

Closes COL-###

## Submission Checklist

- [ ] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [ ] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [ ] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

<!-- List the Module > Submodule impacted by this test (e.g. Validation > Project Boundary or Subscriptions > Add) -->
<!-- The current list of all Modules is: Home, Institution, Imagery, Projects, Wizard, Survey & Rules, Collection, GeoDash. -->

### Role

<!-- Admin, User, or Visitor -->

### Steps

<!-- All steps needed to test this PR -->

1.

### Desired Outcome

---

<!-- If needed, add more tests using the format above (Module Impacted, Role, Steps, Desired Outcome) here. -->

## Screenshots

<!-- Add a screen shot when UI changes are included -->
