### PR TITLE
Col 1396/acarlile/number inputs

### DIFF
--- a/src/js/wizard/PlotStep.jsx
+++ b/src/js/wizard/PlotStep.jsx
@@ -238,11 +238,18 @@ export const PlotStep = ({ imageryList = [] }) => {
     <div className="form-group mb-3">
       <label className="text-label-sm">{labelPlotDimensionUnits} <span style={{ color: 'red' }}>*</span></label>
       <input
-        type="number"
+        type="text"
         className="text-input"
         placeholder="Enter Number"
         value={plotSize}
-        onChange={(e) => dispatch([event_ids.plots.plotSize, Number(e.target.value)])}
+        onChange={(e) => {
+          const regex = /^[0-9]*\.?[0-9]*$/;
+          const input = e.target.value;                   
+          dispatch([event_ids.plots.plotSize,
+                    input !== "" &&                              
+                    regex.test(input) ? input
+                    : input.slice(0, input.length - 1)]);
+                 }}
       />
     </div>
   );
@@ -252,12 +259,17 @@ export const PlotStep = ({ imageryList = [] }) => {
       <div className="form-group mb-3">
         <label className="text-label-sm">Number of Plots this project will contain <span style={{ color: 'red' }}>*</span></label>
         <input 
-          type="number" 
+          type="text" 
           className="text-input" 
           placeholder="Enter Number (Max 5000)"
           value={numPlots}
-          max="5000"
-          onChange={(e) => dispatch([event_ids.plots.numPlots, Number(e.target.value)])}
+          onChange={(e) =>{
+            const regex = /^[0-9]*$/;
+            const input = e.target.value;
+            function inRange (n) {return (1 < Number(n) && Number(n) < 5000);};
+            const value = (regex.test(input) && inRange(input)) ? input : input.slice(0, input.length - 1);
+            dispatch([event_ids.plots.numPlots, value]);
+          }}
         />
       </div>
       {renderPlotSizeInput()}

--- a/src/js/wizard/SampleStep.jsx
+++ b/src/js/wizard/SampleStep.jsx
@@ -12,7 +12,7 @@ export const SampleStep = () => {
   const plotShape = useSubscription([sub_ids.plots.plotShape]) || 'circle';
 
   const sampleDistribution = useSubscription([sub_ids.samples.sampleDistribution]) || "random";
-  const samplesPerPlot = useSubscription([sub_ids.samples.samplesPerPlot]) || 1;
+  const samplesPerPlot = useSubscription([sub_ids.samples.samplesPerPlot]);
   const sampleResolution = useSubscription([sub_ids.samples.sampleResolution]) || 0;
   const [sampleFeatures, setSampleFeatures] = useState([]);
 
@@ -68,7 +68,7 @@ export const SampleStep = () => {
 
 export const SampleGenerationCard = ({ setSampleFeatures }) => {
   const sampleDistribution = useSubscription([sub_ids.samples.sampleDistribution]) || "random";
-  const samplesPerPlot = useSubscription([sub_ids.samples.samplesPerPlot]) || 1;
+  const samplesPerPlot = useSubscription([sub_ids.samples.samplesPerPlot]);
   const sampleResolution = useSubscription([sub_ids.samples.sampleResolution]) || 0;
   const sampleFileName = useSubscription([sub_ids.samples.sampleFileName]) || "";
   const extension = sampleDistribution === 'shp' ? 'zip' : sampleDistribution;
@@ -182,8 +182,13 @@ export const SampleGenerationCard = ({ setSampleFeatures }) => {
       {sampleDistribution === 'random' && (
         <div className="form-group mt-3">
           <label className="text-label-sm">Number of Samples</label>
-          <input className="text-input" type="number" value={samplesPerPlot} 
-            onChange={(e) => dispatch([event_ids.samples.samplesPerPlot, Number(e.target.value)])} />
+          <input className="text-input" type="text"
+                 value={samplesPerPlot} 
+                 onChange={(e) => {                   
+                   const regex = /^[0-9]*$/;
+                   const input = e.target.value;
+                   const value = regex.test(input) ? input : input.slice(0, input.length - 1);
+                   dispatch([event_ids.samples.samplesPerPlot, value]);}} />
         </div>
       )}
 

--- a/src/js/wizard/SurveyQuestionsStep.jsx
+++ b/src/js/wizard/SurveyQuestionsStep.jsx
@@ -179,7 +179,7 @@ export const QuestionCard = ({
                     onChange={(e) => updateAnswer(aId, 'color', e.target.value)}
                   />
                   <input
-                    type={question.dataType === 'number' ? 'number' : 'text'}
+                    type="text"
                     className="text-input question-answer-input"
                     value={a.answer}
                     placeholder={`Enter Answer ${question.dataType === 'number' ? 'Number' : 'Text'}`}
@@ -188,15 +188,14 @@ export const QuestionCard = ({
                         e.preventDefault();
                       }
                     }}
+                    defaultValue={question.dataType === 'number' ? 0 : ''}                    
                     onChange={(e) => {
-                      if (question.dataType !== 'number') {
-                        updateAnswer(aId, 'answer', e.target.value);
-                        return;
-                      }
-                      const s = e.target.value;
-                      const n = s === '' ? 0 : Number(s);
-                      updateAnswer(aId, 'answer', Number.isNaN(n) ? 0 : n);
-                    }}
+                      const regex = /^[0-9]*\.?[0-9]*$/;
+                      question.dataType === 'number'
+                        ? updateAnswer(aId, 'answer', regex.test(e.target.value)
+                                       ? e.target.value
+                                       : e.target.value.slice(0, e.target.value.length - 1))
+                        : updateAnswer(aId, 'answer', e.target.value);}}
                   />
                   <input
                     type="checkbox"


### PR DESCRIPTION
## Purpose

fixes how numerical inputs are handled so that no non-numerical amounts are allowed, except where decimal places are allowed, and allows for backspacing and inputting 0.

## Related Issues

Closes COL-1398,  COL-1369

## Submission Checklist

- [ ] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [ ] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [ ] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

<!-- List the Module > Submodule impacted by this test (e.g. Validation > Project Boundary or Subscriptions > Add) -->
<!-- The current list of all Modules is: Home, Institution, Imagery, Projects, Wizard, Survey & Rules, Collection, GeoDash. -->

### Role

<!-- Admin, User, or Visitor -->

### Steps

<!-- All steps needed to test this PR -->

1.

### Desired Outcome

---

<!-- If needed, add more tests using the format above (Module Impacted, Role, Steps, Desired Outcome) here. -->

## Screenshots

<!-- Add a screen shot when UI changes are included -->
