### PR TITLE
Col xxx/acarlile/reflex

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "@ckeditor/ckeditor5-build-classic": "^41.4.2",
     "@ckeditor/ckeditor5-react": "^11.0.1",
     "@emotion/react": "^11.14.0",
+    "@flexsurfer/reflex": "0.1.25",
     "@svgr/core": "^8.0.0",
     "@tanstack/react-table": "^8.10.0",
     "airbnb-prop-types": "^2.16.0",

--- a/src/js/projectWizard.jsx
+++ b/src/js/projectWizard.jsx
@@ -1,13 +1,14 @@
 import React, { useEffect, useState } from "react";
 import ReactDOM from "react-dom";
 import { useAtom, useSetAtom, useAtomValue } from 'jotai';
+import { useSubscription, dispatch } from '@flexsurfer/reflex';
 
 import { BreadCrumbs, NavigationBar } from "./components/PageComponents";
 import  Modal  from "./components/Modal";
 import SvgIcon from "./components/svg/SvgIcon";
 
 import { stateAtom } from "./utils/constants";
-import { projectWizardAtom } from "./state/projectWizard";
+import { projectWizardAtom, event_ids, sub_ids } from "./state/projectWizard";
 
 import "../css/project-wizard.css";
 
@@ -87,9 +88,7 @@ const ProjectWizardNavigator = () => {
 };
 
 const NewProjectModal = () => {
-  const { projectSource } = useAtomValue(projectWizardAtom);
   const setProjectWizardState = useSetAtom(projectWizardAtom);
-  
   const newProjectOptions = {
     newProject: ['Create a new project',
                  'Generate a new project from scratch by customizing all steps.'],
@@ -97,6 +96,7 @@ const NewProjectModal = () => {
                       'Select a template and prefill all the steps. You can edit and customize it.'],
     importProject: ['Import Collect Earth Project',
                     'Need Description']};
+  const projectSource = useSubscription([sub_ids.project_source]);
 
   return (
     <div
@@ -108,9 +108,9 @@ const NewProjectModal = () => {
                        "radio-selected-button"
                        : "radio-selection-button"}
             key={id}
-            onClick={()=> {setProjectWizardState((s)=>({
-              ... s, projectSource: id}));
-                          }}>
+            onClick={()=> {
+              dispatch([event_ids.projectSource, id]);
+            }}>
             <p
               className="radio-button-labeled"
             >{projectSource === id
@@ -160,14 +160,11 @@ const ProjectWizardModal = () => {
 };
 
 const OverviewStep = () => {
-  const { overview } = useAtomValue(projectWizardAtom);
   const setProjectWizardState = useSetAtom(projectWizardAtom);
-
-  const handleProjectName = (input) => {
-    setProjectWizardState((s)=>({
-      ...s, overview: {
-        ... s.overview, projectName: input}}));
-  };
+  const projectType = useSubscription([sub_ids.overview.projectType]);
+  const projectName = useSubscription([sub_ids.overview.projectName]);
+  const projectDescription = useSubscription([sub_ids.overview.projectDescription]);
+  const learningMaterial = useSubscription([sub_ids.overview.learningMaterial]);
   
   const GeneralInformationCard = () => {
     const projectTypeOptions = {regular: 'Regular Project', simplified: 'Simplified Project'};
@@ -184,18 +181,15 @@ const OverviewStep = () => {
                   return (<div
                             className="labeled-input"                       
                             key={id}
-                            onClick={()=> {                              
-                              setProjectWizardState((s) => ({
-                                ...s, overview: {
-                                ... s.overview, projectType: id}}));                                
-                            }}>
-                            <span>{ overview.projectType == id
+                            onClick={()=> {dispatch([event_ids.overview.projectType, id]);
+                                          }}>
+                            <span>{ projectType == id
                                     ? <SvgIcon icon="radioChecked" size="1.2rem" />    
                                     : <SvgIcon icon="radio" size="1.2rem"/>}</span>
                             <label                              
                               className="text-label"
-                              style={overview.projectType == id ? {fontWeight: "bold"} : {}}
-                            >{ label  }</label>
+                              style={projectType == id ? {fontWeight: "bold"} : {}}
+                            >{ label }</label>
                           </div>);                  
                 })}</div>
                 <div>
@@ -204,9 +198,9 @@ const OverviewStep = () => {
                   <input type="text"
                          className="text-input"
                          id="project-name"
-                         value={overview.projectName}
-                         onChange={(e)=>handleProjectName(e.target.value)}
-                         placeholder="Enter Text"/>
+                         value={projectName}            
+                         onChange={(e)=> {dispatch([event_ids.overview.projectName, e.target.value]);}} 
+                         placeholder="Enter Text"></input>
                 </div>
                 <div>
                   <label className="text-label"
@@ -214,12 +208,8 @@ const OverviewStep = () => {
                   <input type="text"
                          className="text-input"
                          id="project-description"
-                         onChange={(e)=>{                           
-                           setProjectWizardState((s)=>({
-                             ...s, overview: {
-                               ...s.overview, projectDescription: e.target.value}}));
-                         }}
-                         value={overview.projectDescription}
+                         onChange={(e)=>dispatch([event_ids.overview.projectDescription, e.target.value])}
+                         value={projectDescription}                         
                          placeholder="Enter Text"/>
                 </div>
                 <div>
@@ -227,17 +217,15 @@ const OverviewStep = () => {
                   >Learning Material (Optional)<SvgIcon icon="info" size="1.2rem" /></label>
                   <input type="text"
                          className="text-input"
-                         value={overview.learningMaterial}
-                         onChange={(e)=>{                                                      
-                           setProjectWizardState((s)=>({
-                             ...s, overview: {
-                               ...s.overview, learningMaterial: e.target.value}}));
+                         value={learningMaterial}
+                         onChange={(e)=>{
+                           dispatch([event_ids.overview.learningMaterial, e.target.value]);
                          }}
                          id="learning-material"
                          placeholder="Enter URL"/>
                 </div>
               </div>
-            </div>);
+            </div>);p
   };
 
   const VisibilityCard = () => {    
@@ -245,7 +233,7 @@ const OverviewStep = () => {
                              users: "Users: Logged In Users",
                              institution: "Institution: Group Members",
                              private: "Private: Group Admins"};
-    
+    const visibility = useSubscription([sub_ids.overview.visbility]);
     return (
       <div className="visibility-card card">
         <p className="card-title">Visibility<span style={{color:"red"}}>*</span>
@@ -253,16 +241,14 @@ const OverviewStep = () => {
         {Object.entries(visibilityOptions).map(([id, label])=>{
 	  return (<div className="labeled-input"
                        key={id}
-                       onClick={()=>{                         
-                         setProjectWizardState((s) => ({
-                           ...s, overview: {
-                             ...s.overview, visibility: id}}));
+                       onClick={()=>{
+                         dispatch([event_ids.overview.visibility, id]);                         
                        }}>
-                     <span>{ overview.visibility == id
+                     <span>{visibility == id
                              ? <SvgIcon icon="radioChecked" size="1.2rem" />    
                              : <SvgIcon icon="radio" size="1.2rem"/>}</span>
                     <label className="text-label"
-                           style={overview.visibility == id ? {fontWeight: "bold"} : {}}
+                           style={visibility == id ? {fontWeight: "bold"} : {}}
                     >{ label  }</label>
                    </div>);
         })}
@@ -272,9 +258,14 @@ const OverviewStep = () => {
 
   const ProjectOptionsCard = () => {    
     const projectOptionsMap={gee: "Show GEE Script Link on Collection Page",
-                          extraPlotColumns: "Show Extra Plot Columns on Collection Page",
-                          plotConfidence: "Collect Plot Confidence on Collection Page",
-                          autoGeo: "Auto-launch Geo-Dash"};
+                             extraPlotColumns: "Show Extra Plot Columns on Collection Page",
+                             plotConfidence: "Collect Plot Confidence on Collection Page",
+                             autoGeo: "Auto-launch Geo-Dash"};
+    const projectOptions = {gee: useSubscription([sub_ids.overview.projectOptions.gee]),
+                            extraPlotColumns: useSubscription([sub_ids.overview.projectOptions.extraPlotColumns]),
+                            plotConfidence: useSubscription([sub_ids.overview.projectOptions.plotConfidence]),
+                            autoGeo: useSubscription([sub_ids.overview.projectOptions.autoGeo])
+                           };
     
     return(<div className="project-options-card card">
            <p className="card-title">Project Options</p>
@@ -283,19 +274,16 @@ const OverviewStep = () => {
 	       <div className="labeled-input">
 		 <span
                    className="checkbox"
-		   onClick={() => {                     
-                     setProjectWizardState((s)=>({
-                       ... s, overview: {
-                         ...s.overview, projectOptions: {
-                           ...s.overview.projectOptions, [id]: !overview.projectOptions[id]
-                       }}})); 
+		   onClick={() => {
+                     dispatch([event_ids.overview.projectOptions[id], !projectOptions[id]]);
+                     
                    }}>
-		   {overview.projectOptions[id]
+		   {projectOptions[id]
                     ? (<SvgIcon icon="checkboxChecked" size="1.2rem" />)
                     : <SvgIcon icon="checkboxUnchecked" size="1.2rem" />}
 		 </span>
 		 <label className="text-label"
-                        style={overview.projectOptions[id] ? {fontWeight: "bold"} : {}}
+                        style={projectOptions[id] ? {fontWeight: "bold"} : {}}
                  >{label}</label>
 	       </div>
 	     ) ;
@@ -399,13 +387,16 @@ const ProjectWizard = ({userId, userName, version, institutionId}) => {
   // HOOKS
   // ------------------
   
-  useEffect(() => {    
-      setProjectWizardState((s) => ({ ... s, modal: {title: 'Project Setup',
-                               closeText: '',
-                               confirmText: 'Get Started',
-                               onConfirm: handleNewProject,
-                               id: 'newProject',
-                               children: (<NewProjectModal/>)}}));
+  useEffect(() => {
+    dispatch(['print-db']);
+    setProjectWizardState((s) => ({
+      ... s,
+      modal: {title: 'Project Setup',
+              closeText: '',
+              confirmText: 'Get Started',
+              onConfirm: handleNewProject,
+              id: 'newProject',
+              children: (<NewProjectModal/>)}}));
   }, []);
 
   

--- a/src/js/projectWizard.jsx
+++ b/src/js/projectWizard.jsx
@@ -8,7 +8,7 @@ import  Modal  from "./components/Modal";
 import SvgIcon from "./components/svg/SvgIcon";
 
 import { stateAtom } from "./utils/constants";
-import { projectWizardAtom, event_ids, sub_ids } from "./state/projectWizard";
+import {  event_ids, sub_ids } from "./state/projectWizard";
 
 import "../css/project-wizard.css";
 

--- a/src/js/projectWizard.jsx
+++ b/src/js/projectWizard.jsx
@@ -14,34 +14,33 @@ import "../css/project-wizard.css";
 
 
 const projectSteps =
-          [{id: 'overview',
-            label: 'Project Overview'},
-           {id: 'imagery',
-            label: 'Imagery Selection'},
-           {id: 'boundary',
-            label: 'Project Boundary'},
-           {id: 'plots',
-            label: 'Plot Generation'},
-           {id: 'samples',
-            label: 'Sample Design'},
-           {id: 'questions',
-            label: 'Survey Questions'},
-           {id: 'rules',
-            label: 'Survey Rules'},
-           {id: 'review',
-            label: 'Review & Publish'}];
+      [{id: 'overview',
+        label: 'Project Overview'},
+       {id: 'imagery',
+        label: 'Imagery Selection'},
+       {id: 'boundary',
+        label: 'Project Boundary'},
+       {id: 'plots',
+        label: 'Plot Generation'},
+       {id: 'samples',
+        label: 'Sample Design'},
+       {id: 'questions',
+        label: 'Survey Questions'},
+       {id: 'rules',
+        label: 'Survey Rules'},
+       {id: 'review',
+        label: 'Review & Publish'}];
 
 
 const NavButtons = () => {
-  const { currentStep } = useAtomValue(projectWizardAtom);
-  const setProjectWizardState = useSetAtom(projectWizardAtom);
+  const currentStep = useSubscription([sub_ids.currentStep]);
   
   const  continueHandler = () => {
     const currentIdx = projectSteps.findIndex(({id})=>{return (id == currentStep);});
     
     currentIdx + 1 < projectSteps.length
-      ? setProjectWizardState((s)=>({...s, currentStep: projectSteps[currentIdx + 1].id}))
-      : setProjectWizardState((s)=>({...s, modal: {title: "Confirm & Submit"}}));
+      ? dispatch([event_ids.currentStep, projectSteps[currentIdx + 1].id])
+      : dispatch([event_ids.modal, {title: "Confirm & Submit"}]);
   };
 
   return (<div className="nav-buttons">
@@ -63,8 +62,7 @@ const NavButtons = () => {
 };
 
 const ProjectWizardNavigator = () => {
-  const { currentStep } = useAtomValue(projectWizardAtom);
-  const setProjectWizardState = useSetAtom(projectWizardAtom);
+  const currentStep = useSubscription([sub_ids.currentStep]);
   
   return (
     <div
@@ -75,8 +73,10 @@ const ProjectWizardNavigator = () => {
             <div
               key={id}
               style={{fontWeight: currentStep === id ? 'bold' : 'normal'}}
-              onClick={()=> setProjectWizardState((s) => ({
-                ... s, currentStep: id}))}>
+              onClick={
+                () => dispatch([event_ids.currentStep, id])
+              }
+            >
               <span className={currentStep === id && "selected"}
               >{index + 1}</span>
               {label}
@@ -88,7 +88,6 @@ const ProjectWizardNavigator = () => {
 };
 
 const NewProjectModal = () => {
-  const setProjectWizardState = useSetAtom(projectWizardAtom);
   const newProjectOptions = {
     newProject: ['Create a new project',
                  'Generate a new project from scratch by customizing all steps.'],
@@ -96,7 +95,7 @@ const NewProjectModal = () => {
                       'Select a template and prefill all the steps. You can edit and customize it.'],
     importProject: ['Import Collect Earth Project',
                     'Need Description']};
-  const projectSource = useSubscription([sub_ids.project_source]);
+  const projectSource = useSubscription([sub_ids.projectSource]);
 
   return (
     <div
@@ -110,7 +109,7 @@ const NewProjectModal = () => {
             key={id}
             onClick={()=> {
               dispatch([event_ids.projectSource, id]);
-            }}>
+            }}>            
             <p
               className="radio-button-labeled"
             >{projectSource === id
@@ -128,8 +127,8 @@ const NewProjectModal = () => {
   
 const ProjectWizardModal = () => {
   // this is the container for any modal related to this page. based on state, this actually renders modals as they are explicitly defined above., provided through "children" value of modal map"
-  const { modal, projectSource } = useAtomValue(projectWizardAtom);
-  const setProjectWizardState = useSetAtom(projectWizardAtom);
+  const projectSource = useSubscription([sub_ids.projectSource]);
+  const modal = useSubscription([sub_ids.modal]);
   
   const children = () => {
     switch (modal.id) {
@@ -150,25 +149,25 @@ const ProjectWizardModal = () => {
       closeText={modal.closeText}
       confirmText={modal.confirmText}
       onConfirm={modal.onConfirm && modal.onConfirm}
-      confirmDisabled={projectSource === null}//{confirmDisabled()}
+      confirmDisabled={confirmDisabled()}
       onClose={()=>{
         modal.onClose ? modal.onClose()
-          : setProjectWizardState((s) => ({... s, modal: null}));
+          : dispatch([event_ids.modal, null]);
       }}>
       {children()}
     </Modal>);
 };
 
 const OverviewStep = () => {
-  const setProjectWizardState = useSetAtom(projectWizardAtom);
-  const projectType = useSubscription([sub_ids.overview.projectType]);
-  const projectName = useSubscription([sub_ids.overview.projectName]);
-  const projectDescription = useSubscription([sub_ids.overview.projectDescription]);
-  const learningMaterial = useSubscription([sub_ids.overview.learningMaterial]);
+
   
   const GeneralInformationCard = () => {
     const projectTypeOptions = {regular: 'Regular Project', simplified: 'Simplified Project'};
-    
+    const projectType = useSubscription([sub_ids.overview.projectType]);
+    const projectName = useSubscription([sub_ids.overview.projectName]);
+    const projectDescription = useSubscription([sub_ids.overview.projectDescription]);
+    const learningMaterial = useSubscription([sub_ids.overview.learningMaterial]);
+
     return (<div
             className="general-info-card card">
               <p className="card-title">General Information</p>
@@ -233,7 +232,7 @@ const OverviewStep = () => {
                              users: "Users: Logged In Users",
                              institution: "Institution: Group Members",
                              private: "Private: Group Admins"};
-    const visibility = useSubscription([sub_ids.overview.visbility]);
+    const visibility = useSubscription([sub_ids.overview.visibility]);
     return (
       <div className="visibility-card card">
         <p className="card-title">Visibility<span style={{color:"red"}}>*</span>
@@ -261,6 +260,7 @@ const OverviewStep = () => {
                              extraPlotColumns: "Show Extra Plot Columns on Collection Page",
                              plotConfidence: "Collect Plot Confidence on Collection Page",
                              autoGeo: "Auto-launch Geo-Dash"};
+    
     const projectOptions = {gee: useSubscription([sub_ids.overview.projectOptions.gee]),
                             extraPlotColumns: useSubscription([sub_ids.overview.projectOptions.extraPlotColumns]),
                             plotConfidence: useSubscription([sub_ids.overview.projectOptions.plotConfidence]),
@@ -293,8 +293,8 @@ const OverviewStep = () => {
 
   return (
     <div className="project-wizard overview-step">
-      <GeneralInformationCard />      
-      <VisibilityCard/>
+      <GeneralInformationCard /> 
+      <VisibilityCard/> 
       <ProjectOptionsCard/>    
     </div>
   );
@@ -356,30 +356,16 @@ const ProjectWizard = ({userId, userName, version, institutionId}) => {
   // VARS & CONSTANTS
   // ------------------
   
-  const { projectSource,
-          currentStep,
-          overview,
-          imagery,
-          boundary,
-          plots,
-          samples,
-          questions,
-          rules,
-          modal
-        } = useAtomValue(projectWizardAtom);
-  const setProjectWizardState = useSetAtom(projectWizardAtom);
-
-  
+  const currentStep = useSubscription([sub_ids.currentStep]);
+  const modal = useSubscription([sub_ids.modal]);
   
   // -------------------
   // HANDLERS
   // ------------------
   
   const handleNewProject = () => {
-    setProjectWizardState((s)=>({
-      ...s, 
-      modal: null,
-      currentStep: 'overview'}));
+    dispatch([event_ids.modal, null]);
+    dispatch([event_ids.currentStep, 'overview']);
     };
 
   
@@ -387,16 +373,13 @@ const ProjectWizard = ({userId, userName, version, institutionId}) => {
   // HOOKS
   // ------------------
   
-  useEffect(() => {
-    dispatch(['print-db']);
-    setProjectWizardState((s) => ({
-      ... s,
-      modal: {title: 'Project Setup',
+  useEffect(() => {    
+    dispatch([event_ids.modal, {title: 'Project Setup',
               closeText: '',
               confirmText: 'Get Started',
               onConfirm: handleNewProject,
               id: 'newProject',
-              children: (<NewProjectModal/>)}}));
+              children: (<NewProjectModal/>)}]);
   }, []);
 
   

--- a/src/js/state/projectWizard.jsx
+++ b/src/js/state/projectWizard.jsx
@@ -1,21 +1,22 @@
 import { atom } from "jotai";
 import { initAppDb , regEvent , regEffect , dispatch , regSub , current } from '@flexsurfer/reflex';
-import _ from 'lodash';
 
 
-const projectWizardState = {
-  projectSource: null, // 'newProject' | 'importProject' | 'templateProject'
-  overview: {projectName: '',
-             projectDescription: '',
-             projectType: null, // 'simplified' | 'regular'
-             learningMaterial: '',
-             visibility: null, // 'public' | 'users' | 'institution' | 'private'
-             projectOptions: {
-               gee: false,
-               extraPlotColumns: false,
-               plotConfidence: false,
-               autoGeo: false
-             }},
+const projectWizardDb = {
+  currentStep: null,
+  modal: null,
+  projectSource: null,
+  // overview
+  'overview.projectName': '',
+  'overview.projectDescription': '',
+  'overview.projectType': null,
+  'overview.learningMaterial': '',
+  'overview.visibility': null,
+  //overview.projectOptions
+  'overview.projectOptions.gee': false,
+  'overview.projectOptions.extraPlotColumns': false,
+  'overview.projectOptions.plotConfidence': false,
+  'overview.projectOptions.autoGeo': false,
   imagery: [],
   boundary: [],
   plots: [],
@@ -23,13 +24,12 @@ const projectWizardState = {
   questions: [],
   rules: []  
 };
-export const projectWizardAtom = atom(projectWizardState);
+
+initAppDb(projectWizardDb);
 
 export const event_ids = {
   currentStep: 'currentStep',
   modal: 'modal',
-  UPDATE_PATH: 'update-path',
-  PRINT_DB: 'print-db',
   projectSource: 'projectSource',
   overview: {projectName: 'overview.projectName',
              projectDescription: 'overview.projectDescription',
@@ -46,7 +46,6 @@ export const event_ids = {
 export const sub_ids = {
   currentStep: 'currentStep',
   modal: 'modal',
-  GET_PATH: 'get-path',
   projectSource: 'projectSource',
   overview: {projectName: 'overview.projectName',
              projectDescription: 'overview.projectDescription',
@@ -61,36 +60,6 @@ export const sub_ids = {
              }}};
 
 export const effects = {};
-
-initAppDb(
-  {
-    currentStep: null,
-    modal: null,
-    projectSource: null,
-    // overview
-    'overview.projectName': '',
-    'overview.projectDescription': '',
-    'overview.projectType': null,
-    'overview.learningMaterial': '',
-    'overview.visibility': null,
-    //overview.projectOptions
-    'overview.projectOptions.gee': false,
-    'overview.projectOptions.extraPlotColumns': false,
-    'overview.projectOptions.plotConfidence': false,
-    'overview.projectOptions.autoGeo': false,
-    imagery: [],
-    boundary: [],
-    plots: [],
-    samples: [],
-    questions: [],
-    rules: []  
-  }
-);
-
-
-regEvent(event_ids.UPDATE_PATH, ({ draftDb }, path, value)=>{
-  _.set(draftDb, path, current(value));
-});
 
 regSub(sub_ids.currentStep, sub_ids.currentStep);
 regSub(sub_ids.modal, sub_ids.modal);
@@ -108,12 +77,12 @@ regSub(sub_ids.overview.projectOptions.autoGeo, sub_ids.overview.projectOptions.
 
 regEvent(event_ids.currentStep,
          ({ draftDb }, currentStep) => {
-           draftDb[event_ids.currentStep] = currentStep;
+           draftDb[event_ids.currentStep] = currentStep;           
          });
 
 regEvent(event_ids.modal,
          ({ draftDb }, modal) => {
-           draftDb[event_ids.modal] = modal;
+           draftDb[event_ids.modal] = modal;           
          });
 
 regEvent(event_ids.overview.projectType,
@@ -123,12 +92,11 @@ regEvent(event_ids.overview.projectType,
 
 regEvent(event_ids.projectSource,
          ({ draftDb }, projectSource) => {           
-           draftDb[event_ids.projectSource] = projectSource;
+           draftDb[event_ids.projectSource] = projectSource;           
          });
 
 regEvent(event_ids.overview.projectName,
          ({ draftDb }, projectName) => {
-           console.log('project name event fires', projectName);
            draftDb[event_ids.overview.projectName] = projectName;
          });
 
@@ -136,14 +104,17 @@ regEvent(event_ids.overview.projectDescription,
          ({ draftDb }, projectDescription) => {
            draftDb[event_ids.overview.projectDescription] = projectDescription;
          });
+
 regEvent(event_ids.overview.learningMaterial,
          ({ draftDb }, learningMaterial) => {
            draftDb[event_ids.overview.learningMaterial] = learningMaterial;
          });
+
 regEvent(event_ids.overview.visibility,
          ({ draftDb }, visibility) => {
            draftDb[event_ids.overview.visibility] = visibility;
          });
+
 regEvent(event_ids.overview.projectOptions.gee,
          ({ draftDb }) => {
            draftDb[event_ids.overview.projectOptions.gee] = !draftDb[event_ids.overview.projectOptions.gee];
@@ -163,17 +134,6 @@ regEvent(event_ids.overview.projectOptions.autoGeo,
          ({ draftDb }) => {
            draftDb[event_ids.overview.projectOptions.autoGeo] = !draftDb[event_ids.overview.projectOptions.autoGeo];
          });
-
-
-regSub(sub_ids.GET_PATH,
-       ({ draftDb }, path) => {
-         return _.get(draftDb, path);
-       }, () => []);
-
-
-regEvent(event_ids.PRINT_DB, ({ draftDb })=>{
-  console.log(_.get(draftDb, 'overview.projectName'));  
-});
 
 
 

--- a/src/js/state/projectWizard.jsx
+++ b/src/js/state/projectWizard.jsx
@@ -26,8 +26,11 @@ const projectWizardState = {
 export const projectWizardAtom = atom(projectWizardState);
 
 export const event_ids = {
+  currentStep: 'currentStep',
+  modal: 'modal',
   UPDATE_PATH: 'update-path',
   PRINT_DB: 'print-db',
+  projectSource: 'projectSource',
   overview: {projectName: 'overview.projectName',
              projectDescription: 'overview.projectDescription',
              projectType: 'overview.projectType',
@@ -41,6 +44,8 @@ export const event_ids = {
              }}};
 
 export const sub_ids = {
+  currentStep: 'currentStep',
+  modal: 'modal',
   GET_PATH: 'get-path',
   projectSource: 'projectSource',
   overview: {projectName: 'overview.projectName',
@@ -59,6 +64,8 @@ export const effects = {};
 
 initAppDb(
   {
+    currentStep: null,
+    modal: null,
     projectSource: null,
     // overview
     'overview.projectName': '',
@@ -82,11 +89,12 @@ initAppDb(
 
 
 regEvent(event_ids.UPDATE_PATH, ({ draftDb }, path, value)=>{
-  console.log(_.get(draftDb, path), value);
   _.set(draftDb, path, current(value));
 });
 
-regSub(sub_ids.projectsource, sub_ids.projectSource);
+regSub(sub_ids.currentStep, sub_ids.currentStep);
+regSub(sub_ids.modal, sub_ids.modal);
+regSub(sub_ids.projectSource, sub_ids.projectSource);
 regSub(sub_ids.overview.projectType, sub_ids.overview.projectType);
 regSub(sub_ids.overview.projectName, sub_ids.overview.projectName);
 regSub(sub_ids.overview.projectDescription, sub_ids.overview.projectDescription);
@@ -98,13 +106,23 @@ regSub(sub_ids.overview.projectOptions.plotConfidence, sub_ids.overview.projectO
 regSub(sub_ids.overview.projectOptions.autoGeo, sub_ids.overview.projectOptions.autoGeo);
 
 
+regEvent(event_ids.currentStep,
+         ({ draftDb }, currentStep) => {
+           draftDb[event_ids.currentStep] = currentStep;
+         });
+
+regEvent(event_ids.modal,
+         ({ draftDb }, modal) => {
+           draftDb[event_ids.modal] = modal;
+         });
+
 regEvent(event_ids.overview.projectType,
          ({ draftDb }, projectType) => {
            draftDb[event_ids.overview.projectType] = projectType;
          });
 
-regEvent(event_ids.projectsource,
-         ({ draftDb }, projectSource) => {
+regEvent(event_ids.projectSource,
+         ({ draftDb }, projectSource) => {           
            draftDb[event_ids.projectSource] = projectSource;
          });
 
@@ -152,7 +170,6 @@ regSub(sub_ids.GET_PATH,
          return _.get(draftDb, path);
        }, () => []);
 
-regSub(sub_ids.project_source, 'projectSource');
 
 regEvent(event_ids.PRINT_DB, ({ draftDb })=>{
   console.log(_.get(draftDb, 'overview.projectName'));  

--- a/src/js/state/projectWizard.jsx
+++ b/src/js/state/projectWizard.jsx
@@ -1,6 +1,9 @@
 import { atom } from "jotai";
+import { initAppDb , regEvent , regEffect , dispatch , regSub , current } from '@flexsurfer/reflex';
+import _ from 'lodash';
 
-export const projectWizardAtom = atom({
+
+const projectWizardState = {
   projectSource: null, // 'newProject' | 'importProject' | 'templateProject'
   overview: {projectName: '',
              projectDescription: '',
@@ -19,4 +22,144 @@ export const projectWizardAtom = atom({
   samples: [],
   questions: [],
   rules: []  
+};
+export const projectWizardAtom = atom(projectWizardState);
+
+export const event_ids = {
+  UPDATE_PATH: 'update-path',
+  PRINT_DB: 'print-db',
+  overview: {projectName: 'overview.projectName',
+             projectDescription: 'overview.projectDescription',
+             projectType: 'overview.projectType',
+             learningMaterial: 'overview.learningMaterial',
+             visibility: 'overview.visibility',
+             projectOptions: {
+               gee: 'overview.projectOptions.gee',
+               extraPlotColumns: 'overview.projectOptions.extraPlotColumns',
+               plotConfidence: 'overview.projectOptions.plotConfidence',
+               autoGeo: 'overview.projectOptions.autoGeo'
+             }}};
+
+export const sub_ids = {
+  GET_PATH: 'get-path',
+  projectSource: 'projectSource',
+  overview: {projectName: 'overview.projectName',
+             projectDescription: 'overview.projectDescription',
+             projectType: 'overview.projectType',
+             learningMaterial: 'overview.learningMaterial',
+             visibility: 'overview.visibility',
+             projectOptions: {
+               gee: 'overview.projectOptions.gee',
+               extraPlotColumns: 'overview.projectOptions.extraPlotColumns',
+               plotConfidence: 'overview.projectOptions.plotConfidence',
+               autoGeo: 'overview.projectOptions.autoGeo'
+             }}};
+
+export const effects = {};
+
+initAppDb(
+  {
+    projectSource: null,
+    // overview
+    'overview.projectName': '',
+    'overview.projectDescription': '',
+    'overview.projectType': null,
+    'overview.learningMaterial': '',
+    'overview.visibility': null,
+    //overview.projectOptions
+    'overview.projectOptions.gee': false,
+    'overview.projectOptions.extraPlotColumns': false,
+    'overview.projectOptions.plotConfidence': false,
+    'overview.projectOptions.autoGeo': false,
+    imagery: [],
+    boundary: [],
+    plots: [],
+    samples: [],
+    questions: [],
+    rules: []  
+  }
+);
+
+
+regEvent(event_ids.UPDATE_PATH, ({ draftDb }, path, value)=>{
+  console.log(_.get(draftDb, path), value);
+  _.set(draftDb, path, current(value));
 });
+
+regSub(sub_ids.projectsource, sub_ids.projectSource);
+regSub(sub_ids.overview.projectType, sub_ids.overview.projectType);
+regSub(sub_ids.overview.projectName, sub_ids.overview.projectName);
+regSub(sub_ids.overview.projectDescription, sub_ids.overview.projectDescription);
+regSub(sub_ids.overview.learningMaterial, sub_ids.overview.learningMaterial);
+regSub(sub_ids.overview.visibility, sub_ids.overview.visibility);
+regSub(sub_ids.overview.projectOptions.gee, sub_ids.overview.projectOptions.gee);
+regSub(sub_ids.overview.projectOptions.extraPlotColumns, sub_ids.overview.projectOptions.extraPlotColumns);
+regSub(sub_ids.overview.projectOptions.plotConfidence, sub_ids.overview.projectOptions.plotConfidence);
+regSub(sub_ids.overview.projectOptions.autoGeo, sub_ids.overview.projectOptions.autoGeo);
+
+
+regEvent(event_ids.overview.projectType,
+         ({ draftDb }, projectType) => {
+           draftDb[event_ids.overview.projectType] = projectType;
+         });
+
+regEvent(event_ids.projectsource,
+         ({ draftDb }, projectSource) => {
+           draftDb[event_ids.projectSource] = projectSource;
+         });
+
+regEvent(event_ids.overview.projectName,
+         ({ draftDb }, projectName) => {
+           console.log('project name event fires', projectName);
+           draftDb[event_ids.overview.projectName] = projectName;
+         });
+
+regEvent(event_ids.overview.projectDescription,
+         ({ draftDb }, projectDescription) => {
+           draftDb[event_ids.overview.projectDescription] = projectDescription;
+         });
+regEvent(event_ids.overview.learningMaterial,
+         ({ draftDb }, learningMaterial) => {
+           draftDb[event_ids.overview.learningMaterial] = learningMaterial;
+         });
+regEvent(event_ids.overview.visibility,
+         ({ draftDb }, visibility) => {
+           draftDb[event_ids.overview.visibility] = visibility;
+         });
+regEvent(event_ids.overview.projectOptions.gee,
+         ({ draftDb }) => {
+           draftDb[event_ids.overview.projectOptions.gee] = !draftDb[event_ids.overview.projectOptions.gee];
+         });
+
+regEvent(event_ids.overview.projectOptions.extraPlotColumns,
+         ({ draftDb }) => {
+           draftDb[event_ids.overview.projectOptions.extraPlotColumns] = !draftDb[event_ids.overview.projectOptions.extraPlotColumns];
+         });
+
+regEvent(event_ids.overview.projectOptions.plotConfidence,
+         ({ draftDb }) => {
+           draftDb[event_ids.overview.projectOptions.plotConfidence] = !draftDb[event_ids.overview.projectOptions.plotConfidence];
+         });
+
+regEvent(event_ids.overview.projectOptions.autoGeo,
+         ({ draftDb }) => {
+           draftDb[event_ids.overview.projectOptions.autoGeo] = !draftDb[event_ids.overview.projectOptions.autoGeo];
+         });
+
+
+regSub(sub_ids.GET_PATH,
+       ({ draftDb }, path) => {
+         return _.get(draftDb, path);
+       }, () => []);
+
+regSub(sub_ids.project_source, 'projectSource');
+
+regEvent(event_ids.PRINT_DB, ({ draftDb })=>{
+  console.log(_.get(draftDb, 'overview.projectName'));  
+});
+
+
+
+
+
+


### PR DESCRIPTION


This adds the @flexsurfer/reflex library into CEO enabling us to handle state through subscriptions and effect handlers much like clojurescipt's day8/re-frame library.

subscriptions are defined with a name string and a dependency array. Two boilerplate dampness had to happen with the creation of the state objects sub_ids and event_ids. Access into the state object gets dicey when data nests too deep, so the object is a key-associated collection where the keys look like and represent the location of the data in a theoretical nested data structure. This data structure is represented in the sub_ids and event_ids maps. the name of the event handler or subscription is a string that represents the path to retrieve that same string, but that path string is also the key of the related data in the application state object. for example:

// state object
{'foo.spam':  'bar',
 'foo.eggs' : 'baz'}

// event_ids
{foo : { spam: 'foo.spam'
            eggs: 'foo.eggs'}

//sub_ids
{foo : { spam: 'foo.spam'
            eggs: 'foo.eggs'}

regSub([sub_ids.foo.spam, sub_ids.foo.spam])

subscribe([sub_ids.foo.spam]) => 'bar'

there is OOP at the bottom of it all, however: effects handlers are not pure. the function that creates them, regEvent, is pure, but when one initiates the application state object they create 'draftDb' as a result. to update the app state object as it is used by the app, one must supply a function that mutates draftDb; the return value is ignored.