### PR TITLE
restore shapefile validation

### DIFF
--- a/src/sql/functions/project.sql
+++ b/src/sql/functions/project.sql
@@ -1455,3 +1455,16 @@ BEGIN
    AND sv.user_plot_rid = old_up.user_plot_uid;
 END;
 $$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION hex_ewkb_to_all_vertices(hex_ewkb text)
+RETURNS TABLE(x float, y float) AS $$
+DECLARE
+    geom geometry;
+BEGIN
+    geom := ST_GeomFromEWKB(decode(hex_ewkb, 'hex'));
+    
+    RETURN QUERY
+    SELECT ST_X((dp).geom) AS x, ST_Y((dp).geom) AS y
+    FROM ST_DumpPoints(geom) AS dp;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Purpose

in commit #effe6bf9581bdf7b71a65c193428771f39196c5a, shapefile validation function hex_ewkb_to_all_vertices was overwritten or removed from src/sql/functions/project.sql, but reference to it was not removed from src/clj/collect_earth_online/db/projects/get-plot-points. this restores the SQL. 

## Related Issues

Closes COL-1277

## Submission Checklist

- [x ] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [x ] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [x ] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

Projects 

### Role

User

### Steps

<!-- All steps needed to test this PR -->

1. create a project or choose an existing project.
2. edit the project from step 1; navigate to the plot design step.
3. scroll down to the second option, "add new plot(s)"; select "shp file" from the drop down.
4. click "upload shapefile" and select a shapefile to use.
5. observe the filename change.


### Desired Outcome

---

<!-- If needed, add more tests using the format above (Module Impacted, Role, Steps, Desired Outcome) here. -->

## Screenshots

<!-- Add a screen shot when UI changes are included -->
