### PR TITLE
Col 1423/acarlile/dupe q name

### DIFF
--- a/src/js/wizard/Modals.jsx
+++ b/src/js/wizard/Modals.jsx
@@ -220,8 +220,8 @@ function TemplateProjectModal () {
              {templateProjects
               .filter(({id, name}) => {
                 return ((id.toString().includes(filterProjectId.toString())) ||
-                        (name.includes(filterProjectName)));
-
+                        (name.toLocaleLowerCase().includes(filterProjectName.toLocaleLowerCase()))
+                       );
               })
               .map(e =>(<option key={e.id} value={e.id}>{e.name}</option>))}
          </select>

--- a/src/js/wizard/SurveyQuestionsStep.jsx
+++ b/src/js/wizard/SurveyQuestionsStep.jsx
@@ -294,10 +294,10 @@ export const SurveyQuestionsStep = () => {
       },
     };    
     const duplicateQuestions =   Object.values(questions)
-          .map(({questionLabel})=> questionLabel.split(/\(\d\)/)[0] == questionToAdd.questionLabel.split(/\(\d\)/)[0]);
+          .map(({question})=> question.split(/\(\d\)/)[0] == questionToAdd.question.split(/\(\d\)/)[0]);
     duplicateQuestions.some((e)=>e) && !duplicateWarning ? errors(
-      [`Warning: This is a duplicate name.  It will be added as "${questionToAdd.questionLabel.split(/\(\d\)/)[0] + "(" + duplicateQuestions.length + ")"}" in design mode.`])
-      : setQuestions({ ...questions, [nextId]: duplicateQuestions.some((e)=>e) ? {... questionToAdd, questionLabel: questionToAdd.questionLabel.split(/\(\d\)/)[0] + "(" + duplicateQuestions.length + ")"}
+      [`Warning: This is a duplicate name.  It will be added as "${questionToAdd.question.split(/\(\d\)/)[0] + "(" + duplicateQuestions.length + ")"}" in design mode.`])
+      : setQuestions({ ...questions, [nextId]: duplicateQuestions.some((e)=>e) ? {... questionToAdd, question: questionToAdd.question.split(/\(\d\)/)[0] + "(" + duplicateQuestions.length + ")"}
                        : questionToAdd });
     setNewQuestion(newDefaultQuestion);
   };


### PR DESCRIPTION
## Purpose

updates method by which we determine duplicate questions in the project wizard survey questions step to compare question text instead of question label.

## Related Issues

Closes COL-###

## Submission Checklist

- [ ] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [ ] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [ ] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

<!-- List the Module > Submodule impacted by this test (e.g. Validation > Project Boundary or Subscriptions > Add) -->
<!-- The current list of all Modules is: Home, Institution, Imagery, Projects, Wizard, Survey & Rules, Collection, GeoDash. -->

### Role

<!-- Admin, User, or Visitor -->

### Steps

<!-- All steps needed to test this PR -->

1.

### Desired Outcome

---

<!-- If needed, add more tests using the format above (Module Impacted, Role, Steps, Desired Outcome) here. -->

## Screenshots

<!-- Add a screen shot when UI changes are included -->
