### PR TITLE
dynamic world is now an old-style imagery option

### DIFF
--- a/src/js/imagery/imageryOptions.js
+++ b/src/js/imagery/imageryOptions.js
@@ -81,6 +81,14 @@ export const imageryOptions = [
     ],
     // FIXME, add url if help document is created.
   },
+  {type: "DynamicWorld",
+   label: "Dynamic World",
+   optionalProxy: false,
+   defaultProxy: false,
+   params: [
+     { key: "startDate", display: "Start Date", type: "date" },
+     { key: "endDate", display: "End Date", type: "date" }
+   ]},
   {
     type: "xyz",
     label: "XYZ Imagery",

--- a/src/js/reviewInstitution.jsx
+++ b/src/js/reviewInstitution.jsx
@@ -1105,7 +1105,7 @@ class NewImagery extends React.Component {
     ? "Planet Labs Global Mosaic | © Planet Labs, Inc"
     : type === "SecureWatch"
     ? "SecureWatch Imagery | © Maxar Technologies Inc."
-    : ["Sentinel1", "Sentinel2"].includes(type) || type.includes("GEE")
+    : ["Sentinel1", "Sentinel2", "DynamicWorld"].includes(type) || type.includes("GEE")
     ? "Google Earth Engine | © Google LLC"
     : type.includes("MapBox")
     ? "© Mapbox"


### PR DESCRIPTION
## Purpose

Adds "Dynamic World" as an imagery option

## Related Issues

Closes COL-1250

## Submission Checklist

- [ ] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [ ] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [ ] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

<!-- List the Module > Submodule impacted by this test (e.g. Validation > Project Boundary or Subscriptions > Add) -->
<!-- The current list of all Modules is: Home, Institution, Imagery, Projects, Wizard, Survey & Rules, Collection, GeoDash. -->

### Role

<!-- Admin, User, or Visitor -->

### Steps

<!-- All steps needed to test this PR -->

1.

### Desired Outcome

---

<!-- If needed, add more tests using the format above (Module Impacted, Role, Steps, Desired Outcome) here. -->

## Screenshots

<!-- Add a screen shot when UI changes are included -->
