### PR TITLE
filters survey questions for those without parentIds to make a survey…

### DIFF
--- a/src/js/project/ManageProject.jsx
+++ b/src/js/project/ManageProject.jsx
@@ -207,8 +207,7 @@ class ProjectManagement extends React.Component {
     }
   };
 
-  deleteProject = () => {
-    console.log(this.context);
+  deleteProject = () => {    
     if (confirm("Do you want to delete this project? This operation cannot be undone.")) {
       this.context.processModal("Deleting project", () =>
         fetch(`/archive-project?projectId=${this.context.id}`, { method: "POST" }).then(

--- a/src/js/survey/SurveyCard.jsx
+++ b/src/js/survey/SurveyCard.jsx
@@ -31,11 +31,11 @@ export default function SurveyCard({ cardNumber, editMode, surveyQuestionId, top
   };
 
   const surveyQuestion = surveyQuestions[surveyQuestionId];
-
+  
   return (
-    <div className="border rounded border-dark">
-      <div className="container">
-        <div className="row">
+    <div className="border rounded border-dark">      
+      <div className="container">        
+        <div className="row">          
           <div className="col-10 d-flex pl-1">
             <button
               className="btn btn-outline-lightgreen my-2"
@@ -48,7 +48,9 @@ export default function SurveyCard({ cardNumber, editMode, surveyQuestionId, top
                 <SvgIcon icon="plus" size="0.9rem" />
               )}
             </button>
-            <h2 className="font-weight-bold mt-2 pt-1 ml-2">Survey Card Number {cardNumber}</h2>
+            <h2 className="font-weight-bold mt-2 pt-1 ml-2">
+               Survey Card Number{cardNumber}
+            </h2>
             <h3 className="m-3">
               {!showQuestions &&
                 `-- ${editMode === "review" ? removeEnumerator(surveyQuestion.question) : surveyQuestion.question}`}

--- a/src/js/survey/SurveyCardList.jsx
+++ b/src/js/survey/SurveyCardList.jsx
@@ -12,8 +12,10 @@ export default function SurveyCardList({ editMode }) {
   const topLevelNodes = mapObjectArray(surveyQuestions, ([id, sq]) => ({
     nodeId: id,
     cardOrder: sq.cardOrder,
+    parentIds: sq.parentAnswerIds
   }))
     .filter(({ cardOrder }) => isNumber(cardOrder))
+    .filter(({parentIds}) => !parentIds.length)
     .sort((a, b) => a.cardOrder - b.cardOrder)
     .map(({ nodeId }) => Number(nodeId));
 

--- a/src/js/survey/SurveyQuestionsDesigner.jsx
+++ b/src/js/survey/SurveyQuestionsDesigner.jsx
@@ -7,7 +7,7 @@ import { ProjectContext } from "../project/constants";
 
 export default function SurveyQuestionsDesigner() {
   const { setProjectDetails, surveyQuestions, surveyRules, projectId, originalProject, type, isProjectAdmin } =
-        useContext(ProjectContext);
+        useContext(ProjectContext);  
   const editMode =
     projectId === -1 || originalProject.availability === "unpublished" ? "full" : "partial";
   return (


### PR DESCRIPTION
… card

## Purpose

When displayingsurvey questions during the project creation wizard, we implemented a map and filter algorithm to determine what questions to use as top-level nodes (or "survey cards"). This filter did not check for questions with parentAnswerIds, which is how we determine whether a question is a child of another question. This resulted in some (almost all) copied child questions inject a new "survey card" as well as child question. This PR injects a logic filter during the filter-map algorithm to check survey questions for the presence of parentAnswerIds, preventing erroneous "survey cards" from rendering.

## Related Issues

Closes COL-1193

## Submission Checklist

- [x ] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [ x] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [ x] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

Project Wizard

### Role

User

### Steps

<!-- All steps needed to test this PR -->

1

    Create or edit a project.
    In the project wizard, navigate to the "survey questions" step.
    create or copy questions as parent or child questions.
    observe.


### Desired Outcome

---

<!-- If needed, add more tests using the format above (Module Impacted, Role, Steps, Desired Outcome) here. -->

## Screenshots

<!-- Add a screen shot when UI changes are included -->
