### PR TITLE
adds id and project name inputs that filter template project options

### DIFF
--- a/src/js/wizard/Modals.jsx
+++ b/src/js/wizard/Modals.jsx
@@ -219,8 +219,9 @@ function TemplateProjectModal () {
              <option value={-1} selected disabled hidden>Select Template Project:</option>
              {templateProjects
               .filter(({id, name}) => {
-                return (((filterProjectId !== -1) && id.toString().includes(filterProjectId.toString())) ||
-                        ((filterProjectName !== "") && name.includes(filterProjectName)));
+                return ((id.toString().includes(filterProjectId.toString())) ||
+                        (name.includes(filterProjectName)));
+
               })
               .map(e =>(<option key={e.id} value={e.id}>{e.name}</option>))}
          </select>

--- a/src/js/wizard/Modals.jsx
+++ b/src/js/wizard/Modals.jsx
@@ -95,6 +95,9 @@ function TemplateProjectModal () {
   const projectType = useSubscription([sub_ids.overview.projectType]) || 'regular';
   const [templateProjectId, setTemplateProjectId] = useState(-1);
   const [templateProjects, setTemplateProjects] = useState([]);
+  const [filterProjectId, setFilterProjectId] = useState(-1);
+  const [filterProjectName, setFilterProjectName] = useState("");
+  const [filteredProjects, filterProjects] = useState([]);
 
   function setTemplateProject (templateProject) {dispatch([event_ids.templateProject, templateProject]);}
   function setUseTemplatePlots (useTemplatePlots) {dispatch([event_ids.overview.useTemplatePlots, useTemplatePlots]);}
@@ -118,7 +121,7 @@ function TemplateProjectModal () {
             users: [],
             percents: []}})
           : setDesignSettings(data.designSettings);
-        setTemplateProjectId(projectId);        
+        setTemplateProjectId(projectId);
         setImageryId(institutionImageryIds.includes(data.imageryId)
                      ? [data.imageryId]
                      : institutionImageryIds);
@@ -169,7 +172,9 @@ function TemplateProjectModal () {
         dispatch([event_ids.errors, [['Template Projects', ['Failed to load template projects']]]]);
         Promise.reject(error);
       });
-  }, []);  
+  }, []);
+
+  
   return (
     <Modal
       title='Select Template Project'
@@ -178,14 +183,49 @@ function TemplateProjectModal () {
       onConfirm={()=> {getTemplateProjects(templateProjectId);}}      
       onClose={()=>{ dispatch([event_ids.modal, 'newProject']);}}>
       <div>        
-        {templateProjects.length &&
-         <select
-           className="text-input"
-           onChange={(e)=>{
-             setTemplateProjectId(Number(e.target.value));}}>
-           <option value={-1} selected disabled hidden>Select Template Project:</option>
-           {templateProjects.map(e =>(<option key={e.id} value={e.id}>{e.name}</option>))}
-         </select>}
+        {templateProjects.length ?
+         <div>
+           <p>Filter Template Projects:</p>
+           <div style={{display: "flex",
+                        gap: "1rem",
+                        flexDirection: "row"}}>
+             <input
+               className="text-input"
+               style={{width: "20%"}}
+               type="text"
+               placeHolder="Id"
+               value={filterProjectId > 0 ? filterProjectId : null}
+               onKeyPress={(e)=>{
+                 const pattern = /^[0-9]+$/;
+                 const input = e.key;
+                 !pattern.test(input) && e.preventDefault();
+               }}
+               onChange={(e)=>{setFilterProjectId(e.target.value);}}
+             />
+             <input
+               placeholder="Project Name"
+               className="text-input"
+               style={{flexGrow: 2}}
+               type="text"
+               value={filterProjectName}
+               onChange={(e)=>{setFilterProjectName(e.target.value);}}
+             />
+             
+           </div>
+           <select
+             className="text-input"
+             onChange={(e)=>{
+               setTemplateProjectId(Number(e.target.value));}}>
+             <option value={-1} selected disabled hidden>Select Template Project:</option>
+             {templateProjects
+              .filter(({id, name}) => {
+                return (((filterProjectId !== -1) && id.toString().includes(filterProjectId.toString())) ||
+                        ((filterProjectName !== "") && name.includes(filterProjectName)));
+              })
+              .map(e =>(<option key={e.id} value={e.id}>{e.name}</option>))}
+         </select>
+         </div>
+         : <></>}
       </div>
     </Modal>
   );


### PR DESCRIPTION
## Purpose

Adds inputs to the "Template Project" modal to capture project id or name for filtering template projects.

## Related Issues

Closes COL-1382

## Submission Checklist

- [ ] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [ ] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [ ] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

<!-- List the Module > Submodule impacted by this test (e.g. Validation > Project Boundary or Subscriptions > Add) -->
<!-- The current list of all Modules is: Home, Institution, Imagery, Projects, Wizard, Survey & Rules, Collection, GeoDash. -->

### Role

User

### Steps

<!-- All steps needed to test this PR -->

1. navigate to your insitution splash page
2. click "add new project"
3. opt to "create project from template"
4. input an id and/or a project name in the provided inputs.
5. find that it is not possible to input non-numeric characters into the ID field.
6. observe that the list of returned template projects changes in relation to the provided filter parameters

### Desired Outcome

---

<!-- If needed, add more tests using the format above (Module Impacted, Role, Steps, Desired Outcome) here. -->

## Screenshots

<img width="681" height="434" alt="image" src="https://github.com/user-attachments/assets/86698c6b-d90f-47bd-8c1e-904eaf6cedf6" />

