### PR TITLE
Col 1264/acarlile/update metrics

### DIFF
--- a/src/clj/collect_earth_online/db/metrics.clj
+++ b/src/clj/collect_earth_online/db/metrics.clj
@@ -38,12 +38,18 @@
         (let [start-date (:startDate params)
               end-date   (:endDate params)]
           (->> (call-sql "get_imagery_counts" start-date end-date)
-               (mapv (fn [{:keys [imagery_id imagery_name user_plot_count start_date end_date]}]
+               (mapv (fn [{:keys [imagery_id
+                                  imagery_name
+                                  user_plot_count
+                                  start_date
+                                  end_date
+                                  project_name]}]
                        {:imageryId   imagery_id
                         :imageryName imagery_name
                         :plots       user_plot_count
                         :startDate   start_date 
-                        :endDate     end_date}))
+                        :endDate     end_date
+                        :project     project_name}))
                (data-response)))
         (catch Exception e
           (log (ex-message e))

--- a/src/clj/collect_earth_online/db/metrics.clj
+++ b/src/clj/collect_earth_online/db/metrics.clj
@@ -73,13 +73,15 @@
     (if (:valid validation)
       (try
         (let [start-date (:startDate params)
-              end-date   (:endDate params)]
+              end-date   (:endDate params)
+              {:keys [project_count]} (first (call-sql "get_project_count" start-date end-date))]
           (->> (call-sql "get_sample_plot_counts" start-date end-date)
                (mapv (fn [{:keys [user_plot_count total_sample_count distinct_project_count start_date end_date]}]
                        {:userPlots          user_plot_count
+                        :assignedProjects   distinct_project_count
+                        :totalProjects      project_count
                         :totalSamples       total_sample_count
-                        :distinctProjects   distinct_project_count
-                        :startDate          start_date 
+                        :startDate          start_date
                         :endDate            end_date}))
                (data-response)))
         (catch Exception e

--- a/src/js/metrics.jsx
+++ b/src/js/metrics.jsx
@@ -68,8 +68,7 @@ const MetricsDashboard = () => {
       const ceoUrl = buildUrl(handlerUrl, startDate, endDate);
       const response = await fetch(ceoUrl);
       const result = await response.json();
-
-      if (result.length === 0) {
+      if (result.length === 0) {        
         setAlertMessage("🚫 No data found for the selected filters.");
         setData([]); // Clear previous data
         setColumns([]); // Clear previous columns

--- a/src/sql/functions/imagery.sql
+++ b/src/sql/functions/imagery.sql
@@ -158,7 +158,7 @@ CREATE OR REPLACE FUNCTION archive_imagery(_imagery_id integer)
 $$ LANGUAGE SQL;
 
 -- FIXME, source config wont need to be stripped if the function is updated
--- Returns all rows in imagery for which visibility = "public"
+-- Returns all rows in imagery for which visibility = "platform"
 CREATE OR REPLACE FUNCTION select_public_imagery()
  RETURNS setOf imagery_return AS $$
 

--- a/src/sql/functions/metrics.sql
+++ b/src/sql/functions/metrics.sql
@@ -62,9 +62,9 @@ $$ LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION get_sample_plot_counts(start_date_param TEXT, end_date_param TEXT)
 RETURNS TABLE (
-    user_plot_count BIGINT,
-    total_sample_count BIGINT,
+    user_plot_count BIGINT,    
     distinct_project_count BIGINT,
+    total_sample_count BIGINT,
     start_date TEXT,
     end_date TEXT
 ) AS $$

--- a/src/sql/functions/metrics.sql
+++ b/src/sql/functions/metrics.sql
@@ -3,33 +3,34 @@
 
 CREATE OR REPLACE FUNCTION get_imagery_counts(start_date_param TEXT, end_date_param TEXT)
 RETURNS TABLE (
-    imagery_id INT,
-    imagery_name TEXT,
-    user_plot_count BIGINT,
-    start_date TEXT,
-    end_date TEXT
+     imagery_id INT,
+     imagery_name TEXT,
+     user_plot_count BIGINT,
+     start_date TEXT,
+     end_date TEXT,
+     project_name TEXT
 ) AS $$
 BEGIN
     RETURN QUERY
     SELECT 
-        i.imagery_uid AS imagery_id,
-        i.title AS imagery_name,
-        COUNT(up.user_plot_uid) AS user_plot_count,
-        start_date_param AS start_date,
-        end_date_param AS end_date
+         i.imagery_uid AS imagery_id,
+         i.title AS imagery_name,
+         COUNT(up.user_plot_uid) AS user_plot_count,
+         start_date_param AS start_date,
+         end_date_param AS end_date,
+         proj.name AS project_name,
     FROM 
-        user_plots up
+        imagery i
+    JOIN project_imagery pi on pi.imagery_rid = i.imagery_uid
     JOIN 
-        plots p ON up.plot_rid = p.plot_uid
-    JOIN 
-        projects proj ON p.project_rid = proj.project_uid
-    LEFT JOIN 
-        imagery i ON proj.imagery_rid = i.imagery_uid
+        projects proj ON pi.project_rid = proj.project_uid
+    JOIN plots p ON p.project_rid = proj.project_uid 
+    JOIN user_plots up ON up.plot_rid = p.plot_uid
     WHERE 
         up.collection_start BETWEEN start_date_param::DATE AND end_date_param::DATE
     GROUP BY 
         i.imagery_uid, i.title
-    ORDER BY 
+    ORDER BY
         user_plot_count DESC;
 END;
 $$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Purpose

Updates to the /metrics tables:

"Imagery Access Metrics"
  - retrieves Imagery not by project_rid (which limits results to 1 imagery) but through the projecT_imagery joining table.

"Projects with GEE Metrics"
  - retrieves projects not by user_plots but from the projects table itself. also rearranges the order of column data returned.



## Related Issues

Closes COL-1264

## Submission Checklist

- [x ] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [x ] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [ x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

Metrics

### Role

SIG approved metrics users

### Steps

<!-- All steps needed to test this PR -->

1. login as an approved metrics user.
2. navigate to /metrics.
3. select a metrics table from the dropdown list and select start and end dates. click "go"

### Desired Outcome

---

<!-- If needed, add more tests using the format above (Module Impacted, Role, Steps, Desired Outcome) here. -->

## Screenshots

<!-- Add a screen shot when UI changes are included -->
