### PR TITLE
cannot .filter map objects, updated

### DIFF
--- a/src/js/wizard/NewRuleDesigner.jsx
+++ b/src/js/wizard/NewRuleDesigner.jsx
@@ -720,16 +720,15 @@ function MultipleIncompatibleAnswersForm () {//WORKSN'T
           >
             <option value="-1" selected disabled hidden>- Select Question -</option>
             {mapObjectArray(
-              surveyQuestions
-                .filter(({componentType})=>componentType !== 'input'),
-              ([aqId, aq]) => {
-                if(answers[aqId] === undefined) {
-                  return (
-                    <option key={aqId} value={aqId}>
+              surveyQuestions,
+              ([aqId, aq]) => {                
+                if(answers[aqId] === undefined && aq.componentType !== 'input') {                  
+                    return (
+                      <option key={aqId} value={aqId}>
                       {aq.question}
                     </option>
                   );
-              } else {return (<></>);}})}
+                  } else {return (<></>);}})}
           </select>
         </div>
         <div className="new-rule-input">


### PR DESCRIPTION
## Purpose

we had some artifcat logic treating survey questions as an array of questions [] when the survey questions are in fact an index-keyed object. we were calling .filter on survey questions so that quesiton types that weren't allowed in multiple-incompatibe-answers would not show up as options. this updates that error.

## Related Issues

Closes COL-###

## Submission Checklist

- [ ] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [ ] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [ ] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

<!-- List the Module > Submodule impacted by this test (e.g. Validation > Project Boundary or Subscriptions > Add) -->
<!-- The current list of all Modules is: Home, Institution, Imagery, Projects, Wizard, Survey & Rules, Collection, GeoDash. -->

### Role

<!-- Admin, User, or Visitor -->

### Steps

<!-- All steps needed to test this PR -->

1.

### Desired Outcome

---

<!-- If needed, add more tests using the format above (Module Impacted, Role, Steps, Desired Outcome) here. -->

## Screenshots

<!-- Add a screen shot when UI changes are included -->
