### PR TITLE
Remove plot similarity for simplified projects

### DIFF
--- a/src/js/project/PlotDesign.jsx
+++ b/src/js/project/PlotDesign.jsx
@@ -354,6 +354,7 @@ export class PlotDesign extends React.Component {
       sampleDistribution: "center",
       numPlots: 1,
       plotSize: Math.floor(plotWidth / 2),
+      projectOptions: { ...this.context.projectOptions, plotSimilarity: false },
       allowDrawnSamples: true,
       plotDistribution: "simplified",
       designSettings: {
@@ -899,29 +900,29 @@ export class PlotDesign extends React.Component {
             <div className="form-group" style={{ width: "fit-content" }}>
               <label>Spatial distribution</label>
               <div style={{position: "relative"}}>
-              {spatialDistributionOptions[plotDistribution]?.alert &&
-             <p className="alert">- {spatialDistributionOptions[plotDistribution]?.alert}</p>}
-              <select
-                className="form-control form-control-sm"
-                onChange={(e) =>
-                  designSettings?.userAssignment?.userMethod === "file" ?
-                    this.setPlotDetails({
-                      plotDistribution: e.target.value,
-                      designSettings: { ...designSettings,
-                                        userAssignment: {userMethod: "none", users: [], percents: []},
-                                        qaqcAssignment: {qaqcMethod: "none", smes: [], overlap: 0}}})
-                    : this.setPlotDetails({ plotDistribution: e.target.value })
-                }
-                value={plotDistribution}
-                disabled={this.context?.availability==="published"}
-              >
-                {Object.entries(spatialDistributionOptions).map(([key, options]) => (
-                  <option key={key} value={key}>
-                    {options.display}
-                  </option>
-                ))}
-      </select>
-      </div>
+                {spatialDistributionOptions[plotDistribution]?.alert &&
+                  <p className="alert">- {spatialDistributionOptions[plotDistribution]?.alert}</p>}
+                <select
+                  className="form-control form-control-sm"
+                  onChange={(e) =>
+                    designSettings?.userAssignment?.userMethod === "file" ?
+                      this.setPlotDetails({
+                        plotDistribution: e.target.value,
+                        designSettings: { ...designSettings,
+                          userAssignment: {userMethod: "none", users: [], percents: []},
+                          qaqcAssignment: {qaqcMethod: "none", smes: [], overlap: 0}}})
+                      : this.setPlotDetails({ plotDistribution: e.target.value })
+                  }
+                  value={plotDistribution}
+                  disabled={this.context?.availability==="published"}
+                >
+                  {Object.entries(spatialDistributionOptions).map(([key, options]) => (
+                    <option key={key} value={key}>
+                      {options.display}
+                    </option>
+                  ))}
+                </select>
+              </div>
             </div>
             <p className="font-italic ml-2">{`- ${spatialDistributionOptions[plotDistribution]?.description}`}</p>
           </div>
@@ -935,82 +936,86 @@ export class PlotDesign extends React.Component {
             }}
           >
             {totalPlots > 0 &&
-             `This project will contain around ${formatNumberWithCommas(totalPlots)} plots.`}
+              `This project will contain around ${formatNumberWithCommas(totalPlots)} plots.`}
             {totalPlots > 0 &&
-             totalPlots > plotLimit &&
-             `\n* The maximum allowed number for the selected plot distribution is ${formatNumberWithCommas(
+              totalPlots > plotLimit &&
+              `\n* The maximum allowed number for the selected plot distribution is ${formatNumberWithCommas(
                 plotLimit
               )}.`}
           </p>
-          <h3 className="mb-3">Plot Similarity Configuration</h3>
-          <div className="form-check">
-            <input
-              checked={this.context.projectOptions.plotSimilarity}
-              className="form-check-input"
-              id="similarPlots"
-              onChange={() =>
-                this.context.setProjectDetails({
-                  projectOptions: { ...this.context.projectOptions, plotSimilarity: !this.context.projectOptions.plotSimilarity },
-                })
-              }
-              type="checkbox"
-            />
-            <label className="form-check-label" htmlFor="similarPlots">
-              Enable navigation by similarity
-            </label>
-            {this.context.projectOptions.plotSimilarity ? (
-              <>
-                <div className="form-group">
-                  <label htmlFor="referencePlotId"> Reference plot ID: {"  "}</label>
-                  <select
-                    id="referencePlotId"
-                    value={this.context.plotSimilarityDetails?.referencePlotId || ""}
-                    onChange={(e) =>
-                      this.context.setProjectDetails({
-                        plotSimilarityDetails: {
-                          ...this.context.plotSimilarityDetails,
-                          referencePlotId: e.target.value,
-                        },
-                      })
-                    }
-                  >
-                    <option value="" disabled>
-                      Select a plot ID
-                    </option>
-                    {this.state.plotIdList?.map((id) => (
-                      <option key={id} value={id}>
-                        {id}
-                      </option>
-                    ))}
-                  </select>
-                  <br/>
-                  <label htmlFor="year"> Year for comparison: {"  "} </label>
-                  <DatePicker
-                    selected={
-                      this.context.plotSimilarityDetails?.years?.[0]
-                        ? new Date(this.context.plotSimilarityDetails.years[0], 0, 1)
-                        : new Date(new Date().getFullYear() - 1, 0, 1)
-                    }
-                    onChange={(d) => {
-                      const year = d.getFullYear();
+          {(this.context.type==='regular') && (
+            <>
+              <h3 className="mb-3">Plot Similarity Configuration</h3>
+              <div className="form-check">
+                <input
+                  checked={this.context.projectOptions.plotSimilarity}
+                  className="form-check-input"
+                  id="similarPlots"
+                  onChange={() =>
+                    this.context.setProjectDetails({
+                      projectOptions: { ...this.context.projectOptions, plotSimilarity: !this.context.projectOptions.plotSimilarity },
+                    })
+                  }
+                  type="checkbox"
+                />
+                <label className="form-check-label" htmlFor="similarPlots">
+                  Enable navigation by similarity
+                </label>
+                {this.context.projectOptions.plotSimilarity ? (
+                  <>
+                    <div className="form-group">
+                      <label htmlFor="referencePlotId"> Reference plot ID: {"  "}</label>
+                      <select
+                        id="referencePlotId"
+                        value={this.context.plotSimilarityDetails?.referencePlotId || ""}
+                        onChange={(e) =>
+                          this.context.setProjectDetails({
+                            plotSimilarityDetails: {
+                              ...this.context.plotSimilarityDetails,
+                              referencePlotId: e.target.value,
+                            },
+                          })
+                        }
+                      >
+                        <option value="" disabled>
+                          Select a plot ID
+                        </option>
+                        {this.state.plotIdList?.map((id) => (
+                          <option key={id} value={id}>
+                            {id}
+                          </option>
+                        ))}
+                      </select>
+                      <br/>
+                      <label htmlFor="year"> Year for comparison: {"  "} </label>
+                      <DatePicker
+                        selected={
+                          this.context.plotSimilarityDetails?.years?.[0]
+                            ? new Date(this.context.plotSimilarityDetails.years[0], 0, 1)
+                            : new Date(new Date().getFullYear() - 1, 0, 1)
+                        }
+                        onChange={(d) => {
+                          const year = d.getFullYear();
 
-                      this.context.setProjectDetails({
-                        plotSimilarityDetails: {
-                          ...this.context.plotSimilarityDetails,
-                          years: [year]
-                        },
-                      });
-                    }}
-                    className="form-control"
-                    showYearPicker
-                    dateFormat="yyyy"
-                    minDate={new Date(2000, 0, 1)}
-                    maxDate={new Date(new Date().getFullYear() - 1, 0, 1)}
-                  />
-                </div>
-              </>
-            ) : null}
-          </div>
+                          this.context.setProjectDetails({
+                            plotSimilarityDetails: {
+                              ...this.context.plotSimilarityDetails,
+                              years: [year]
+                            },
+                          });
+                        }}
+                        className="form-control"
+                        showYearPicker
+                        dateFormat="yyyy"
+                        minDate={new Date(2000, 0, 1)}
+                        maxDate={new Date(new Date().getFullYear() - 1, 0, 1)}
+                      />
+                    </div>
+                  </>
+                ) : null}
+              </div>
+            </>
+          )}
         </div>
         <hr/>
       </div>

--- a/src/js/project/ReviewChanges.jsx
+++ b/src/js/project/ReviewChanges.jsx
@@ -42,18 +42,20 @@ export default class ReviewChanges extends React.Component {
           .then((response) => Promise.all([response.ok, response.json()]))
           .then((data) => {
             if (data[0] && Number.isInteger(data[1].projectId)) {
-              fetch("/start-plot-similarity", {
-                method: "POST",
-                headers: {
-                  Accept: "application/json",
-                  "Content-Type": "application/json; charset=utf-8",
-                },
-                body: JSON.stringify({
-                  projectId: data[1].projectId,
-                  referencePlotId: this.context.plotSimilarityDetails?.referencePlotId,
-                  similarityYears: this.context.plotSimilarityDetails?.years,
-                })
-              });
+              if(this.context.projectOptions.plotSimilarity) {
+                fetch("/start-plot-similarity", {
+                  method: "POST",
+                  headers: {
+                    Accept: "application/json",
+                    "Content-Type": "application/json; charset=utf-8",
+                  },
+                  body: JSON.stringify({
+                    projectId: data[1].projectId,
+                    referencePlotId: this.context.plotSimilarityDetails?.referencePlotId,
+                    similarityYears: this.context.plotSimilarityDetails?.years,
+                  })
+                });
+              }
               window.location = `/review-project?projectId=${data[1].projectId}`;
               return Promise.resolve();
             } else {


### PR DESCRIPTION
## Purpose

Disables the plot similarity feature for simplified projects

## Related Issues

Closes COL-1279

## Submission Checklist

- [x] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

<!-- List the Module > Submodule impacted by this test (e.g. Validation > Project Boundary or Subscriptions > Add) -->
<!-- The current list of all Modules is: Home, Institution, Imagery, Projects, Wizard, Survey & Rules, Collection, GeoDash. -->

### Role

Admin

### Steps

1. Go to project wizard and open dev tools on network
2. create a simplified project, make sure no requests to the route `start-plot-similarity` is made
3. now try creating a regular project with plot similarity
4. make sure it works