### PR TITLE
adds project description card

### DIFF
--- a/src/css/sidebar.css
+++ b/src/css/sidebar.css
@@ -44,6 +44,8 @@
   align-items: center;
   /* justify-content: space-between; */
   padding: 1rem;
+  border: none;
+  padding: 0;
 }
 
 .sidebar-title {

--- a/src/js/collection.jsx
+++ b/src/js/collection.jsx
@@ -45,7 +45,7 @@ import {
 import { mercator } from "./utils/mercator";
 import { outlineKML } from "./utils/kml";
 
-export const Collection = ({ projectId, acceptedTerms, plotId, userEmail }) => {
+export function Collection ({ projectId, acceptedTerms, plotId, userEmail }) {
   const [state, setState] = useAtom(stateAtom);
 
   // INIT COLLECTION EFFECT

--- a/src/js/components/CollectionSidebar.jsx
+++ b/src/js/components/CollectionSidebar.jsx
@@ -76,11 +76,27 @@ const StatsCard = ({}) => {
   );
 };
 
-export const CollectionSidebar = ({ processModal, userEmail }) => {
+export function OverviewCard ({}) {
+  const { currentProject } = useAtomValue(stateAtom);
+  console.log('overview card: ', currentProject);
+  return (
+    <SidebarCard
+         title="Project Description"
+       >
+         <div id="overview-card">
+           <span>{currentProject.description}</span>
+         </div>         
+       </SidebarCard>
+  );
+
+}
+
+export function CollectionSidebar ({ processModal, userEmail }) {
   const { currentPlot, currentProject } = useAtomValue(stateAtom);
   const content = (
     <>
       <NewPlotNavigation userEmail={userEmail}/>
+      <OverviewCard/>
       <StatsCard/>
       {currentPlot.id > 0 && (
         <>


### PR DESCRIPTION
## Purpose

adds a 'project descripiton' card to the collect splash page that displays the description column of the current project.

## Related Issues

Closes COL-1433

## Submission Checklist

- [ ] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [ ] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [ ] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

<!-- List the Module > Submodule impacted by this test (e.g. Validation > Project Boundary or Subscriptions > Add) -->
<!-- The current list of all Modules is: Home, Institution, Imagery, Projects, Wizard, Survey & Rules, Collection, GeoDash. -->

### Role

User

### Steps

<!-- All steps needed to test this PR -->

1. Navigate to your institution projects page.
2. select a project and click 'collect' to navigate to the collection page
3. observe collection sidebar

### Desired Outcome

---

<!-- If needed, add more tests using the format above (Module Impacted, Role, Steps, Desired Outcome) here. -->

## Screenshots

<img width="2510" height="1364" alt="image" src="https://github.com/user-attachments/assets/ed650525-5378-4371-b3fc-1fb09e2bd4c6" />
