### PR TITLE
Removing plot similarity for simplified projects

### DIFF
--- a/src/js/project/PlotDesign.jsx
+++ b/src/js/project/PlotDesign.jsx
@@ -948,7 +948,7 @@ export class PlotDesign extends React.Component {
                 plotLimit
               )}.`}
           </p>
-          {(this.context.type != "simplified") ? (
+          {(this.context.type != "simplified") && (
             <>
               <h3 className="mb-3">Plot Similarity Configuration</h3>
               <div className="form-check">
@@ -966,7 +966,7 @@ export class PlotDesign extends React.Component {
                 <label className="form-check-label" htmlFor="similarPlots">
                   Enable navigation by similarity
                 </label>
-                {this.context.projectOptions.plotSimilarity ? (
+                {this.context.projectOptions.plotSimilarity && (
                   <>
                     <div className="form-group">
                       <label htmlFor="referencePlotId"> Reference plot ID: {"  "}</label>
@@ -1015,10 +1015,10 @@ export class PlotDesign extends React.Component {
                       />
                     </div>
                   </>
-                ) : null}
+                )}
               </div>
             </>
-          ) : null}
+          )}
         </div>
         <hr/>
       </div>


### PR DESCRIPTION
## Purpose

Removes plot similarity option for simplified projects, as they only have a single plot

## Related Issues

Closes COL-1145

## Submission Checklist

- [x] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

Project Wizard > Plot Design

### Role

Admin

### Steps

1. Start creating a project
2. Check that the plot similarity navigation is enabled for regular projects in the plot design tab.
3. Go back to the overview tab, change the  project type to simplified
4. Make sure that the option to enable navigation by plot similarity is not present anymore.
