### PR TITLE
spoofs a modal closing behavior, but prevent interaction with other c…

### DIFF
--- a/src/js/components/CollectionSidebar.jsx
+++ b/src/js/components/CollectionSidebar.jsx
@@ -207,6 +207,18 @@ export const NewPlotNavigation = ({userEmail}) => {
     };
     
     return (
+      <>
+      <div
+        className="modal-spoofer"
+        onClick={()=>{setAppState((s) => ({... s, showInfoModal: !s.showInfoModal}));}}
+        style={{backgroundColor: 'red',
+                position: 'fixed',
+                top: 0,
+                left: 0,
+                opacity: 0,
+                width: '100vw',
+                height: '100vh'}}>
+      </div>
       <div
         style={{
           position: "absolute", 
@@ -260,7 +272,8 @@ export const NewPlotNavigation = ({userEmail}) => {
              </div>
            </>}
         </SidebarCard>
-      </div>);};
+      </div>
+    </>);};
 
   return (
     <SidebarCard      

--- a/src/js/components/Sidebar.jsx
+++ b/src/js/components/Sidebar.jsx
@@ -60,6 +60,7 @@ export const SidebarCard = ({
            /* justifyContent: "space-between", */
            alignItems: "center",
            cursor: collapsible ? "pointer" : "default",
+           paddingTop: 0
          }}
          onClick={collapsible ? () => setOpen(!open) : undefined}
        >


### PR DESCRIPTION
…omponents while stats are up

## Purpose

adds a page-wide, invisible div underneath the project stats component that closes the project stats component on click.

## Related Issues

Closes COL-1370

## Submission Checklist

- [ ] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [ ] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [ ] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

<!-- List the Module > Submodule impacted by this test (e.g. Validation > Project Boundary or Subscriptions > Add) -->
<!-- The current list of all Modules is: Home, Institution, Imagery, Projects, Wizard, Survey & Rules, Collection, GeoDash. -->

### Role

Visitor

### Steps

<!-- All steps needed to test this PR -->

1.

### Desired Outcome

---

<!-- If needed, add more tests using the format above (Module Impacted, Role, Steps, Desired Outcome) here. -->

## Screenshots

<!-- Add a screen shot when UI changes are included -->
