### PR TITLE
fixed with a simple SQL command

### DIFF
--- a/src/sql/changes/2026-03-17_update-2023-rubber-public
+++ b/src/sql/changes/2026-03-17_update-2023-rubber-public
@@ -1,0 +1,5 @@
+UPDATE imagery
+SET visibility = 'public'
+WHERE
+title LIKE '%2023 Rubber Probability%'
+ 


### PR DESCRIPTION
## Purpose

This updates the visibility of imagery '2023 Rubber Probability' to 'public'. it is currently set to 'platform' id 8363.

## Related Issues

Closes COL-1231

## Submission Checklist

- [ ] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [ ] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [ ] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

<!-- List the Module > Submodule impacted by this test (e.g. Validation > Project Boundary or Subscriptions > Add) -->
<!-- The current list of all Modules is: Home, Institution, Imagery, Projects, Wizard, Survey & Rules, Collection, GeoDash. -->

### Role

<!-- Admin, User, or Visitor -->

### Steps

<!-- All steps needed to test this PR -->

1.

### Desired Outcome

---

<!-- If needed, add more tests using the format above (Module Impacted, Role, Steps, Desired Outcome) here. -->

## Screenshots

<!-- Add a screen shot when UI changes are included -->
