### PR TITLE
tighten up some collection sidebar compoennts

### DIFF
--- a/src/css/sidebar.css
+++ b/src/css/sidebar.css
@@ -65,10 +65,10 @@
 
 .sidebar-select {
   width: 100%;
-  padding: 8px;
+  padding: 4px;
   border: 1px solid #ccc;
   border-radius: 4px;
-  margin-bottom: 20px;
+  margin-bottom: 10px;
 }
 
 .sidebar-mode {
@@ -214,7 +214,7 @@
 .ext-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 14px;
+  gap: 7px;
 }
 
 .ext-btn {
@@ -222,7 +222,7 @@
   align-items: center;
   justify-content: center;
   gap: 10px;
-  padding: 12px 14px;
+  padding: 6px 7px;
   border: 1px solid #3D7F7A;
   color: #3D7F7A;
   background: transparent;

--- a/src/js/components/CollectionSidebar.jsx
+++ b/src/js/components/CollectionSidebar.jsx
@@ -342,7 +342,6 @@ export const NewPlotNavigation = ({userEmail}) => {
               Go To Plot
             </label>
           </div>
-          <br />
           {navigationMode === "similar" && (
             <div className="sidebar-mode">
               <span>Reference Plot: {currentProject?.plotSimilarityDetails?.referencePlotId}</span>


### PR DESCRIPTION
## Purpose

This may need some extra input from Karen once she's able to sign off on the Figma wireframes, but here is a draft pass at reducing unnecessary padding in the collection sidebar.

## Related Issues

Closes COL-1357

## Submission Checklist

- [ ] Included Jira issue in the PR title (e.g. `COL-### Did something here`)
- [ ] Code passes linter rules for each file you updated. To lint all files at once, run `npm run lint`. To just lint one specific file run `npx quick-lint-js src/js/<file-you-changed> --snarky`.
- [ ] No new reflection warnings (`clojure -M:check-reflection`)

## Testing

### Module Impacted

<!-- List the Module > Submodule impacted by this test (e.g. Validation > Project Boundary or Subscriptions > Add) -->
<!-- The current list of all Modules is: Home, Institution, Imagery, Projects, Wizard, Survey & Rules, Collection, GeoDash. -->

### Role

<!-- Admin, User, or Visitor -->

### Steps

<!-- All steps needed to test this PR -->

1.

### Desired Outcome

---

<!-- If needed, add more tests using the format above (Module Impacted, Role, Steps, Desired Outcome) here. -->

## Screenshots

<!-- Add a screen shot when UI changes are included -->
