### PR TITLE
closing the window returns to inst-splash page

### DIFF
--- a/src/js/wizard/Modals.jsx
+++ b/src/js/wizard/Modals.jsx
@@ -215,14 +215,14 @@ function NewProjectModal () {
     importProject: ['Import Collect Earth Project',
                     'Import a project from the Collect Earth desktop application.']};
   const projectSource = useSubscription([sub_ids.projectSource]);
-
+  const institutionId = useSubscription([sub_ids.institutionId]);
   return (
     <Modal
       title='Project Setup'
       closeText=''
       confirmText='Get Started'
       onConfirm={()=>{handleNewProject(projectSource);}}
-      onClose={()=>{dispatch([event_ids.modal, 'newProject']);}}
+      onClose={()=>{window.location.assign(`/review-institution?institutionId=${institutionId}`);}}
       confirmDisabled={projectSource === null}>
       <div
         className="inputs">


### PR DESCRIPTION
## Purpose

When in the "add a new project" workflow from the institution splash page, if the visitor closes the new project modal instead of selecting an option and proceeding with the wizard, they will be redirected back to the institution splash page.

## Related Issues

Closes COL-1407

## Submission Checklist

- [ ] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [ ] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [ ] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

<!-- List the Module > Submodule impacted by this test (e.g. Validation > Project Boundary or Subscriptions > Add) -->
<!-- The current list of all Modules is: Home, Institution, Imagery, Projects, Wizard, Survey & Rules, Collection, GeoDash. -->

### Role

<!-- Admin, User, or Visitor -->

### Steps

<!-- All steps needed to test this PR -->

1.

### Desired Outcome

---

<!-- If needed, add more tests using the format above (Module Impacted, Role, Steps, Desired Outcome) here. -->

## Screenshots

<!-- Add a screen shot when UI changes are included -->
