### PR TITLE
adds collect button

### DIFF
--- a/src/js/components/ProjectsTab.jsx
+++ b/src/js/components/ProjectsTab.jsx
@@ -81,6 +81,13 @@ export const ProjectsTab = ({
         selector: (row) => row.availability ?? "Unpublished",
         sortable: true,
       },
+      {cell: (row)=> <input
+                    className="btn btn-outline-lightgreen btn-sm w-100"
+                    onClick={() => window.open(`/collection?projectId=${row.id}&institutionId=${institutionId}`)
+                            }
+                    type="button"
+                    value="Collect"
+                  />}
     ],
     []
   );


### PR DESCRIPTION
## Purpose

Adds a "Collect" button to each row of the projects tab of the institution dahsboard. Clicking this button opens a new tab that collects on that project.

## Related Issues

Closes COL-1118

## Submission Checklist

- [ ] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [ ] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [ ] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

<!-- List the Module > Submodule impacted by this test (e.g. Validation > Project Boundary or Subscriptions > Add) -->
<!-- The current list of all Modules is: Home, Institution, Imagery, Projects, Wizard, Survey & Rules, Collection, GeoDash. -->

### Role

<!-- Admin, User, or Visitor -->

### Steps

<!-- All steps needed to test this PR -->

1.

### Desired Outcome

---

<!-- If needed, add more tests using the format above (Module Impacted, Role, Steps, Desired Outcome) here. -->

## Screenshots

<!-- Add a screen shot when UI changes are included -->
