### PR TITLE
andy/COL-1180/dynamic-widget-basemap

### DIFF
--- a/src/js/geodash/DynamicWorldDesigner.jsx
+++ b/src/js/geodash/DynamicWorldDesigner.jsx
@@ -1,10 +1,9 @@
 import React, { useContext, useState } from "react";
 import _ from "lodash";
 
+import BasemapSelector from "./form/BasemapSelector";
 import GDDateRange from "./form/GDDateRange";
-import GDInput from "./form/GDInput";
 import GDTextArea from "./form/GDTextArea";
-import GDSelect from "./form/GDSelect";
 import ImageCollectionAssetDesigner from "./ImageCollectionAssetDesigner";
 
 
@@ -19,6 +18,7 @@ export default function DynamicWorldDesigner({prefixPath = ""}) {
         title="Image Parameters (JSON format)"
       />
       <GDDateRange prefixPath={prefixPath} />
+      <BasemapSelector />
     </>
   );
 }


### PR DESCRIPTION
## Purpose

adds basemap selector to dynamic world geodash widget designer. the default option is 'open street maps'

## Related Issues

Closes COL-1180

## Submission Checklist

- [ ] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [ ] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [ ] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

GeoDash

### Role

User

### Steps

<!-- All steps needed to test this PR -->

1. Log in and navigate to the desired institution via the left sidebar.
2. select a project from among the list by clicking on the project title or using the red 'edit' symbol of its row.
3. from the project splash page, select 'configure geodash'
4. from the geodash page, click 'add new widget'
5. choose 'dynamic world' from among the dropdown list, and observe the 'basemap' selector.
6. create the widget.
7. back in your project splash page, click 'collect'
8. from the collection page, click 'geodash'
9. observe the new widget.

### Desired Outcome

---

<!-- If needed, add more tests using the format above (Module Impacted, Role, Steps, Desired Outcome) here. -->

## Screenshots

<!-- Add a screen shot when UI changes are included -->
