### PR TITLE
fixes function call, reference to this.state

### DIFF
--- a/src/js/project/PlotDesign.jsx
+++ b/src/js/project/PlotDesign.jsx
@@ -273,10 +273,10 @@ export class PlotDesign extends React.Component {
 
     if (
       this.context.type === "simplified" &&
-        (lonMin !== prevState.lonMin ||
-         latMin !== prevState.latMin ||
-         lonMax !== prevState.lonMax ||
-         latMax !== prevState.latMax)
+        (this.state.lonMin !== prevState.lonMin ||
+         this.state.latMin !== prevState.latMin ||
+         this.state.lonMax !== prevState.lonMax ||
+         this.state.latMax !== prevState.latMax)
     ) {
       this.setSimplifiedProjectDetails();
     }
@@ -884,7 +884,7 @@ export class PlotDesign extends React.Component {
       simplified: {
         display: "Simplified AOI",
         description: "Use the map preview or the coordinate inputs to create the project plot",
-        layout: this.renderSimplifiedSelector(),
+        layout: this.renderSimplifiedSelector,
       },
     };
 


### PR DESCRIPTION
## Purpose

Some missed formatting with regards to an input layout function and the reference to geocoords in state.

## Related Issues

Closes COL-1135

## Submission Checklist

- [ ] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [ ] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [ ] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

<!-- List the Module > Submodule impacted by this test (e.g. Validation > Project Boundary or Subscriptions > Add) -->
<!-- The current list of all Modules is: Home, Institution, Imagery, Projects, Wizard, Survey & Rules, Collection, GeoDash. -->

### Role

<!-- Admin, User, or Visitor -->

### Steps

<!-- All steps needed to test this PR -->

1.

### Desired Outcome

---

<!-- If needed, add more tests using the format above (Module Impacted, Role, Steps, Desired Outcome) here. -->

## Screenshots

<!-- Add a screen shot when UI changes are included -->
