### PR TITLE
Col 1375/acarlile/disallow dupe qs

### DIFF
--- a/src/js/wizard/SurveyQuestionsStep.jsx
+++ b/src/js/wizard/SurveyQuestionsStep.jsx
@@ -4,6 +4,7 @@ import { dispatch, useSubscription } from '@flexsurfer/reflex';
 import { SurveyQuestions } from '../components/SurveyQuestions';
 import SvgIcon from '../components/svg/SvgIcon';
 import { event_ids, sub_ids } from '../state/projectWizard';
+import { mapObjectArray } from '../utils/sequence';
 
 
 export const QuestionCard = ({
@@ -255,6 +256,7 @@ export const QuestionCard = ({
 };
 
 export const SurveyQuestionsStep = () => {
+  const [duplicateWarning, confirmDuplicateWarning] = useState(false);
   const newDefaultQuestion = {
     questionText: '',
     questionLabel: '',
@@ -268,6 +270,8 @@ export const SurveyQuestionsStep = () => {
   function setQuestions (questions) {dispatch([event_ids.questions.setQuestions, questions]);}
   const questions = useSubscription([sub_ids.questions.questions]);
   const [newQuestion, setNewQuestion] = useState(newDefaultQuestion);
+  function errors (errors) {dispatch([event_ids.errors, [['questions', errors]]]);
+                            confirmDuplicateWarning(true);}
   
   const addQuestion = () => {
     if (!newQuestion.questionText) return;
@@ -290,8 +294,12 @@ export const SurveyQuestionsStep = () => {
         "1": { answer: defaultAnswer, color: "#109844" },
       },
     };
-
-    setQuestions({ ...questions, [nextId]: questionToAdd });
+    const testquestions = {... questions, 0: {question: 'test question', questionLabel: 'test label'}};
+    const duplicateQuestions =   Object.values(testquestions)
+          .map(({questionLabel})=> questionLabel.split(/\(\d\)/)[0] == questionToAdd.questionLabel.split(/\(\d\)/)[0]);
+    duplicateQuestions.some((e)=>e) && !duplicateWarning ? errors(
+      [`Warning: This is a duplicate name.  It will be added as "${questionToAdd.questionLabel.split(/\(\d\)/)[0] + "(" + duplicateQuestions.length + ")"}" in design mode.`])
+      : setQuestions({ ...questions, [nextId]: questionToAdd });
     setNewQuestion(newDefaultQuestion);
   };
 

--- a/src/js/wizard/SurveyQuestionsStep.jsx
+++ b/src/js/wizard/SurveyQuestionsStep.jsx
@@ -293,13 +293,13 @@ export const SurveyQuestionsStep = () => {
       answers: newQuestion.answers || {
         "1": { answer: defaultAnswer, color: "#109844" },
       },
-    };
-    const testquestions = {... questions, 0: {question: 'test question', questionLabel: 'test label'}};
-    const duplicateQuestions =   Object.values(testquestions)
+    };    
+    const duplicateQuestions =   Object.values(questions)
           .map(({questionLabel})=> questionLabel.split(/\(\d\)/)[0] == questionToAdd.questionLabel.split(/\(\d\)/)[0]);
     duplicateQuestions.some((e)=>e) && !duplicateWarning ? errors(
       [`Warning: This is a duplicate name.  It will be added as "${questionToAdd.questionLabel.split(/\(\d\)/)[0] + "(" + duplicateQuestions.length + ")"}" in design mode.`])
-      : setQuestions({ ...questions, [nextId]: questionToAdd });
+      : setQuestions({ ...questions, [nextId]: duplicateQuestions.some((e)=>e) ? {... questionToAdd, questionLabel: questionToAdd.questionLabel.split(/\(\d\)/)[0] + "(" + duplicateQuestions.length + ")"}
+                       : questionToAdd });
     setNewQuestion(newDefaultQuestion);
   };
 


### PR DESCRIPTION
## Purpose

adds functionality to prevent duplicate question labels by appending a "(1)" to the end of the question label string. issues a warning label on first attempt per project.

## Related Issues

Closes COL-1375

## Submission Checklist

- [ ] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [ ] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [ ] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

<!-- List the Module > Submodule impacted by this test (e.g. Validation > Project Boundary or Subscriptions > Add) -->
<!-- The current list of all Modules is: Home, Institution, Imagery, Projects, Wizard, Survey & Rules, Collection, GeoDash. -->

### Role

<!-- Admin, User, or Visitor -->

### Steps

<!-- All steps needed to test this PR -->

1.

### Desired Outcome

---

<!-- If needed, add more tests using the format above (Module Impacted, Role, Steps, Desired Outcome) here. -->

## Screenshots

<!-- Add a screen shot when UI changes are included -->
