### PR TITLE
restore shapefile validation

### DIFF
--- a/src/sql/functions/project.sql
+++ b/src/sql/functions/project.sql
@@ -1455,3 +1455,16 @@ BEGIN
    AND sv.user_plot_rid = old_up.user_plot_uid;
 END;
 $$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION hex_ewkb_to_all_vertices(hex_ewkb text)
+RETURNS TABLE(x float, y float) AS $$
+DECLARE
+    geom geometry;
+BEGIN
+    geom := ST_GeomFromEWKB(decode(hex_ewkb, 'hex'));
+    
+    RETURN QUERY
+    SELECT ST_X((dp).geom) AS x, ST_Y((dp).geom) AS y
+    FROM ST_DumpPoints(geom) AS dp;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Purpose

We were missing an important SQL function which calculates the bounds of input shapefiles, even if the files themselves were valid. As a result, ux never updates the filename when user uploads a sample shapefile. This restores the function and therefore the functionality.

## Related Issues

Closes COL-1277

## Submission Checklist

- [ x] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [x ] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [x ] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

Projects => Plot Design

### Role

User

### Steps

<!-- All steps needed to test this PR -->

1. Select an existing project to edit.
2. navigate to the plot design step. upload a new shapefile.
3. observe the filename now updates.

### Desired Outcome

---

<!-- If needed, add more tests using the format above (Module Impacted, Role, Steps, Desired Outcome) here. -->

## Screenshots

<!-- Add a screen shot when UI changes are included -->
