### PR TITLE
splits off components to own files, adds back button

### DIFF
--- a/src/js/projectWizard.jsx
+++ b/src/js/projectWizard.jsx
@@ -3,7 +3,7 @@ import ReactDOM from "react-dom";
 import { useSubscription, dispatch } from '@flexsurfer/reflex';
 
 import { BreadCrumbs, NavigationBar } from "./components/PageComponents";
-import Modal from "./components/Modal";
+
 import SvgIcon from "./components/svg/SvgIcon";
 import { ImageryStep } from "./wizard/ImageryStep";
 import { BoundaryStep } from "./wizard/BoundaryStep";
@@ -13,251 +13,12 @@ import { SampleStep } from "./wizard/SampleStep";
 import ReviewStep from "./wizard/ReviewStep";
 import OverviewStep from './wizard/OverviewStep';
 import RulesStep from './wizard/RulesStep';
-
-import { 
-  event_ids,
-  sub_ids
-} from "./state/projectWizard";
+import NavButtons, { ProjectWizardNavigator } from './wizard/NavButtons';
+import ProjectWizardModal from './wizard/Modals';
+import { event_ids,  sub_ids } from "./state/projectWizard";
 
 import "../css/project-wizard.css";
 
-
-const projectSteps = [
-  {id: 'overview', label: 'Project Overview'},
-  {id: 'imagery', label: 'Imagery Selection'},
-  {id: 'boundary', label: 'Project Boundary'},
-  {id: 'plots', label: 'Plot Generation'},
-  {id: 'samples', label: 'Sample Design'},
-  {id: 'questions', label: 'Survey Questions'},
-  {id: 'rules', label: 'Survey Rules'},
-  {id: 'review', label: 'Review & Publish'}
-];
-
-const exitModal = {
-  title: 'Exit "Add a New Project" Workflow?',
-  id: 'exit',
-  closeText: "Exit Workflow",
-  confirmText: "Stay",
-  onClose: ()=> {
-    dispatch([event_ids.modal, null]);
-  },
-  onConfirm: ()=>{
-    dispatch([event_ids.saveDraft]);
-    dispatch([event_ids.modal, null]);
-  },
-};
-
-function NavButtons  () {
-  const currentStep = useSubscription([sub_ids.currentStep]);
-  function continueHandler () {dispatch([event_ids.continueHandler, currentStep]);}
-  function saveDraftHandler () {
-    dispatch([event_ids.saveDraft]);
-  };
-
-  return (<div className="nav-buttons">
-            <button
-              className="btn btn-secondary btn-sm"
-              onClick={()=>dispatch([event_ids.modal, exitModal])}
-            >Exit</button>
-            <button
-              className={'btn btn-sm'}
-              style={{backgroundColor: "#2d6f74",
-
-                      color: "#fff"}}
-              onClick={()=>saveDraftHandler()}
-            >Save Draft</button>
-            <button
-              className={'btn btn-sm'}
-              onClick={()=>continueHandler()}
-              style={{backgroundColor: "#2d6f74",
-                      color: "#fff"}}
-            >Save & {currentStep === 'review' ? 'Publish' : 'Continue'}</button>
-
-          </div>);
-};
-
-const ProjectWizardNavigator = () => {
-  const currentStep = useSubscription([sub_ids.currentStep]);
-  
-  return (
-    <div
-      className="project-wizard-navigator">
-      {projectSteps.map(({id, label}, index)=>{
-        return(
-          <>                         
-            <div
-              key={id}
-              style={{fontWeight: currentStep === id ? 'bold' : 'normal',
-                display: 'inline-flex',
-                cursor: 'pointer'}}
-              onClick={
-                () => dispatch([event_ids.currentStep, id])
-              }
-            >
-              <span className={currentStep === id && "selected"}
-              >{index + 1}</span>
-              {label}
-            </div>
-            {index + 1 < projectSteps.length && "- -- -"}
-          </>);
-      })}              
-    </div>);
-};
-
-function NewProjectModal () {
-  const newProjectOptions = {
-    newProject: ['Create a new project',
-      'Generate a new project from scratch by customizing all steps.'],
-    templateProject: ['Select from an existing template',
-      'Select a template and prefill all the steps. You can edit and customize it.'],
-    importProject: ['Import Collect Earth Project',
-      'Need Description']};
-  const projectSource = useSubscription([sub_ids.projectSource]);
-
-  return (
-    <div
-      className="inputs">
-      {Object.entries(newProjectOptions).map(([id, [title, description]]) => {
-        return (
-          <div
-            className={projectSource === id ?
-              "radio-selected-button"
-              : "radio-selection-button"}
-            key={id}
-            onClick={()=> {
-              dispatch([event_ids.projectSource, id]);
-            }}>            
-            <p
-              className="radio-button-labeled"
-            >{projectSource === id
-              ? <SvgIcon icon="radioChecked" size="1.2rem" />                            
-              : <SvgIcon icon="radio" size="1.2rem"
-                         className="radio-button-unchecked"/> }
-              {"    "}
-
-              { title } </p>
-            <label
-              className="radio-button-description"
-            >{ description }</label>
-          </div>);
-      })}
-    </div>);
-};
-
-function SubmitProjectModal () {
-  return (
-    <div>
-      <p >You are about to publish this project. Once published it will be added to your institution. You’ll still be able to make changes later from the project page within your institution.</p>
-      <p > Are you sure you want to continue?</p>
-    </div>);
-};
-
-function SuccessModal () {
-  return (
-    <>
-      <div className="success-icon">
-        <SvgIcon  icon='check' size='2rem'/>
-      </div>
-      <br/>
-      <b>Your Project has been published! </b>
-      <p >The Published Project can now be viewed in your Institutions Project Page.</p>
-    </>
-  );
-};
-
-function ErrorModal () {
-  const errors = useSubscription([sub_ids.errors]);
-  const [visible, setVisible] = useState([]);
-  function toggleVisible (errorType) {
-    visible.includes(errorType) ? setVisible(visible.filter((e) => e !== errorType)) : setVisible([... visible, errorType]);
-  };
-  console.log('error modal', errors);
-  function stepName (errorType) {
-    switch(errorType){
-    case 'overview' : return 'Overview Step';
-    case 'imagery' : return 'Imagery Step';
-    case 'plots' : return 'Plot Step';
-    case 'samples' : return 'Plot Samples';
-    case 'questions' : return 'Survey Questions';
-    default: return 'Unknown Error';
-    }
-  }
-  return  (
-    <div style={{display: 'flex',
-                 flexDirection: 'column',
-                 gap: '1rem'}}>
-      <div className='alert-icon'>
-        <SvgIcon  icon='alert' size='2rem'/>
-      </div>
-      <b className='error-title'> Your Project contains the following errors:</b>
-      <br/>      
-      {errors.map(([errorType, errorMessages])=> {
-        return (<div className='error-card'>
-                  <div className='error-header' onClick={()=>toggleVisible(errorType)}>
-                    <b > {stepName(errorType)}</b>
-                    <SvgIcon icon={visible.includes(errorType) ? 'upCaretNew' : 'downCaretNew'}
-                             size='1.2rem'> </SvgIcon>
-                  </div>
-                  {visible.includes(errorType) &&
-                   <div style={{gap: '1rem'}}>
-                     <br/>
-                     {errorMessages.map((message) => {
-                       return (
-                         <p > - {message}
-                         </p>);
-                     })}
-                   </div>}
-                </div>);
-      })}
-    </div>
-  );
-};
-
-
-function ExitModal () {
-  return (
-    <p > Are you sure you want to exit “Create New Scenario”? Saved steps will be kept in draft form, any steps you haven’t saved will be lost.</p>
-  );
-}
-
-
-const ProjectWizardModal = () => {
-  // this is the container for any modal related to this page. based on state, this actually renders modals as they are explicitly defined above., provided through "children" value of modal map"
-  const projectSource = useSubscription([sub_ids.projectSource]);
-  const modal = useSubscription([sub_ids.modal]);
- 
-  function children () {
-    switch (modal.id) {
-    case 'newProject'  : return (<NewProjectModal/>);
-    case 'review'      : return (<SubmitProjectModal/>);
-    case 'success'     : return (<SuccessModal/>);
-    case 'error'       : return (<ErrorModal/>);
-    case 'exit'        : return (<ExitModal/>);
-    default : break;
-    }};
-
-  function confirmDisabled () {
-
-    switch (modal.id) {
-    case 'newProject'
-      : return projectSource === null;
-    default: return false;
-    }};
-  
-  return (
-    <Modal
-      title={modal.title}
-      closeText={modal.closeText}
-      confirmText={modal.confirmText}
-      onConfirm={modal.onConfirm && modal.onConfirm}
-      confirmDisabled={confirmDisabled()}
-      onClose={()=>{
-        modal.onClose ? modal.onClose()
-          : dispatch([event_ids.modal, null]);
-      }}>
-      {children()}
-    </Modal>);
-};
 
 const ProjectWizard = ({userId, userName, version, institutionId}) => {
 
@@ -291,7 +52,8 @@ const ProjectWizard = ({userId, userName, version, institutionId}) => {
       confirmText: 'Get Started',
       onConfirm: handleNewProject,
       id: 'newProject',
-      children: (<NewProjectModal/>)}]);  
+//      children: (<NewProjectModal/>)
+    }]);  
     fetch(`/get-institution-imagery?institutionId=${institutionId}`)
       .then(res => res.json())
       .then(data => setAvailableImagery(data))

--- a/src/js/wizard/Modals.jsx
+++ b/src/js/wizard/Modals.jsx
@@ -1,0 +1,160 @@
+import { useSubscription, dispatch } from '@flexsurfer/reflex';
+import React, { useEffect, useState } from "react";
+
+import Modal from "../components/Modal";
+import SvgIcon from "../components/svg/SvgIcon";
+import { event_ids,  sub_ids } from "../state/projectWizard";
+
+function NewProjectModal () {
+  const newProjectOptions = {
+    newProject: ['Create a new project',
+      'Generate a new project from scratch by customizing all steps.'],
+    templateProject: ['Select from an existing template',
+      'Select a template and prefill all the steps. You can edit and customize it.'],
+    importProject: ['Import Collect Earth Project',
+      'Need Description']};
+  const projectSource = useSubscription([sub_ids.projectSource]);
+
+  return (
+    <div
+      className="inputs">
+      {Object.entries(newProjectOptions).map(([id, [title, description]]) => {
+        return (
+          <div
+            className={projectSource === id ?
+              "radio-selected-button"
+              : "radio-selection-button"}
+            key={id}
+            onClick={()=> {
+              dispatch([event_ids.projectSource, id]);
+            }}>            
+            <p
+              className="radio-button-labeled"
+            >{projectSource === id
+              ? <SvgIcon icon="radioChecked" size="1.2rem" />                            
+              : <SvgIcon icon="radio" size="1.2rem"
+                         className="radio-button-unchecked"/> }
+              {"    "}
+              { title } </p>
+            <label
+              className="radio-button-description"
+            >{ description }</label>
+          </div>);
+      })}
+    </div>);
+};
+
+function SubmitProjectModal () {
+  return (
+    <div>
+      <p >You are about to publish this project. Once published it will be added to your institution. You’ll still be able to make changes later from the project page within your institution.</p>
+      <p > Are you sure you want to continue?</p>
+    </div>);
+};
+
+function SuccessModal () {
+  return (
+    <>
+      <div className="success-icon">
+        <SvgIcon  icon='check' size='2rem'/>
+      </div>
+      <br/>
+      <b>Your Project has been published! </b>
+      <p >The Published Project can now be viewed in your Institutions Project Page.</p>
+    </>
+  );
+};
+
+function ErrorModal () {
+  const errors = useSubscription([sub_ids.errors]);
+  const [visible, setVisible] = useState([]);
+  function toggleVisible (errorType) {
+    visible.includes(errorType) ? setVisible(visible.filter((e) => e !== errorType)) : setVisible([... visible, errorType]);
+  };
+
+  function stepName (errorType) {
+    switch(errorType){
+    case 'overview' : return 'Overview Step';
+    case 'imagery' : return 'Imagery Step';
+    case 'plots' : return 'Plot Step';
+    case 'samples' : return 'Plot Samples';
+    case 'questions' : return 'Survey Questions';
+    default: return 'Unknown Error';
+    }
+  }
+  return  (
+    <div style={{display: 'flex',
+                 flexDirection: 'column',
+                 gap: '1rem'}}>
+      <div className='alert-icon'>
+        <SvgIcon  icon='alert' size='2rem'/>
+      </div>
+      <b className='error-title'> Your Project contains the following errors:</b>
+      <br/>      
+      {errors.map(([errorType, errorMessages])=> {
+        return (<div className='error-card'>
+                  <div className='error-header' onClick={()=>toggleVisible(errorType)}>
+                    <b > {stepName(errorType)}</b>
+                    <SvgIcon icon={visible.includes(errorType) ? 'upCaretNew' : 'downCaretNew'}
+                             size='1.2rem'> </SvgIcon>
+                  </div>
+                  {visible.includes(errorType) &&
+                   <div style={{gap: '1rem'}}>
+                     <br/>
+                     {errorMessages.map((message) => {
+                       return (
+                         <p > - {message}
+                         </p>);
+                     })}
+                   </div>}
+                </div>);
+      })}
+    </div>
+  );
+};
+
+
+function ExitModal () {
+  return (
+    <p > Are you sure you want to exit “Create New Scenario”? Saved steps will be kept in draft form, any steps you haven’t saved will be lost.</p>
+  );
+}
+
+
+export default function ProjectWizardModal () {
+  // this is the container for any modal related to this page. based on state, this actually renders modals as they are explicitly defined above., provided through "children" value of modal map"
+  const projectSource = useSubscription([sub_ids.projectSource]);
+  const modal = useSubscription([sub_ids.modal]);
+ 
+  function children () {
+    switch (modal.id) {
+    case 'newProject'  : return (<NewProjectModal/>);
+    case 'review'      : return (<SubmitProjectModal/>);
+    case 'success'     : return (<SuccessModal/>);
+    case 'error'       : return (<ErrorModal/>);
+    case 'exit'        : return (<ExitModal/>);
+    default : break;
+    }};
+
+  function confirmDisabled () {
+
+    switch (modal.id) {
+    case 'newProject'
+      : return projectSource === null;
+    default: return false;
+    }};
+  
+  return (
+    <Modal
+      title={modal.title}
+      closeText={modal.closeText}
+      confirmText={modal.confirmText}
+      onConfirm={modal.onConfirm && modal.onConfirm}
+      confirmDisabled={confirmDisabled()}
+      onClose={()=>{
+        modal.onClose ? modal.onClose()
+          : dispatch([event_ids.modal, null]);
+      }}>
+      {children()}
+    </Modal>);
+};

--- a/src/js/wizard/NavButtons.jsx
+++ b/src/js/wizard/NavButtons.jsx
@@ -1,0 +1,90 @@
+import { useSubscription, dispatch } from '@flexsurfer/reflex';
+
+import { event_ids,  sub_ids } from "../state/projectWizard";
+
+
+const exitModal = {
+  title: 'Exit "Add a New Project" Workflow?',
+  id: 'exit',
+  closeText: "Exit Workflow",
+  confirmText: "Stay",
+  onClose: ()=> {
+    dispatch([event_ids.modal, null]);
+  },
+  onConfirm: ()=>{
+    dispatch([event_ids.saveDraft]);
+    dispatch([event_ids.modal, null]);
+  },
+};
+
+const projectSteps = [
+  {id: 'overview', label: 'Project Overview'},
+  {id: 'imagery', label: 'Imagery Selection'},
+  {id: 'boundary', label: 'Project Boundary'},
+  {id: 'plots', label: 'Plot Generation'},
+  {id: 'samples', label: 'Sample Design'},
+  {id: 'questions', label: 'Survey Questions'},
+  {id: 'rules', label: 'Survey Rules'},
+  {id: 'review', label: 'Review & Publish'}
+];
+
+export default function NavButtons () {
+  const currentStep = useSubscription([sub_ids.currentStep]);
+  const stepIdx = projectSteps.map((e)=>e.id).indexOf(currentStep);
+  function continueHandler () {dispatch([event_ids.continueHandler, currentStep]);}
+  function saveDraftHandler () {dispatch([event_ids.saveDraft]);};
+
+  function navBackHandler () { dispatch([event_ids.currentStep, projectSteps[stepIdx - 1].id]);}
+
+  return (<div className="nav-buttons">
+            <button
+              className="btn btn-secondary btn-sm"
+              onClick={()=>dispatch([event_ids.modal, exitModal])}
+            >Exit</button>
+            {stepIdx > 0 &&
+             (<button
+              className={'btn btn-sm'}
+              style={{backgroundColor: "#2d6f74",
+                      color: "#fff"}}
+              onClick={()=>navBackHandler()}
+            >Back</button>)}
+            <button
+              className={'btn btn-sm'}
+              style={{backgroundColor: "#2d6f74",
+                      color: "#fff"}}
+              onClick={()=>saveDraftHandler()}
+            >Save Draft</button>
+            <button
+              className={'btn btn-sm'}
+              onClick={()=>continueHandler()}
+              style={{backgroundColor: "#2d6f74",
+                      color: "#fff"}}
+            >Save & {currentStep === 'review' ? 'Publish' : 'Continue'}</button>
+          </div>);
+};
+
+export function ProjectWizardNavigator () {
+  const currentStep = useSubscription([sub_ids.currentStep]);
+  
+  return (
+    <div
+      className="project-wizard-navigator">
+      {projectSteps.map(({id, label}, index)=>{
+        return(
+          <>                         
+            <div
+              key={id}
+              style={{fontWeight: currentStep === id ? 'bold' : 'normal',
+                display: 'inline-flex',
+                cursor: 'pointer'}}
+              onClick={() => dispatch([event_ids.currentStep, id])}
+            >
+              <span className={currentStep === id && "selected"}
+              >{index + 1}</span>
+              {label}
+            </div>
+            {index + 1 < projectSteps.length && "- -- -"}
+          </>);
+      })}              
+    </div>);
+};


### PR DESCRIPTION
## Purpose

Adds a "back" button to the project wizard navigation buttons component.

## Related Issues

Closes COL-1353

## Submission Checklist

- [ ] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [ ] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [ ] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted
Wizard
### Role

User

### Steps

<!-- All steps needed to test this PR -->

1. navigate to your institution and 'create a new project'
2. advance forward in project creation
3. use the back button.

### Desired Outcome

---

<!-- If needed, add more tests using the format above (Module Impacted, Role, Steps, Desired Outcome) here. -->

## Screenshots

<!-- Add a screen shot when UI changes are included -->
