### PR TITLE
COL-1173

### DIFF
--- a/src/clj/collect_earth_online/db/projects.clj
+++ b/src/clj/collect_earth_online/db/projects.clj
@@ -178,7 +178,8 @@
                     :surveyQuestions            (tc/jsonb->clj (:survey_questions project) [])
                     :surveyRules                (tc/jsonb->clj (:survey_rules project) [])
                     :projectOptions             (merge default-options (tc/jsonb->clj (:options project)))
-                    :designSettings             (merge default-settings (tc/jsonb->clj (:design_settings project)))})))
+                    :designSettings             (merge default-settings (tc/jsonb->clj (:design_settings project)))
+                    :referencePlot              (:reference_plot_rid project)})))
 
 (defn get-project-stats [{:keys [params]}]
   (let [project-id (tc/val->int (:projectId params))

--- a/src/js/project/CreateProjectWizard.jsx
+++ b/src/js/project/CreateProjectWizard.jsx
@@ -62,6 +62,7 @@ export default class CreateProjectWizard extends React.Component {
         title: "Plot Design",
         description: "Area of interest and plot generation for collection",
         StepComponent: () => <PlotStep
+                               templatePlots={this.state.templatePlots}
                                getTotalPlots={this.getTotalPlots}
                                steps={this.state.steps}
                                projectType={this.state.type}

--- a/src/js/project/PlotDesign.jsx
+++ b/src/js/project/PlotDesign.jsx
@@ -1,4 +1,5 @@
 import React, { useContext, useState } from "react";
+import { useAtomValue } from 'jotai';
 import shp from "shpjs";
 import DatePicker from 'react-datepicker';
 
@@ -1027,12 +1028,12 @@ export class PlotDesign extends React.Component {
 }
 PlotDesign.contextType = ProjectContext;
 
-export function PlotDesignReview() {
+export function PlotDesignReview({ templatePlots }) {
   const { institutionImagery } = useContext(ProjectContext);
   return (
     <div className="d-flex">
       <div className="col-6">
-        <PlotReview />
+        <PlotReview templatePlots={templatePlots}/>
       </div>
       <div className="col-6">
         <AOIReview
@@ -1043,7 +1044,7 @@ export function PlotDesignReview() {
   );
 }
 
-export function PlotReview() {
+export function PlotReview({ templatePlots }) {
   const {
     numPlots,
     plotDistribution,
@@ -1052,7 +1053,8 @@ export function PlotReview() {
     plotSize,
     plotSpacing,
     useTemplatePlots,
-  } = useContext(ProjectContext);
+    referencePlot,
+  } = useContext(ProjectContext);  
   return (
     <div id="plot-review">
       {useTemplatePlots && <h3 className="mb-3">Plots will be copied from template project</h3>}
@@ -1095,6 +1097,14 @@ export function PlotReview() {
                     </td>
                   </tr>
                 </>
+              )}
+              {referencePlot && (
+                <tr>
+                  <td className="w-80">Plot Similarity</td>
+                  <td className="w-20 text-center">
+                    <span className="badge badge-pill bg-lightgreen"> Plot {templatePlots.filter(({ plotId }) => plotId === referencePlot)[0].id} </span>
+                  </td>
+                </tr>
               )}
               {["shp", "csv"].includes(plotDistribution) && (
                 <tr>

--- a/src/js/project/PlotStep.jsx
+++ b/src/js/project/PlotStep.jsx
@@ -5,13 +5,13 @@ import AssignPlots from "./AssignPlots";
 import QualityControl from "./QualityControl";
 import { PlotDesign, PlotDesignReview, NewPlotDesign} from "./PlotDesign";
 
-export default function PlotStep({ getTotalPlots, projectType }) {
+export default function PlotStep({ getTotalPlots, projectType, templatePlots = [] }) {
   const { institutionUserList, aoiFeatures, useTemplatePlots, availability } = useContext(ProjectContext);  
   const totalPlots = getTotalPlots();
   return (
     <>
       {useTemplatePlots ? (
-        <PlotDesignReview />
+        <PlotDesignReview templatePlots={templatePlots}/>
       ) : (
         <PlotDesign
           aoiFeatures={aoiFeatures}


### PR DESCRIPTION
## Purpose

Adds a new row in the "Plot Design" step for new projects created from a template. If the template project has plot similarity enabled, the plot design step renders a row associating the reference_plot_rid of the project with its visible id.

## Related Issues

Closes COL-1173

## Submission Checklist

- [ ] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [ ] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [ ] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

Projects 

### Role

User

### Steps

<!-- All steps needed to test this PR -->

1. Navigate to your desired institution and click "new project"
2. choose to build project from a template. be sure to choose a project with 'navigation by plot similarity' enabled.
3. skip to the 'plot design' step
4. witness

### Desired Outcome

---

<!-- If needed, add more tests using the format above (Module Impacted, Role, Steps, Desired Outcome) here. -->

## Screenshots

<!-- Add a screen shot when UI changes are included -->
