### PR TITLE
Col bug/acarlile/save draft modal

### DIFF
--- a/src/clj/collect_earth_online/db/projects.clj
+++ b/src/clj/collect_earth_online/db/projects.clj
@@ -1289,6 +1289,18 @@
           (when-not causes (log (ex-message e)))
           (data-response "Internal server error." {:status 500}))))))
 
+(defn delete-draft-projects-bulk!
+  [{:keys [params]}]
+  (let [project-ids (clojure.string/join "," (:projectIds params))
+        institution-id (tc/val->int (:institutionId params))]
+    (try
+      (let [result (call-sql "delete_project_drafts_bulk" institution-id project-ids)]
+        (data-response {:message "Projects deleted"
+                        :project-ids project-ids}))
+      (catch Exception e
+        (println e)
+        (data-response "Internal server error." {:status 500})))))
+
 (defn delete-projects-bulk!
   [{:keys [params]}]
   (let [project-ids (clojure.string/join "," (:projectIds params))

--- a/src/clj/collect_earth_online/routing.clj
+++ b/src/clj/collect_earth_online/routing.clj
@@ -139,6 +139,9 @@
    [:get "/delete-project-draft"]            {:handler     (validate projects/delete-project-draft!)
                                               :auth-type   :user
                                               :auth-action :block}
+   [:post "/delete-draft-projects-bulk"]     {:handler     projects/delete-draft-projects-bulk!
+                                              :auth-tupe   :admin
+                                              :auth-action :block}
    [:post "/delete-projects-bulk"]           {:handler     (validate projects/delete-projects-bulk!)
                                               :auth-type   :admin
                                               :auth-action :block}

--- a/src/js/institution/ProjectsTab.jsx
+++ b/src/js/institution/ProjectsTab.jsx
@@ -26,10 +26,11 @@ export const ProjectsTab = ({
   ];
   
   const filteredProjects = useMemo(() => {
+    const idOffset =  getNextInSequence(projectList.map((e)=>e.id));
     const lower = filterText.toLowerCase();
     return projectList.concat(projectDrafts.map((p)=>{return {... p, isDraft: true,
                                                               draftId: p.id,
-                                                              id: (Number(p.id) + getNextInSequence(projectList.map((e)=>e.id)))};}))
+                                                              id: (Number(p.id) + idOffset)};}))
       .filter((p) => p.name?.toLowerCase().includes(lower));
   }, [projectList, projectDrafts, filterText]);
 

--- a/src/js/institution/ProjectsTab.jsx
+++ b/src/js/institution/ProjectsTab.jsx
@@ -104,19 +104,20 @@ export const ProjectsTab = ({
         cell: (row)=> <div
                         className="edit-button"
                         onClick={()=> {
-			  window.open(`/review-project?projectId=${row.id}&institutionId=${institutionId}`);
+                          window.location.assign(`project-wizard?draftId=${row.id}&institutionId=${institutionId}`);
 		        }}
         >
                         <SvgIcon icon="edit" size="1.2rem"/>
                       </div>
       },
-      {cell: (row)=> !row.isDraft && <input
-                       className="btn btn-outline-lightgreen btn-sm w-100"
-                       onClick={() => window.open(`/collection?projectId=${row.id}&institutionId=${institutionId}`)
-                               }
-                       type="button"
-                       value="Collect"
-                     />}
+      {cell: (row)=> !row.isDraft &&
+       <input
+            className="btn btn-outline-lightgreen btn-sm w-100"
+            onClick={() => window.open(`/collection?projectId=${row.id}&institutionId=${institutionId}`)
+                    }
+            type="button"
+            value="Collect"
+          />}
     ],
     [isAdmin]
   );

--- a/src/js/institution/ProjectsTab.jsx
+++ b/src/js/institution/ProjectsTab.jsx
@@ -2,17 +2,20 @@ import React, { useMemo, useState, useEffect } from "react";
 import DataTable from "react-data-table-component";
 import SvgIcon from "../components/svg/SvgIcon";
 import { BulkActions } from "../components/BulkActions";
+import { getNextInSequence, } from "../utils/sequence";
 
 import '../../css/institution.css';
 
 export const ProjectsTab = ({
   institutionId,
   projectList = [],
+  projectDrafts = [],
   isAdmin,
-  deleteProjectsBulk,
+  deleteDraftProjects,
+  deleteProjectsBulk,  
   editProjectsBulk,
   downloadProjectsBulk,
-}) => {
+}) => {  
   const [selectedRows, setSelectedRows] = useState([]);
   const [filterText, setFilterText] = useState("");
   const visibilityOptions = [
@@ -24,15 +27,17 @@ export const ProjectsTab = ({
   
   const filteredProjects = useMemo(() => {
     const lower = filterText.toLowerCase();
-    return projectList.filter((p) => p.name?.toLowerCase().includes(lower));
-  }, [projectList, filterText]);
+    return projectList.concat(projectDrafts.map((p)=>{return {... p, isDraft: true,
+                                                              draftId: p.id,
+                                                              id: (Number(p.id) + getNextInSequence(projectList.map((e)=>e.id)))};}))
+      .filter((p) => p.name?.toLowerCase().includes(lower));
+  }, [projectList, projectDrafts, filterText]);
 
   const columns = useMemo(
     () => [
-      
       {
         name: "Visibility",
-        selector: (row) => row.privacyLevel || "—",
+        selector: (row) => row.isDraft ? 'draft' : row.privacyLevel || "—",
         sortable: true,
         grow: 0.8,
       },
@@ -88,7 +93,7 @@ export const ProjectsTab = ({
       },
       {
         name: "Publication",
-        selector: (row) => row.availability ?? "Unpublished",
+        selector: (row) => row.isDraft ? 'draft' : row.availability ?? "Unpublished",
         sortable: true,
       },
       
@@ -105,7 +110,7 @@ export const ProjectsTab = ({
                         <SvgIcon icon="edit" size="1.2rem"/>
                       </div>
       },
-      {cell: (row)=> <input
+      {cell: (row)=> !row.isDraft && <input
                        className="btn btn-outline-lightgreen btn-sm w-100"
                        onClick={() => window.open(`/collection?projectId=${row.id}&institutionId=${institutionId}`)
                                }
@@ -133,8 +138,14 @@ export const ProjectsTab = ({
   };
 
   const handleDelete = () => {
+    
+    const selectedProjects = selectedRows.map((r) => !r.isDraft && r.id).filter((e)=>e);
+    const selectedDrafts = selectedRows.map((r) => r.isDraft && r.draftId).filter((e)=>e);
+    console.log('handle delete projects', selectedProjects);
+    console.log('handle delete drafts', selectedDrafts);
     if (selectedRows.length === 0) return;
-    deleteProjectsBulk(selectedRows.map((r) => r.id));
+    selectedProjects.length && deleteProjectsBulk(selectedRows.map((r) => !r.isDraft && r.id));
+    selectedDrafts.length && deleteDraftProjects(selectedRows.map((r) => r.isDraft && r.draftId));
   };
 
   const handleDownload = (selectedFiles) => {
@@ -149,6 +160,10 @@ export const ProjectsTab = ({
         borderLeft: '4px solid #9286D3',
       },
     },
+    { // Draft Project: Red?
+      when: row => row.isDraft,
+      style: {
+        borderLeft: '4px solid #D98EB2'}},
     { // No Plots Collected: Red
       when: row => row.type !== "simplified" && row.percentComplete == 0,
       style: {

--- a/src/js/projectWizard.jsx
+++ b/src/js/projectWizard.jsx
@@ -20,7 +20,7 @@ import { event_ids,  sub_ids } from "./state/projectWizard";
 import "../css/project-wizard.css";
 
 
-const ProjectWizard = ({userId, userName, version, institutionId}) => {
+const ProjectWizard = ({userId, userName, version, institutionId, draftId}) => {
 
   // -------------------
   // VARS & CONSTANTS
@@ -31,7 +31,7 @@ const ProjectWizard = ({userId, userName, version, institutionId}) => {
   const projectSource = useSubscription([sub_ids.projectSource]);
   function setInstitutionImagery (imagery) {dispatch([event_ids.institution.imagery, imagery]);}
   const institutionImagery = useSubscription([sub_ids.institution.imagery]);
-  
+  function setDraftProject (draftProject) {dispatch([event_ids.draftProject, draftProject]);};
   
   // -------------------
   // HOOKS
@@ -40,7 +40,7 @@ const ProjectWizard = ({userId, userName, version, institutionId}) => {
   useEffect(() => {
     dispatch([event_ids.institutionId, institutionId]);
     dispatch([event_ids.modal, 'newProject']);
-
+    draftId && setDraftProject(draftId);
     fetch(`/get-institution-imagery?institutionId=${institutionId}`)
       .then(res => res.json())
       .then(data => setInstitutionImagery(data))
@@ -101,6 +101,7 @@ export function pageInit(params, session) {
       userId={session.userId}
       userName={session.userName}
       version={session.versionDeployed}
+      draftId={params.draftId}
       institutionId={params.institutionId}/>,
     document.getElementById("app")
   );

--- a/src/js/reviewInstitution.jsx
+++ b/src/js/reviewInstitution.jsx
@@ -154,6 +154,31 @@ export const ReviewInstitution = ({ institutionId, userId }) => {
     }
   };
 
+  function deleteDraftProjects (projectIds) {
+    confirm("Do you REALLY want to delete ALL selected project drafts? This operation cannot be undone.") && fetch(`/delete-draft-projects-bulk?institutionId=${institutionId}`, {
+      method: "POST",
+      body: JSON.stringify({ projectIds }),
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+    }).then((response) => {
+      if (response.ok) {
+        getProjectList();
+        showAlert({
+          title: "Project Info",
+          body: "Selected project draftss have been deleted.",
+        });
+      } else {
+        console.error(response);
+        showAlert({
+          title: "Project Info Error",
+          body: "Error deleting project drafts. See console for details.",
+        });
+      }
+    }); 
+  };
+
   const deleteProjectsBulk = (projectIds) => {
     if (confirm("Do you REALLY want to delete ALL selected projects? This operation cannot be undone.")) {
       fetch(`/delete-projects-bulk?institutionId=${institutionId}`, {
@@ -421,7 +446,9 @@ export const ReviewInstitution = ({ institutionId, userId }) => {
         <ProjectsTab
           institutionId={institutionId}
           projectList={state.projectList}
+          projectDrafts={state.draftProjects}
           isAdmin={state.isAdmin}
+          deleteDraftProjects={deleteDraftProjects}
           deleteProjectsBulk={deleteProjectsBulk}
           editProjectsBulk={editProjectsBulk}
           downloadProjectsBulk={downloadProjectsBulk}

--- a/src/js/state/projectWizard.jsx
+++ b/src/js/state/projectWizard.jsx
@@ -135,9 +135,9 @@ initAppDb(projectWizardDb);
 export const event_ids = {
   institutionId: 'institutionId',
   templateProject: 'templateProject',
+  draftProject: 'draftProject',
   submitForm: 'submitForm',
   saveDraft: 'saveDraft',
-  getDraft: 'getDraft',
   errors: 'errors',
   continueHandler: 'continueHandler',
   validate: 'validate',
@@ -429,7 +429,7 @@ regEvent(event_ids.institutionId, ({ draftDb }, institutionId )=> {
 
 // PROJECT WIZARD EVENTS
 
-regEvent(event_ids.getDraft, ({ draftDb }, draftId) => {
+regEvent(event_ids.draftProject, ({ draftDb }, draftId) => {
   function getProjectDraftById(projectDraftId) {
     fetch(`/get-project-draft-by-id?projectDraftId=${projectDraftId}`)
       .then((response) => (response.ok ? response.json() : Promise.reject(response)))
@@ -438,7 +438,7 @@ regEvent(event_ids.getDraft, ({ draftDb }, draftId) => {
           dispatch([event_ids.errors, [['server', ["No draft found with ID " + projectDraftId + "."]]]]);
           return Promise.resolve();
         } else {
-          dispatch([event_ids.successResponse, ['success', data]]);
+          dispatch([event_ids.templateProject, data]);
           return Promise.resolve();
         }
       }).catch(() => {
@@ -447,6 +447,8 @@ regEvent(event_ids.getDraft, ({ draftDb }, draftId) => {
       });
   }
   getProjectDraftById(draftId);
+  dispatch([event_ids.modal, null]);
+  dispatch([event_ids.currentStep, 'review']);
 });
 
 export function buildProject (draftDb, sub_ids) {

--- a/src/js/state/projectWizard.jsx
+++ b/src/js/state/projectWizard.jsx
@@ -703,7 +703,9 @@ regEvent(event_ids.saveDraft, ({ draftDb }) => {
       .then((data) => {
         console.log('create project draft request result', data);
         if (data[0] && Number.isInteger(data[1].projectDraftId)) {
-          dispatch([event_ids.successReponse, data[1]]);
+          console.log('dispatch success response');
+          dispatch([event_ids.modal, 'draft-success']);
+          //dispatch([event_ids.successResponse, data[1]]);
           return Promise.resolve();
         } else {          
           let errs = Object.entries(data[1].params).map(([field, message])=>{return (field + "; " + message);});
@@ -737,6 +739,7 @@ regEvent(event_ids.saveDraft, ({ draftDb }) => {
     })
       .then((response) => Promise.all([response.ok, response.json()]))
       .then((data) => {
+        console.log('resolving project draft data');
         dispatch([event_ids.successResponse, ['Project Saved', data]]);
         return Promise.resolve();
       })

--- a/src/js/wizard/Modals.jsx
+++ b/src/js/wizard/Modals.jsx
@@ -271,6 +271,24 @@ function SubmitProjectModal () {
   );
 };
 
+function DraftSuccessModal () {
+  const institutionId = useSubscription([sub_ids.institutionId]);
+  return (
+    <Modal
+      title='Draft Success'
+      closeText='Return to Institution'
+      confirmText='Return to Wizard'
+      onConfirm={()=>{dispatch([event_ids.modal, null]);}}
+      onClose={()=>{window.location=`/review-institution?institutionId=${institutionId}`;}}
+    >
+      <div>
+        <p > You have Successfully saved your Draft Project.</p>
+        <p > Click below to return to institution dashboard, or continue editing your project. </p>
+      </div>
+    </Modal>
+  );
+}
+
 function SuccessModal () {  
   return (
     <Modal
@@ -373,7 +391,9 @@ export default function ProjectWizardModal () {
   case 'review'      : return (<SubmitProjectModal/>);
   case 'success'     : return (<SuccessModal/>);
   case 'error'       : return (<ErrorModal/>);
+  case 'draft-success' : return (<DraftSuccessModal/>);
   case 'exit'        : return (<ExitModal/>);
+    
   default : break;
   }
 };

--- a/src/sql/functions/project.sql
+++ b/src/sql/functions/project.sql
@@ -1385,6 +1385,18 @@ RETURNS integer AS $$
     RETURNING project_draft_uid
 $$ LANGUAGE SQL;
 
+CREATE OR REPLACE FUNCTION delete_project_drafts_bulk(_institution_id integer, _project_ids_text TEXT)
+RETURNS VOID AS $$
+DECLARE
+    project_ids INTEGER[];
+    deleted_ids INTEGER[];
+BEGIN
+    DELETE FROM project_drafts    
+    WHERE project_draft_uid = ANY(string_to_array(_project_ids_text, ',')::INTEGER[]) AND institution_rid = _institution_id;    
+END;
+$$ LANGUAGE plpgsql;
+
+
 -- Delete projects in bulk
 CREATE OR REPLACE FUNCTION delete_projects_bulk(_institution_id integer, _project_ids_text TEXT)
 RETURNS VOID AS $$


### PR DESCRIPTION
## Purpose

Introduces a success modal on draft save that prompt user to return to orkflow, or to institution projects. displays user draft projects. adds edit button to user draft projects that treats draft as template project to edit in the wizard.

this PR includes updates to SQL code, so be sure to update functions!

## Related Issues
.
Closes COL-###

## Submission Checklist

- [ ] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [ ] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [ ] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

<!-- List the Module > Submodule impacted by this test (e.g. Validation > Project Boundary or Subscriptions > Add) -->
<!-- The current list of all Modules is: Home, Institution, Imagery, Projects, Wizard, Survey & Rules, Collection, GeoDash. -->

### Role

<!-- Admin, User, or Visitor -->

### Steps

<!-- All steps needed to test this PR -->

1.

### Desired Outcome

---

<!-- If needed, add more tests using the format above (Module Impacted, Role, Steps, Desired Outcome) here. -->

## Screenshots

<!-- Add a screen shot when UI changes are included -->
